### PR TITLE
fix(kit): map Play one-time product state

### DIFF
--- a/packages/kit/convex/products/play.test.ts
+++ b/packages/kit/convex/products/play.test.ts
@@ -3,11 +3,43 @@ import { describe, expect, it } from "vitest";
 
 import {
   basePlanIdForPeriod,
+  mapModernPlayOneTimeState,
   moneyToMicros,
   playPriceMicrosToNumber,
   shouldFallbackToLegacyOneTimeProduct,
   upsertModernAndroidOneTimeProduct,
 } from "./play";
+
+describe("mapModernPlayOneTimeState", () => {
+  it("maps the modern purchase-option lifecycle without assuming availability", () => {
+    expect(mapModernPlayOneTimeState([{ state: "DRAFT" }])).toBe("Draft");
+    expect(mapModernPlayOneTimeState([{ state: "INACTIVE" }])).toBe("Removed");
+    expect(mapModernPlayOneTimeState([{ state: "INACTIVE_PUBLISHED" }])).toBe(
+      "Removed",
+    );
+    expect(mapModernPlayOneTimeState(undefined)).toBe("Removed");
+    expect(mapModernPlayOneTimeState(null)).toBe("Removed");
+    expect(mapModernPlayOneTimeState([])).toBe("Removed");
+    expect(mapModernPlayOneTimeState([{ state: "STATE_UNSPECIFIED" }])).toBe(
+      "Removed",
+    );
+    expect(mapModernPlayOneTimeState([{ state: "FUTURE_STATE" }])).toBe(
+      "Removed",
+    );
+  });
+
+  it("keeps a product active when any purchase option remains active", () => {
+    expect(
+      mapModernPlayOneTimeState([{ state: "INACTIVE" }, { state: "ACTIVE" }]),
+    ).toBe("Active");
+  });
+
+  it("treats mixed inactive and draft options as unavailable", () => {
+    expect(
+      mapModernPlayOneTimeState([{ state: "DRAFT" }, { state: "INACTIVE" }]),
+    ).toBe("Removed");
+  });
+});
 
 describe("upsertModernAndroidOneTimeProduct", () => {
   it("uses the generated lowercase one-time-product PATCH route", async () => {

--- a/packages/kit/convex/products/play.ts
+++ b/packages/kit/convex/products/play.ts
@@ -413,7 +413,7 @@ async function performAndroidSync(
               priceAmountMicros,
               currency: preferred?.currencyCode ?? undefined,
               storeRef: product.productId,
-              state: "Active",
+              state: mapModernPlayOneTimeState(product.purchaseOptions),
             });
             pulled += 1;
           }
@@ -1238,6 +1238,24 @@ function mapPlayStatus(
     default:
       return "Draft";
   }
+}
+
+export function mapModernPlayOneTimeState(
+  purchaseOptions: Array<{ state?: string | null }> | null | undefined,
+): "Draft" | "Active" | "Removed" {
+  const states = (purchaseOptions ?? []).map((option) =>
+    option.state?.toUpperCase(),
+  );
+  if (states.includes("ACTIVE")) return "Active";
+  if (states.includes("INACTIVE") || states.includes("INACTIVE_PUBLISHED")) {
+    return "Removed";
+  }
+  if (states.length > 0 && states.every((state) => state === "DRAFT")) {
+    return "Draft";
+  }
+  // Missing or future states must not become a kit Draft: a `both` sync would
+  // treat that as an instruction to push and could make the option sellable.
+  return "Removed";
 }
 
 function pickPlayTitle(

--- a/packages/kit/convex/products/sync.test.ts
+++ b/packages/kit/convex/products/sync.test.ts
@@ -6,6 +6,7 @@ import {
   deleteRemovedProductRow as registeredDeleteRemovedProductRow,
   isSafePriceAmountMicros,
   listDraftIosProducts as registeredListDraftIosProducts,
+  listRemovedAndroidProducts as registeredListRemovedAndroidProducts,
   markPushed as registeredMarkPushed,
   shouldPreserveKitRemovedDuringPull,
   upsertFromStore as registeredUpsertFromStore,
@@ -18,6 +19,9 @@ const deleteRemovedProductRow = testableFunction(
 );
 const upsertFromStore = testableFunction(registeredUpsertFromStore);
 const listDraftIosProducts = testableFunction(registeredListDraftIosProducts);
+const listRemovedAndroidProducts = testableFunction(
+  registeredListRemovedAndroidProducts,
+);
 const markPushed = testableFunction(registeredMarkPushed);
 
 type Row = Record<string, unknown> & { _id: string };
@@ -125,6 +129,103 @@ describe("shouldPreserveKitRemovedDuringPull", () => {
         origin: "kit",
       }),
     ).toBe(false);
+  });
+});
+
+describe("upsertFromStore removal provenance", () => {
+  function writableDb(product: Row) {
+    return new TestDb({
+      organizations: [{ _id: "organization_a", pendingDeletion: false }],
+      projects: [
+        {
+          _id: "project_a",
+          organizationId: "organization_a",
+          pendingDeletion: false,
+        },
+      ],
+      products: [product],
+    });
+  }
+
+  it("marks a store-reported removal as store-authored", async () => {
+    const product = {
+      _id: "product_a",
+      projectId: "project_a",
+      platform: "Android",
+      productId: "legacy_bundle",
+      type: "NonConsumable",
+      title: "Legacy bundle",
+      state: "Active",
+      origin: "kit",
+      storeRef: "legacy_bundle",
+      updatedAt: 1,
+    };
+    const db = writableDb(product);
+
+    await upsertFromStore._handler(
+      { db },
+      {
+        projectId: "project_a" as never,
+        productId: "legacy_bundle",
+        platform: "Android",
+        type: "NonConsumable",
+        title: "Legacy bundle",
+        storeRef: "legacy_bundle",
+        state: "Removed",
+      },
+    );
+
+    expect(product).toMatchObject({ state: "Removed", origin: "store" });
+    await expect(
+      listRemovedAndroidProducts._handler(
+        { db },
+        { projectId: "project_a" as never },
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("preserves an explicit kit removal for the push phase", async () => {
+    const product = {
+      _id: "product_a",
+      projectId: "project_a",
+      platform: "Android",
+      productId: "legacy_bundle",
+      type: "NonConsumable",
+      title: "Legacy bundle",
+      state: "Removed",
+      origin: "kit",
+      storeRef: "legacy_bundle",
+      updatedAt: 1,
+    };
+    const db = writableDb(product);
+
+    await upsertFromStore._handler(
+      { db },
+      {
+        projectId: "project_a" as never,
+        productId: "legacy_bundle",
+        platform: "Android",
+        type: "NonConsumable",
+        title: "Legacy bundle",
+        storeRef: "legacy_bundle",
+        state: "Removed",
+      },
+    );
+
+    expect(product).toMatchObject({ state: "Removed", origin: "kit" });
+    await expect(
+      listRemovedAndroidProducts._handler(
+        { db },
+        { projectId: "project_a" as never },
+      ),
+    ).resolves.toEqual([
+      {
+        productId: "legacy_bundle",
+        platform: "Android",
+        type: "NonConsumable",
+        storeRef: "legacy_bundle",
+      },
+    ]);
   });
 });
 

--- a/packages/kit/convex/products/sync.ts
+++ b/packages/kit/convex/products/sync.ts
@@ -189,13 +189,16 @@ export const upsertFromStore = internalMutation({
         offers: args.offers,
         syncedAt: now,
         updatedAt: now,
-        // Preserve `origin` on UPDATE — only set it if absent
-        // (back-fill for rows created before this field existed).
-        // A pulled row touched later by `upsertProduct` keeps
-        // `origin: "store"`; a kit row touched by pull-sync keeps
-        // `origin: "kit"`. The push filter then correctly excludes
-        // pulled-from-store rows even after they're re-touched.
-        ...(existing.origin === undefined ? { origin: "store" as const } : {}),
+        // A store-reported removal is upstream state, not a new kit-authored
+        // delete request. Reclassify it so the push half of a `both` job does
+        // not attempt to delete the already-unavailable resource. An explicit
+        // kit removal returned above before reaching this patch and therefore
+        // keeps its deletion intent. Preserve origin for all other updates.
+        ...(args.state === "Removed"
+          ? { origin: "store" as const }
+          : existing.origin === undefined
+            ? { origin: "store" as const }
+            : {}),
       });
       return existing._id;
     }


### PR DESCRIPTION
## Summary

- map modern Google Play one-time purchase option states instead of marking every pulled product Active
- preserve explicit IAPKit deletion intent while treating upstream removals as store-owned state
- fail closed for missing or future Play states so a `both` sync cannot republish an unavailable product

## Safety

- any `ACTIVE` option keeps the product Active
- `INACTIVE` and `INACTIVE_PUBLISHED` map to Removed
- only an explicit all-`DRAFT` option set maps to Draft
- store-reported Removed rows are excluded from the same sync job's delete pass
- explicit kit-authored Removed rows remain eligible for the intended upstream delete

## Test plan

- [x] SDK parity audit
- [x] Kit TypeScript and Convex typecheck
- [x] ESLint and Prettier
- [x] Kit test suite: 877 tests
- [x] Vite and compiled-server build
- [x] HTTP and browser smoke probes
- [x] independent two-round review

## Preview

No recording is applicable because this changes server-side Play catalog state mapping. The unit tests cover the state matrix and the same-job removal selector behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Play one-time products now accurately reflect their store-reported status, including draft, active, inactive, missing, and removed states.
  * Store-removed Android products are no longer queued for removal again.
  * Kit-authored removals remain preserved and eligible for synchronization.
* **Tests**
  * Added coverage for Google Play product state mapping and Android product removal synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->