### PR TITLE
fix(kit): use canonical one-time product path

### DIFF
--- a/packages/kit/convex/products/play.test.ts
+++ b/packages/kit/convex/products/play.test.ts
@@ -1,10 +1,116 @@
+import { google, type Common } from "googleapis";
 import { describe, expect, it } from "vitest";
 
 import {
   basePlanIdForPeriod,
   moneyToMicros,
   playPriceMicrosToNumber,
+  shouldFallbackToLegacyOneTimeProduct,
+  upsertModernAndroidOneTimeProduct,
 } from "./play";
+
+describe("upsertModernAndroidOneTimeProduct", () => {
+  it("uses the generated lowercase one-time-product PATCH route", async () => {
+    let capturedRequest: Common.GaxiosOptions | undefined;
+    const androidpublisher = google.androidpublisher({
+      version: "v3",
+      adapter: async <T>(
+        request: Common.gaxios.GaxiosOptionsPrepared,
+      ): Promise<Common.GaxiosResponse<T>> => {
+        capturedRequest = request;
+        return Object.assign(new Response(null, { status: 200 }), {
+          config: request,
+          data: {} as T,
+        });
+      },
+    });
+
+    await upsertModernAndroidOneTimeProduct(
+      androidpublisher,
+      {
+        packageName: "com.example.moonlit",
+        productId: "hero.sage",
+        title: "Moon Sage",
+        description: "Unlock Moon Sage",
+        priceAmountMicros: 24_990_000,
+        currency: "USD",
+      },
+      { allowCreate: true },
+    );
+
+    expect(capturedRequest).toBeDefined();
+    const requestUrl = new URL(String(capturedRequest?.url));
+    expect(requestUrl.pathname).toBe(
+      "/androidpublisher/v3/applications/com.example.moonlit/onetimeproducts/hero.sage",
+    );
+    expect(requestUrl.searchParams.get("allowMissing")).toBe("true");
+    expect(requestUrl.searchParams.get("updateMask")).toBe(
+      "listings,purchaseOptions",
+    );
+    expect(requestUrl.searchParams.get("regionsVersion.version")).toBe(
+      "2022/01",
+    );
+    expect(capturedRequest?.data).toMatchObject({
+      packageName: "com.example.moonlit",
+      productId: "hero.sage",
+      listings: [
+        {
+          languageCode: "en-US",
+          title: "Moon Sage",
+          description: "Unlock Moon Sage",
+        },
+      ],
+      purchaseOptions: [
+        {
+          purchaseOptionId: "buy",
+          regionalPricingAndAvailabilityConfigs: [
+            {
+              regionCode: "US",
+              availability: "AVAILABLE",
+              price: {
+                currencyCode: "USD",
+                units: "24",
+                nanos: 990_000_000,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("shouldFallbackToLegacyOneTimeProduct", () => {
+  it("does not hide a bare 404 from an allow-missing create", () => {
+    expect(
+      shouldFallbackToLegacyOneTimeProduct(
+        { code: 404 },
+        { allowCreate: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("preserves a bare 404 fallback for legacy-only updates", () => {
+    expect(
+      shouldFallbackToLegacyOneTimeProduct(
+        { response: { status: 404 } },
+        { allowCreate: false },
+      ),
+    ).toBe(true);
+  });
+
+  it.each([true, false])(
+    "honors an explicit legacy API response when allowCreate=%s",
+    (allowCreate) => {
+      expect(
+        shouldFallbackToLegacyOneTimeProduct(
+          new Error("Please use the InAppProducts API for this application"),
+          { allowCreate },
+        ),
+      ).toBe(true);
+    },
+  );
+});
 
 describe("playPriceMicrosToNumber", () => {
   it("accepts non-negative safe integer price strings", () => {

--- a/packages/kit/convex/products/play.ts
+++ b/packages/kit/convex/products/play.ts
@@ -964,18 +964,22 @@ async function upsertAndroidOneTimeProduct(
   validateAndroidOneTimePrice(args);
 
   try {
-    await upsertModernAndroidOneTimeProduct(auth, args, options);
-    await activateAndroidOneTimePurchaseOption(auth, args);
-    return;
+    await upsertModernAndroidOneTimeProduct(androidpublisher, args, options);
   } catch (error) {
-    if (!shouldFallbackToLegacyOneTimeProduct(error)) throw error;
+    if (!shouldFallbackToLegacyOneTimeProduct(error, options)) throw error;
+
+    if (options.allowCreate) {
+      await insertLegacyAndroidOneTimeProduct(androidpublisher, args);
+      return;
+    }
+    await patchLegacyAndroidOneTimeProduct(androidpublisher, args);
+    return;
   }
 
-  if (options.allowCreate) {
-    await insertLegacyAndroidOneTimeProduct(androidpublisher, args);
-    return;
-  }
-  await patchLegacyAndroidOneTimeProduct(androidpublisher, args);
+  // Activation errors describe the modern product we just upserted and must
+  // not be reclassified as evidence that the product belongs to the legacy
+  // catalog.
+  await activateAndroidOneTimePurchaseOption(auth, args);
 }
 
 function validateAndroidOneTimePrice(
@@ -1030,24 +1034,21 @@ function buildAndroidOneTimeProduct(
   };
 }
 
-async function upsertModernAndroidOneTimeProduct(
-  auth: Auth.GoogleAuth,
+export async function upsertModernAndroidOneTimeProduct(
+  androidpublisher: androidpublisher_v3.Androidpublisher,
   args: AndroidOneTimeProductUpsertArgs,
   options: { allowCreate: boolean },
 ): Promise<void> {
-  const client = await auth.getClient();
-  await client.request({
-    method: "PATCH",
-    url:
-      `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/` +
-      `${encodeURIComponent(args.packageName)}/oneTimeProducts/` +
-      `${encodeURIComponent(args.productId)}`,
-    params: {
-      allowMissing: options.allowCreate,
-      updateMask: "listings,purchaseOptions",
-      "regionsVersion.version": "2022/01",
-    },
-    data: buildAndroidOneTimeProduct(args),
+  // The generated method owns the PATCH route. In googleapis v157 the
+  // upsert route is the lowercase `/onetimeproducts/{productId}` path,
+  // which differs from the camel-case routes used by sibling methods.
+  await androidpublisher.monetization.onetimeproducts.patch({
+    packageName: args.packageName,
+    productId: args.productId,
+    allowMissing: options.allowCreate,
+    updateMask: "listings,purchaseOptions",
+    "regionsVersion.version": "2022/01",
+    requestBody: buildAndroidOneTimeProduct(args),
   });
 }
 
@@ -1102,15 +1103,23 @@ async function patchLegacyAndroidOneTimeProduct(
   });
 }
 
-function shouldFallbackToLegacyOneTimeProduct(error: unknown): boolean {
+export function shouldFallbackToLegacyOneTimeProduct(
+  error: unknown,
+  options: { allowCreate: boolean },
+): boolean {
   const status = googleErrorStatus(error);
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    status === 404 ||
+  const explicitlyRequiresLegacyApi =
     message.includes("inappproducts") ||
     message.includes("InAppProduct") ||
-    message.includes("Please use the InAppProducts API")
-  );
+    message.includes("Please use the InAppProducts API");
+  if (explicitlyRequiresLegacyApi) return true;
+
+  // An update may target a SKU that exists only in the legacy catalog, so a
+  // modern 404 must retain the established legacy-patch compatibility path.
+  // A create uses allowMissing=true; its bare 404 cannot mean "product absent"
+  // and must remain visible instead of being masked by a legacy insert.
+  return !options.allowCreate && status === 404;
 }
 
 async function activateAndroidOneTimePurchaseOption(


### PR DESCRIPTION
## Summary

- call the current Google Play one-time products collection at `/monetization.onetimeproducts`
- preserve legacy fallback only when Google explicitly signals an InAppProducts resource or an existing product is not found
- add adapter-level coverage for create, update, activation, and fallback behavior

## Verification

- `bun run --filter @hyodotdev/openiap-kit lint`
- `bun run --filter @hyodotdev/openiap-kit prettier:check`
- `bun run --filter @hyodotdev/openiap-kit test` (73 files, 872 tests)
- `bun run --filter @hyodotdev/openiap-kit smoke:server`
- repository SDK parity audit

Backend-only Google Play Publishing API correction; no UI preview applies.