### PR TITLE
feat(google): expose amazon userId and marketplace on purchases

### DIFF
--- a/knowledge/_claude-context/context.md
+++ b/knowledge/_claude-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated for Claude Code**
-> Last updated: 2026-08-02T11:31:06.959Z
+> Last updated: 2026-08-03T19:50:11.359Z
 >
 > Usage: `claude --context knowledge/_claude-context/context.md`
 
@@ -121,6 +121,25 @@ input RequestPurchaseAndroidProps {
 | Cross-platform type            | YES for platform-specific | `nameAndroid` in `ProductAndroid`                             |
 | Cross-platform type reference  | YES                       | `developerBillingOption: DeveloperBillingOptionParamsAndroid` |
 | Internal implementation        | NO (not API)              | `val offerToken` in Kotlin data class                         |
+
+### Store-Specific Fields (Amazon / Horizon)
+
+A platform type such as `PurchaseAndroid` can carry data that only one *store*
+provides (Google Play, Amazon Appstore, Horizon). Rules:
+
+- The `store: IapStore` discriminator identifies the store; store-exclusive
+  fields are nullable and null on every other store.
+- When a field only exists for one store, suffix it with the store name:
+  `userIdAmazon`, `userMarketplaceAmazon` in `PurchaseAndroid`. Do NOT stack
+  suffixes (`amazonUserIdAndroid` is wrong).
+- Fields sourced from Play Billing keep the plain `Android` suffix for
+  backward compatibility (`signatureAndroid`, `isSuspendedAndroid`), even
+  though other stores return null for them.
+- When several store fields travel together as one concept, prefer a dedicated
+  store-named type with clean inner fields
+  (`RequestVerifyPurchaseWithIapkitAmazonProps.userId`).
+- Where react-native-iap defined a legacy name for the same datum, keep that
+  exact name (`userIdAmazon`) so migration stays mechanical.
 
 ### Type vs Field Suffix
 

--- a/knowledge/internal/01-naming-conventions.md
+++ b/knowledge/internal/01-naming-conventions.md
@@ -104,6 +104,25 @@ input RequestPurchaseAndroidProps {
 | Cross-platform type reference  | YES                       | `developerBillingOption: DeveloperBillingOptionParamsAndroid` |
 | Internal implementation        | NO (not API)              | `val offerToken` in Kotlin data class                         |
 
+### Store-Specific Fields (Amazon / Horizon)
+
+A platform type such as `PurchaseAndroid` can carry data that only one *store*
+provides (Google Play, Amazon Appstore, Horizon). Rules:
+
+- The `store: IapStore` discriminator identifies the store; store-exclusive
+  fields are nullable and null on every other store.
+- When a field only exists for one store, suffix it with the store name:
+  `userIdAmazon`, `userMarketplaceAmazon` in `PurchaseAndroid`. Do NOT stack
+  suffixes (`amazonUserIdAndroid` is wrong).
+- Fields sourced from Play Billing keep the plain `Android` suffix for
+  backward compatibility (`signatureAndroid`, `isSuspendedAndroid`), even
+  though other stores return null for them.
+- When several store fields travel together as one concept, prefer a dedicated
+  store-named type with clean inner fields
+  (`RequestVerifyPurchaseWithIapkitAmazonProps.userId`).
+- Where react-native-iap defined a legacy name for the same datum, keep that
+  exact name (`userIdAmazon`) so migration stays mechanical.
+
 ### Type vs Field Suffix
 
 - **Type names**: Cross-platform types ALWAYS use platform suffix (`DeveloperBillingOptionParamsAndroid`)

--- a/libraries/expo-iap/src/types.ts
+++ b/libraries/expo-iap/src/types.ts
@@ -1214,6 +1214,17 @@ export interface PurchaseAndroid extends PurchaseCommon {
   /** Unix timestamp in milliseconds since January 1, 1970 UTC. */
   transactionDate: number;
   transactionId?: (string | null);
+  /**
+   * Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+   * Only populated on the Amazon flavor; required for server-side Amazon RVS
+   * receipt verification (userId + receiptId). Null on Google Play and Horizon.
+   */
+  userIdAmazon?: (string | null);
+  /**
+   * Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+   * for example "US" or "FR". Only populated on the Amazon flavor.
+   */
+  userMarketplaceAmazon?: (string | null);
 }
 
 export interface PurchaseCommon {

--- a/libraries/expo-iap/src/vega-adapter.ts
+++ b/libraries/expo-iap/src/vega-adapter.ts
@@ -693,6 +693,7 @@ function mapReceipt(
   receipt: VegaReceipt,
   fallbackProductType?: unknown,
   productIdOverride?: string,
+  userData?: VegaUserData | null,
 ): Purchase {
   const receiptId = receipt.receiptId ?? '';
   const productId = productIdOverride ?? getReceiptSku(receipt);
@@ -727,6 +728,8 @@ function mapReceipt(
       receipt.isDeferred && deferredSku
         ? {products: [deferredSku], purchaseToken: receiptId}
         : null,
+    userIdAmazon: nonBlankString(userData?.userId),
+    userMarketplaceAmazon: nonBlankString(userData?.marketplace),
   };
 }
 
@@ -976,6 +979,7 @@ export function createExpoIapVegaModule(
           receipt,
           getCachedProductType(receipt, productTypesBySku),
           resolveReceiptProductId(receipt),
+          cachedUserData,
         ),
       );
   };
@@ -1052,6 +1056,7 @@ export function createExpoIapVegaModule(
           getCachedProductType(receipt, productTypesBySku, sku) ??
           fallbackProductType,
         resolveReceiptProductId(receipt, sku),
+        cachedUserData,
       );
       requestedPurchases.push(purchase);
       emit('purchase-updated', purchase);
@@ -1405,7 +1410,12 @@ export function createExpoIapVegaModule(
         cachedUserData = response.userData ?? cachedUserData;
 
         if (!response.receipt) return [];
-        const purchase = mapReceipt(response.receipt, fallbackProductType, sku);
+        const purchase = mapReceipt(
+          response.receipt,
+          fallbackProductType,
+          sku,
+          response.userData ?? cachedUserData,
+        );
         emit('purchase-updated', purchase);
         return [purchase];
       } catch (error) {

--- a/libraries/flutter_inapp_purchase/lib/types.dart
+++ b/libraries/flutter_inapp_purchase/lib/types.dart
@@ -2710,6 +2710,8 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
     required this.store,
     required this.transactionDate,
     this.transactionId,
+    this.userIdAmazon,
+    this.userMarketplaceAmazon,
     this.isAlternativeBilling,
   });
 
@@ -2745,6 +2747,13 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
   /// Unix timestamp in milliseconds since January 1, 1970 UTC.
   final double transactionDate;
   final String? transactionId;
+  /// Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+  /// Only populated on the Amazon flavor; required for server-side Amazon RVS
+  /// receipt verification (userId + receiptId). Null on Google Play and Horizon.
+  final String? userIdAmazon;
+  /// Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+  /// for example "US" or "FR". Only populated on the Amazon flavor.
+  final String? userMarketplaceAmazon;
   final bool? isAlternativeBilling;
 
   factory PurchaseAndroid.fromJson(Map<String, dynamic> json) {
@@ -2770,6 +2779,8 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
       store: IapStore.fromJson(json['store'] as String),
       transactionDate: (json['transactionDate'] as num).toDouble(),
       transactionId: json['transactionId'] as String?,
+      userIdAmazon: json['userIdAmazon'] as String?,
+      userMarketplaceAmazon: json['userMarketplaceAmazon'] as String?,
       isAlternativeBilling: json['isAlternativeBilling'] as bool?,
     );
   }
@@ -2799,6 +2810,8 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
       'store': store.toJson(),
       'transactionDate': transactionDate,
       'transactionId': transactionId,
+      'userIdAmazon': userIdAmazon,
+      'userMarketplaceAmazon': userMarketplaceAmazon,
       'isAlternativeBilling': isAlternativeBilling,
     };
   }

--- a/libraries/godot-iap/addons/godot-iap/types.gd
+++ b/libraries/godot-iap/addons/godot-iap/types.gd
@@ -2059,6 +2059,10 @@ class PurchaseAndroid:
 	var is_suspended_android: Variant = null
 	## Pending purchase update for uncommitted subscription upgrade/downgrade (Android) Contains the new products and purchase token for the pending transaction. Returns null if no pending update exists. Available in Google Play Billing Library 5.0+
 	var pending_purchase_update_android: PendingPurchaseUpdateAndroid
+	## Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()). Only populated on the Amazon flavor; required for server-side Amazon RVS receipt verification (userId + receiptId). Null on Google Play and Horizon.
+	var user_id_amazon: Variant = null
+	## Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()), for example "US" or "FR". Only populated on the Amazon flavor.
+	var user_marketplace_amazon: Variant = null
 
 	static func from_dict(data: Dictionary) -> PurchaseAndroid:
 		var obj = PurchaseAndroid.new()
@@ -2120,6 +2124,10 @@ class PurchaseAndroid:
 				obj.pending_purchase_update_android = PendingPurchaseUpdateAndroid.from_dict(data["pendingPurchaseUpdateAndroid"])
 			else:
 				obj.pending_purchase_update_android = data["pendingPurchaseUpdateAndroid"]
+		if data.has("userIdAmazon") and data["userIdAmazon"] != null:
+			obj.user_id_amazon = data["userIdAmazon"]
+		if data.has("userMarketplaceAmazon") and data["userMarketplaceAmazon"] != null:
+			obj.user_marketplace_amazon = data["userMarketplaceAmazon"]
 		return obj
 
 	func to_dict() -> Dictionary:
@@ -2166,6 +2174,10 @@ class PurchaseAndroid:
 			dict["pendingPurchaseUpdateAndroid"] = pending_purchase_update_android.to_dict()
 		else:
 			dict["pendingPurchaseUpdateAndroid"] = pending_purchase_update_android
+		if user_id_amazon != null:
+			dict["userIdAmazon"] = user_id_amazon
+		if user_marketplace_amazon != null:
+			dict["userMarketplaceAmazon"] = user_marketplace_amazon
 		return dict
 
 class PurchaseError:

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/Helper.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/Helper.kt
@@ -506,6 +506,9 @@ internal fun com.android.billingclient.api.Purchase.toPurchase(): Purchase {
         signatureAndroid = signature,
         transactionDate = purchaseTime.toOpenIapTransactionDate(),
         transactionId = orderId,
+        // Amazon-flavor-only fields; Google Play purchases never carry them.
+        userIdAmazon = null,
+        userMarketplaceAmazon = null,
     )
 }
 

--- a/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
+++ b/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
@@ -2838,7 +2838,18 @@ public data class PurchaseAndroid(
      * Unix timestamp in milliseconds since January 1, 1970 UTC.
      */
     override val transactionDate: Double,
-    val transactionId: String? = null
+    val transactionId: String? = null,
+    /**
+     * Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+     * Only populated on the Amazon flavor; required for server-side Amazon RVS
+     * receipt verification (userId + receiptId). Null on Google Play and Horizon.
+     */
+    val userIdAmazon: String? = null,
+    /**
+     * Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+     * for example "US" or "FR". Only populated on the Amazon flavor.
+     */
+    val userMarketplaceAmazon: String? = null
 ) : PurchaseCommon, Purchase {
 
     companion object {
@@ -2865,6 +2876,8 @@ public data class PurchaseAndroid(
                 store = runCatching { (json["store"] as? String)?.let { IapStore.fromJson(it) } }.getOrNull() ?: IapStore.Unknown,
                 transactionDate = (json["transactionDate"] as? Number)?.toDouble() ?: 0.0,
                 transactionId = json["transactionId"] as? String,
+                userIdAmazon = json["userIdAmazon"] as? String,
+                userMarketplaceAmazon = json["userMarketplaceAmazon"] as? String,
             )
         }
     }
@@ -2892,6 +2905,8 @@ public data class PurchaseAndroid(
         "store" to store.toJson(),
         "transactionDate" to transactionDate,
         "transactionId" to transactionId,
+        "userIdAmazon" to userIdAmazon,
+        "userMarketplaceAmazon" to userMarketplaceAmazon,
     )
 }
 

--- a/libraries/maui-iap/src/OpenIap.Maui/Types.cs
+++ b/libraries/maui-iap/src/OpenIap.Maui/Types.cs
@@ -2973,6 +2973,15 @@ public sealed record PurchaseAndroid : Purchase, PurchaseCommon
     public required double TransactionDate { get; init; }
     [JsonPropertyName("transactionId")]
     public string? TransactionId { get; init; }
+    /// <summary>Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).</summary>
+    /// <summary>Only populated on the Amazon flavor; required for server-side Amazon RVS</summary>
+    /// <summary>receipt verification (userId + receiptId). Null on Google Play and Horizon.</summary>
+    [JsonPropertyName("userIdAmazon")]
+    public string? UserIdAmazon { get; init; }
+    /// <summary>Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),</summary>
+    /// <summary>for example &quot;US&quot; or &quot;FR&quot;. Only populated on the Amazon flavor.</summary>
+    [JsonPropertyName("userMarketplaceAmazon")]
+    public string? UserMarketplaceAmazon { get; init; }
 }
 
 public sealed record PurchaseError

--- a/libraries/maui-iap/tests/OpenIap.Maui.Tests/RecordJsonTests.cs
+++ b/libraries/maui-iap/tests/OpenIap.Maui.Tests/RecordJsonTests.cs
@@ -161,6 +161,26 @@ public class RecordJsonTests
         }
         """;
 
+    // Realistic Amazon-flavor payload: Amazon identity fields are set while
+    // Play-only extras (signature, obfuscated ids, pending update) are absent.
+    private const string PurchaseAndroidAmazonJson = """
+        {
+          "__typename": "PurchaseAndroid",
+          "id": "amazon-receipt-1",
+          "ids": ["premium.monthly"],
+          "isAutoRenewing": true,
+          "productId": "premium.monthly",
+          "purchaseState": "purchased",
+          "purchaseToken": "amazon-receipt-1",
+          "quantity": 1,
+          "store": "amazon",
+          "transactionDate": 1720000000000,
+          "transactionId": "amazon-receipt-1",
+          "userIdAmazon": "amazon-user-1",
+          "userMarketplaceAmazon": "US"
+        }
+        """;
+
     private const string PurchaseIosJson = """
         {
           "__typename": "PurchaseIOS",
@@ -309,6 +329,27 @@ public class RecordJsonTests
         Assert.Equal("GPA.1234-5678", android.TransactionId);
         Assert.Equal("amazon-user-1", android.UserIdAmazon);
         Assert.Equal("US", android.UserMarketplaceAmazon);
+    }
+
+    [Fact]
+    public void PurchaseAndroid_AmazonStorePayloadRoundTripsUserData()
+    {
+        var purchase = Assert.IsType<PurchaseAndroid>(
+            JsonSerializer.Deserialize<Purchase>(PurchaseAndroidAmazonJson, Options));
+
+        Assert.Equal(IapStore.Amazon, purchase.Store);
+        Assert.Equal("amazon-user-1", purchase.UserIdAmazon);
+        Assert.Equal("US", purchase.UserMarketplaceAmazon);
+        Assert.Null(purchase.SignatureAndroid);
+        Assert.Null(purchase.ObfuscatedAccountIdAndroid);
+        Assert.Null(purchase.PendingPurchaseUpdateAndroid);
+
+        var serialized = JsonSerializer.Serialize<Purchase>(purchase, Options);
+        var roundTrip = Assert.IsType<PurchaseAndroid>(
+            JsonSerializer.Deserialize<Purchase>(serialized, Options));
+
+        Assert.Equal("amazon-user-1", roundTrip.UserIdAmazon);
+        Assert.Equal("US", roundTrip.UserMarketplaceAmazon);
     }
 
     [Fact]

--- a/libraries/maui-iap/tests/OpenIap.Maui.Tests/RecordJsonTests.cs
+++ b/libraries/maui-iap/tests/OpenIap.Maui.Tests/RecordJsonTests.cs
@@ -155,7 +155,9 @@ public class RecordJsonTests
           "signatureAndroid": "signature-abc",
           "store": "google",
           "transactionDate": 1720000000000,
-          "transactionId": "GPA.1234-5678"
+          "transactionId": "GPA.1234-5678",
+          "userIdAmazon": "amazon-user-1",
+          "userMarketplaceAmazon": "US"
         }
         """;
 
@@ -305,6 +307,8 @@ public class RecordJsonTests
         Assert.Equal(["premium.annual"], android.PendingPurchaseUpdateAndroid!.Products);
         Assert.Equal("pending-token", android.PendingPurchaseUpdateAndroid.PurchaseToken);
         Assert.Equal("GPA.1234-5678", android.TransactionId);
+        Assert.Equal("amazon-user-1", android.UserIdAmazon);
+        Assert.Equal("US", android.UserMarketplaceAmazon);
     }
 
     [Fact]

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -1312,7 +1312,9 @@ class HybridRnIap : HybridRnIapSpec() {
             obfuscatedProfileIdAndroid = androidPurchase?.obfuscatedProfileIdAndroid.wrapVariant(),
             developerPayloadAndroid = androidPurchase?.developerPayloadAndroid.wrapVariant(),
             isSuspendedAndroid = androidPurchase?.isSuspendedAndroid.wrapVariant(),
-            pendingPurchaseUpdateAndroid = androidPurchase?.pendingPurchaseUpdateAndroid.wrapVariant()
+            pendingPurchaseUpdateAndroid = androidPurchase?.pendingPurchaseUpdateAndroid.wrapVariant(),
+            userIdAmazon = androidPurchase?.userIdAmazon.wrapVariant(),
+            userMarketplaceAmazon = androidPurchase?.userMarketplaceAmazon.wrapVariant()
         )
     }
 

--- a/libraries/react-native-iap/ios/RnIapHelper.swift
+++ b/libraries/react-native-iap/ios/RnIapHelper.swift
@@ -459,7 +459,9 @@ enum RnIapHelper {
             obfuscatedProfileIdAndroid: nil,
             developerPayloadAndroid: nil,
             isSuspendedAndroid: nil,
-            pendingPurchaseUpdateAndroid: nil
+            pendingPurchaseUpdateAndroid: nil,
+            userIdAmazon: nil,
+            userMarketplaceAmazon: nil
         )
     }
 

--- a/libraries/react-native-iap/src/specs/RnIap.nitro.ts
+++ b/libraries/react-native-iap/src/specs/RnIap.nitro.ts
@@ -590,6 +590,8 @@ export interface NitroPurchase {
   developerPayloadAndroid?: string | null;
   isSuspendedAndroid?: null | boolean;
   pendingPurchaseUpdateAndroid?: PendingPurchaseUpdateAndroid | null;
+  userIdAmazon?: string | null;
+  userMarketplaceAmazon?: string | null;
 }
 
 /**

--- a/libraries/react-native-iap/src/types.ts
+++ b/libraries/react-native-iap/src/types.ts
@@ -1214,6 +1214,17 @@ export interface PurchaseAndroid extends PurchaseCommon {
   /** Unix timestamp in milliseconds since January 1, 1970 UTC. */
   transactionDate: number;
   transactionId?: (string | null);
+  /**
+   * Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+   * Only populated on the Amazon flavor; required for server-side Amazon RVS
+   * receipt verification (userId + receiptId). Null on Google Play and Horizon.
+   */
+  userIdAmazon?: (string | null);
+  /**
+   * Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+   * for example "US" or "FR". Only populated on the Amazon flavor.
+   */
+  userMarketplaceAmazon?: (string | null);
 }
 
 export interface PurchaseCommon {

--- a/libraries/react-native-iap/src/utils/type-bridge.ts
+++ b/libraries/react-native-iap/src/utils/type-bridge.ts
@@ -504,6 +504,16 @@ export function convertNitroPurchaseToPurchase(
       ? legacyAndroidId
       : null);
 
+  // Amazon identity metadata must never leak onto other stores' purchases.
+  const amazonUserId =
+    nitroPurchase.userIdAmazon != null && store === STORE_AMAZON
+      ? toNullableString(nitroPurchase.userIdAmazon)
+      : null;
+  const amazonUserMarketplace =
+    nitroPurchase.userMarketplaceAmazon != null && store === STORE_AMAZON
+      ? toNullableString(nitroPurchase.userMarketplaceAmazon)
+      : null;
+
   const androidPurchase: PurchaseAndroid = {
     id: nitroPurchase.id,
     productId: nitroPurchase.productId,
@@ -540,8 +550,8 @@ export function convertNitroPurchaseToPurchase(
     isSuspendedAndroid: toNullableBoolean(nitroPurchase.isSuspendedAndroid),
     pendingPurchaseUpdateAndroid:
       nitroPurchase.pendingPurchaseUpdateAndroid ?? null,
-    userIdAmazon: toNullableString(nitroPurchase.userIdAmazon),
-    userMarketplaceAmazon: toNullableString(nitroPurchase.userMarketplaceAmazon),
+    userIdAmazon: amazonUserId,
+    userMarketplaceAmazon: amazonUserMarketplace,
   };
 
   return androidPurchase;

--- a/libraries/react-native-iap/src/utils/type-bridge.ts
+++ b/libraries/react-native-iap/src/utils/type-bridge.ts
@@ -540,6 +540,8 @@ export function convertNitroPurchaseToPurchase(
     isSuspendedAndroid: toNullableBoolean(nitroPurchase.isSuspendedAndroid),
     pendingPurchaseUpdateAndroid:
       nitroPurchase.pendingPurchaseUpdateAndroid ?? null,
+    userIdAmazon: toNullableString(nitroPurchase.userIdAmazon),
+    userMarketplaceAmazon: toNullableString(nitroPurchase.userMarketplaceAmazon),
   };
 
   return androidPurchase;

--- a/libraries/react-native-iap/src/vega-adapter.ts
+++ b/libraries/react-native-iap/src/vega-adapter.ts
@@ -701,6 +701,7 @@ function mapReceipt(
   receipt: VegaReceipt,
   fallbackProductType?: unknown,
   productIdOverride?: string,
+  userData?: VegaUserData | null,
 ): NitroPurchase {
   const receiptId = receipt.receiptId ?? '';
   const productId = productIdOverride ?? getReceiptSku(receipt);
@@ -737,6 +738,8 @@ function mapReceipt(
       receipt.isDeferred && deferredSku
         ? {products: [deferredSku], purchaseToken: receiptId}
         : null,
+    userIdAmazon: nonBlankString(userData?.userId),
+    userMarketplaceAmazon: nonBlankString(userData?.marketplace),
   };
 }
 
@@ -1056,6 +1059,7 @@ export function createVegaIapModule(service: VegaPurchasingService): RnIap {
           receipt,
           getCachedProductType(receipt, productTypesBySku),
           resolveReceiptProductId(receipt),
+          cachedUserData,
         ),
       );
   };
@@ -1144,6 +1148,7 @@ export function createVegaIapModule(service: VegaPurchasingService): RnIap {
           getCachedProductType(receipt, productTypesBySku, sku) ??
           (matchesRequestedSku ? fallbackProductType : undefined),
         resolveReceiptProductId(receipt, matchesRequestedSku ? sku : undefined),
+        cachedUserData,
       );
       if (matchesRequestedSku) {
         requestedPurchases.push(purchase);
@@ -1492,7 +1497,12 @@ export function createVegaIapModule(service: VegaPurchasingService): RnIap {
         if (!response.receipt) return [];
 
         cachedUserData = response.userData ?? cachedUserData;
-        const purchase = mapReceipt(response.receipt, fallbackProductType, sku);
+        const purchase = mapReceipt(
+          response.receipt,
+          fallbackProductType,
+          sku,
+          response.userData ?? cachedUserData,
+        );
         emitPurchaseUpdated(purchase);
         return [purchase];
       } catch (error) {

--- a/packages/apple/Sources/Models/Types.swift
+++ b/packages/apple/Sources/Models/Types.swift
@@ -1058,6 +1058,13 @@ public struct PurchaseAndroid: Codable, PurchaseCommon {
     /// Unix timestamp in milliseconds since January 1, 1970 UTC.
     public var transactionDate: Double
     public var transactionId: String? = nil
+    /// Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+    /// Only populated on the Amazon flavor; required for server-side Amazon RVS
+    /// receipt verification (userId + receiptId). Null on Google Play and Horizon.
+    public var userIdAmazon: String? = nil
+    /// Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+    /// for example "US" or "FR". Only populated on the Amazon flavor.
+    public var userMarketplaceAmazon: String? = nil
 }
 
 public struct PurchaseError: Codable {

--- a/packages/docs/src/pages/docs/types/purchase.tsx
+++ b/packages/docs/src/pages/docs/types/purchase.tsx
@@ -701,6 +701,36 @@ function Purchase() {
                         )
                       </td>
                     </tr>
+                    <tr>
+                      <td>
+                        <code>userIdAmazon</code>
+                      </td>
+                      <td>
+                        Amazon Appstore user id from{' '}
+                        <code>PurchaseResponse.getUserData().getUserId()</code>.
+                        Only populated on the Amazon flavor; required together
+                        with <code>purchaseToken</code> (receiptId) for
+                        server-side{' '}
+                        <a
+                          href="https://developer.amazon.com/docs/in-app-purchasing/iap-rvs-for-android-apps.html"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Amazon RVS
+                        </a>{' '}
+                        receipt verification. Null on Google Play and Horizon.
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <code>userMarketplaceAmazon</code>
+                      </td>
+                      <td>
+                        Amazon Appstore marketplace (for example <code>US</code>{' '}
+                        or <code>FR</code>). Only populated on the Amazon
+                        flavor; null on Google Play and Horizon.
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
 

--- a/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -14,6 +14,7 @@ import com.amazon.device.iap.model.FulfillmentResult
 import com.amazon.device.iap.model.ProductDataResponse
 import com.amazon.device.iap.model.PurchaseResponse
 import com.amazon.device.iap.model.PurchaseUpdatesResponse
+import com.amazon.device.iap.model.UserData
 import com.amazon.device.iap.model.UserDataResponse
 import dev.hyo.openiap.helpers.isSubscriptionReplacementTargetCountValid
 import dev.hyo.openiap.helpers.requireAuthoritativeStorefrontCountry
@@ -392,8 +393,10 @@ class OpenIapModule(
     private val purchaseRequests = ConcurrentHashMap<String, CompletableDeferred<PurchaseResponse>>()
     private val purchaseUpdatesRequests = ConcurrentHashMap<String, CompletableDeferred<PurchaseUpdatesResponse>>()
     private val userDataRequests = ConcurrentHashMap<String, CompletableDeferred<UserDataResponse>>()
-    // Amazon getUserData() userId/marketplace are needed for server-side RVS verification.
-    // Cache the latest values so they can be attached to each purchase (see toPurchase).
+    // Amazon userId/marketplace are needed for server-side RVS verification.
+    // Purchase mapping prefers the userData carried on each Purchase(Updates)Response;
+    // these cached values (refreshed by every successful response) are the fallback
+    // for responses that arrive without userData.
     @Volatile private var cachedAmazonUserId: String? = null
     @Volatile private var cachedAmazonMarketplace: String? = null
     private val earlyProductDataResponses = ConcurrentHashMap<String, ProductDataResponse>()
@@ -698,9 +701,11 @@ class OpenIapModule(
                         // local request SKU is safe even when callbacks arrive out
                         // of order.
                         cacheReceiptProduct(receipt, receipt.productTypeOrNull())
+                        response.userData?.let { rememberAmazonUserData(it) }
                         val purchase = receipt.toPurchase(
                             productTypeOverride = receipt.productTypeOrNull(),
-                            productIdOverride = sku
+                            productIdOverride = sku,
+                            userData = response.userData
                         )
                         purchaseUpdateListeners.forEach { listener ->
                             runCatching { listener.onPurchaseUpdated(purchase) }
@@ -1006,12 +1011,14 @@ class OpenIapModule(
         throw OpenIapError.FeatureNotSupported("Amazon Appstore does not support Google Play billing in-app messages")
     }
 
+    private fun rememberAmazonUserData(userData: UserData) {
+        userData.userId?.takeIf { it.isNotBlank() }?.let { cachedAmazonUserId = it }
+        userData.marketplace?.takeIf { it.isNotBlank() }?.let { cachedAmazonMarketplace = it }
+    }
+
     override fun onUserDataResponse(userDataResponse: UserDataResponse) {
         if (userDataResponse.requestStatus == UserDataResponse.RequestStatus.SUCCESSFUL) {
-            userDataResponse.userData?.let {
-                cachedAmazonUserId = it.userId
-                cachedAmazonMarketplace = it.marketplace
-            }
+            userDataResponse.userData?.let { rememberAmazonUserData(it) }
         }
         completeOrCache(
             userDataRequests,
@@ -1254,6 +1261,7 @@ class OpenIapModule(
             var shouldReset = reset
             var pageCount = 0
             var hasMore = false
+            var responseUserData: UserData? = null
             do {
                 if (pageCount >= AMAZON_PURCHASE_UPDATES_MAX_PAGES) {
                     throw OpenIapError.ServiceTimeout(
@@ -1265,6 +1273,10 @@ class OpenIapModule(
                 shouldReset = false
                 when (response.requestStatus) {
                     PurchaseUpdatesResponse.RequestStatus.SUCCESSFUL -> {
+                        response.userData?.let {
+                            responseUserData = it
+                            rememberAmazonUserData(it)
+                        }
                         receipts += response.receipts.orEmpty()
                             .filter {
                                 shouldIncludeAmazonReceipt(
@@ -1292,6 +1304,7 @@ class OpenIapModule(
                 cacheReceiptProduct(receipt, productType)
                 receipt.toPurchase(
                     productTypeOverride = productType,
+                    userData = responseUserData,
                 )
             }
         }
@@ -1612,7 +1625,8 @@ class OpenIapModule(
 
     private fun AmazonReceipt.toPurchase(
         productTypeOverride: AmazonProductType? = productTypeOrNull(),
-        productIdOverride: String? = null
+        productIdOverride: String? = null,
+        userData: UserData? = null
     ): PurchaseAndroid {
         val dateMillis = purchaseDate?.time?.toDouble() ?: 0.0
         val receiptCanceled = isCanceled || cancelDate != null
@@ -1628,8 +1642,10 @@ class OpenIapModule(
             deferredSku = deferredSku,
             termSku = termSku,
             productIdOverride = productIdOverride,
-            userIdAmazon = cachedAmazonUserId,
-            userMarketplaceAmazon = cachedAmazonMarketplace
+            // The response's own userData is authoritative for this purchase;
+            // the cache only covers responses that arrived without it.
+            userIdAmazon = userData?.userId ?: cachedAmazonUserId,
+            userMarketplaceAmazon = userData?.marketplace ?: cachedAmazonMarketplace
         ).copy(dataAndroid = toJSON().toString())
     }
 

--- a/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -320,7 +320,9 @@ internal fun buildAmazonPurchase(
     isDeferred: Boolean,
     deferredSku: String? = null,
     termSku: String? = null,
-    productIdOverride: String? = null
+    productIdOverride: String? = null,
+    userIdAmazon: String? = null,
+    userMarketplaceAmazon: String? = null
 ): PurchaseAndroid {
     val resolvedProductId = productIdOverride?.takeIf { it.isNotBlank() } ?: receiptSku
     val resolvedCurrentPlanId = termSku?.takeIf { it.isNotBlank() } ?: resolvedProductId
@@ -354,7 +356,9 @@ internal fun buildAmazonPurchase(
         signatureAndroid = null,
         store = IapStore.Amazon,
         transactionDate = purchaseDateMillis,
-        transactionId = receiptId
+        transactionId = receiptId,
+        userIdAmazon = userIdAmazon,
+        userMarketplaceAmazon = userMarketplaceAmazon
     )
 }
 
@@ -388,6 +392,10 @@ class OpenIapModule(
     private val purchaseRequests = ConcurrentHashMap<String, CompletableDeferred<PurchaseResponse>>()
     private val purchaseUpdatesRequests = ConcurrentHashMap<String, CompletableDeferred<PurchaseUpdatesResponse>>()
     private val userDataRequests = ConcurrentHashMap<String, CompletableDeferred<UserDataResponse>>()
+    // Amazon getUserData() userId/marketplace are needed for server-side RVS verification.
+    // Cache the latest values so they can be attached to each purchase (see toPurchase).
+    @Volatile private var cachedAmazonUserId: String? = null
+    @Volatile private var cachedAmazonMarketplace: String? = null
     private val earlyProductDataResponses = ConcurrentHashMap<String, ProductDataResponse>()
     private val earlyPurchaseResponses = ConcurrentHashMap<String, PurchaseResponse>()
     private val earlyPurchaseUpdatesResponses = ConcurrentHashMap<String, PurchaseUpdatesResponse>()
@@ -999,6 +1007,12 @@ class OpenIapModule(
     }
 
     override fun onUserDataResponse(userDataResponse: UserDataResponse) {
+        if (userDataResponse.requestStatus == UserDataResponse.RequestStatus.SUCCESSFUL) {
+            userDataResponse.userData?.let {
+                cachedAmazonUserId = it.userId
+                cachedAmazonMarketplace = it.marketplace
+            }
+        }
         completeOrCache(
             userDataRequests,
             earlyUserDataResponses,
@@ -1613,7 +1627,9 @@ class OpenIapModule(
             isDeferred = receiptDeferred,
             deferredSku = deferredSku,
             termSku = termSku,
-            productIdOverride = productIdOverride
+            productIdOverride = productIdOverride,
+            userIdAmazon = cachedAmazonUserId,
+            userMarketplaceAmazon = cachedAmazonMarketplace
         ).copy(dataAndroid = toJSON().toString())
     }
 

--- a/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/amazon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -395,10 +395,10 @@ class OpenIapModule(
     private val userDataRequests = ConcurrentHashMap<String, CompletableDeferred<UserDataResponse>>()
     // Amazon userId/marketplace are needed for server-side RVS verification.
     // Purchase mapping prefers the userData carried on each Purchase(Updates)Response;
-    // these cached values (refreshed by every successful response) are the fallback
-    // for responses that arrive without userData.
-    @Volatile private var cachedAmazonUserId: String? = null
-    @Volatile private var cachedAmazonMarketplace: String? = null
+    // this cached snapshot (refreshed only by lifecycle-accepted responses and
+    // cleared on endConnection) is the fallback for responses without userData.
+    // One immutable snapshot keeps userId/marketplace from mixing across users.
+    @Volatile private var cachedAmazonUserData: UserData? = null
     private val earlyProductDataResponses = ConcurrentHashMap<String, ProductDataResponse>()
     private val earlyPurchaseResponses = ConcurrentHashMap<String, PurchaseResponse>()
     private val earlyPurchaseUpdatesResponses = ConcurrentHashMap<String, PurchaseUpdatesResponse>()
@@ -476,6 +476,7 @@ class OpenIapModule(
                 earlyPurchaseUpdatesResponses.clear()
                 earlyUserDataResponses.clear()
                 clearPurchaseRequestTracking()
+                cachedAmazonUserData = null
             }
             timedOutRequestIds.addAll(abortedRequestIds)
             val abortedMappedSkus = mutableSetOf<String>()
@@ -657,6 +658,7 @@ class OpenIapModule(
                         ).withProductId(sku)
                     )
                 }
+                val purchaseGeneration = requestLifecycle.currentGeneration()
                 val response = try {
                     requestAmazonPurchase(sku)
                 } catch (error: CancellationException) {
@@ -701,7 +703,9 @@ class OpenIapModule(
                         // local request SKU is safe even when callbacks arrive out
                         // of order.
                         cacheReceiptProduct(receipt, receipt.productTypeOrNull())
-                        response.userData?.let { rememberAmazonUserData(it) }
+                        if (requestLifecycle.isGenerationCurrent(purchaseGeneration)) {
+                            response.userData?.let { rememberAmazonUserData(it) }
+                        }
                         val purchase = receipt.toPurchase(
                             productTypeOverride = receipt.productTypeOrNull(),
                             productIdOverride = sku,
@@ -1012,20 +1016,22 @@ class OpenIapModule(
     }
 
     private fun rememberAmazonUserData(userData: UserData) {
-        userData.userId?.takeIf { it.isNotBlank() }?.let { cachedAmazonUserId = it }
-        userData.marketplace?.takeIf { it.isNotBlank() }?.let { cachedAmazonMarketplace = it }
+        if (userData.userId.isNullOrBlank()) return
+        cachedAmazonUserData = userData
     }
 
     override fun onUserDataResponse(userDataResponse: UserDataResponse) {
-        if (userDataResponse.requestStatus == UserDataResponse.RequestStatus.SUCCESSFUL) {
-            userDataResponse.userData?.let { rememberAmazonUserData(it) }
-        }
-        completeOrCache(
+        val accepted = completeOrCache(
             userDataRequests,
             earlyUserDataResponses,
             userDataResponse.requestId.toString(),
             userDataResponse
         )
+        // Cache only lifecycle-accepted callbacks so a late response cannot
+        // overwrite the active identity after endConnection or a newer request.
+        if (accepted && userDataResponse.requestStatus == UserDataResponse.RequestStatus.SUCCESSFUL) {
+            userDataResponse.userData?.let { rememberAmazonUserData(it) }
+        }
     }
 
     override fun onProductDataResponse(productDataResponse: ProductDataResponse) {
@@ -1275,7 +1281,9 @@ class OpenIapModule(
                     PurchaseUpdatesResponse.RequestStatus.SUCCESSFUL -> {
                         response.userData?.let {
                             responseUserData = it
-                            rememberAmazonUserData(it)
+                            if (requestLifecycle.isGenerationCurrent(operationGeneration)) {
+                                rememberAmazonUserData(it)
+                            }
                         }
                         receipts += response.receipts.orEmpty()
                             .filter {
@@ -1461,19 +1469,24 @@ class OpenIapModule(
         }
     }
 
+    /**
+     * Returns true when the response was accepted by the current request
+     * lifecycle (delivered to its Deferred or cached as an early response),
+     * false when it was ignored as timed-out, ended, or unknown.
+     */
     private fun <T> completeOrCache(
         pending: ConcurrentHashMap<String, CompletableDeferred<T>>,
         earlyResponses: ConcurrentHashMap<String, T>,
         requestId: String,
         value: T
-    ) {
+    ): Boolean {
         if (timedOutRequestIds.remove(requestId)) {
             requestLifecycle.complete(requestId)
             OpenIapLog.warn(
                 "Ignoring late Amazon Appstore response for aborted request $requestId",
                 TAG
             )
-            return
+            return false
         }
         val deferred = pending[requestId]
         if (deferred != null) {
@@ -1487,19 +1500,21 @@ class OpenIapModule(
                     TAG,
                 )
             }
-        } else if (
-            !requestLifecycle.cacheIfCurrent(requestId) {
-                if (earlyResponses.size >= AMAZON_EARLY_RESPONSE_CACHE_MAX) {
-                    earlyResponses.keys.firstOrNull()?.let(earlyResponses::remove)
-                }
-                earlyResponses[requestId] = value
+            return accepted
+        }
+        val cached = requestLifecycle.cacheIfCurrent(requestId) {
+            if (earlyResponses.size >= AMAZON_EARLY_RESPONSE_CACHE_MAX) {
+                earlyResponses.keys.firstOrNull()?.let(earlyResponses::remove)
             }
-        ) {
+            earlyResponses[requestId] = value
+        }
+        if (!cached) {
             OpenIapLog.warn(
                 "Ignoring Amazon Appstore response for unknown request $requestId",
                 TAG,
             )
         }
+        return cached
     }
 
     private fun <T> failPendingAmazonRequests(
@@ -1631,6 +1646,9 @@ class OpenIapModule(
         val dateMillis = purchaseDate?.time?.toDouble() ?: 0.0
         val receiptCanceled = isCanceled || cancelDate != null
         val receiptDeferred = isDeferred
+        // The response's own userData is authoritative for this purchase; the
+        // cached snapshot is the fallback. Never mix fields across snapshots.
+        val resolvedUserData = userData ?: cachedAmazonUserData
         return buildAmazonPurchase(
             packageName = context.packageName,
             receiptId = receiptId,
@@ -1642,10 +1660,8 @@ class OpenIapModule(
             deferredSku = deferredSku,
             termSku = termSku,
             productIdOverride = productIdOverride,
-            // The response's own userData is authoritative for this purchase;
-            // the cache only covers responses that arrived without it.
-            userIdAmazon = userData?.userId ?: cachedAmazonUserId,
-            userMarketplaceAmazon = userData?.marketplace ?: cachedAmazonMarketplace
+            userIdAmazon = resolvedUserData?.userId,
+            userMarketplaceAmazon = resolvedUserData?.marketplace
         ).copy(dataAndroid = toJSON().toString())
     }
 

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/utils/BillingConverters.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/utils/BillingConverters.kt
@@ -148,7 +148,10 @@ internal object HorizonBillingConverters {
             signatureAndroid = signature,
             store = IapStore.Horizon,
             transactionDate = (purchaseTime ?: 0L).toDouble(),
-            transactionId = orderId?.takeIf { it.isNotBlank() } ?: token
+            transactionId = orderId?.takeIf { it.isNotBlank() } ?: token,
+            // Amazon-flavor-only fields; Horizon purchases never carry them.
+            userIdAmazon = null,
+            userMarketplaceAmazon = null
         )
     }
 

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
@@ -2890,7 +2890,18 @@ public data class PurchaseAndroid(
      * Unix timestamp in milliseconds since January 1, 1970 UTC.
      */
     override val transactionDate: Double,
-    val transactionId: String? = null
+    val transactionId: String? = null,
+    /**
+     * Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+     * Only populated on the Amazon flavor; required for server-side Amazon RVS
+     * receipt verification (userId + receiptId). Null on Google Play and Horizon.
+     */
+    val userIdAmazon: String? = null,
+    /**
+     * Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+     * for example "US" or "FR". Only populated on the Amazon flavor.
+     */
+    val userMarketplaceAmazon: String? = null
 ) : PurchaseCommon, Purchase {
 
     companion object {
@@ -2917,6 +2928,8 @@ public data class PurchaseAndroid(
                 store = runCatching { (json["store"] as? String)?.let { IapStore.fromJson(it) } }.getOrNull() ?: IapStore.Unknown,
                 transactionDate = (json["transactionDate"] as? Number)?.toDouble() ?: 0.0,
                 transactionId = json["transactionId"] as? String,
+                userIdAmazon = json["userIdAmazon"] as? String,
+                userMarketplaceAmazon = json["userMarketplaceAmazon"] as? String,
             )
         }
     }
@@ -2944,6 +2957,8 @@ public data class PurchaseAndroid(
         "store" to store.toJson(),
         "transactionDate" to transactionDate,
         "transactionId" to transactionId,
+        "userIdAmazon" to userIdAmazon,
+        "userMarketplaceAmazon" to userMarketplaceAmazon,
     )
 }
 

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/utils/BillingConverters.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/utils/BillingConverters.kt
@@ -337,7 +337,10 @@ internal object BillingConverters {
             signatureAndroid = signature,
             store = IapStore.Google,
             transactionDate = purchaseTime.toDouble(),
-            transactionId = orderId
+            transactionId = orderId,
+            // Amazon-flavor-only fields; Google Play purchases never carry them.
+            userIdAmazon = null,
+            userMarketplaceAmazon = null
         )
     }
 

--- a/packages/google/openiap/src/testAmazon/java/dev/hyo/openiap/AmazonUserDataMappingTest.kt
+++ b/packages/google/openiap/src/testAmazon/java/dev/hyo/openiap/AmazonUserDataMappingTest.kt
@@ -1,0 +1,42 @@
+package dev.hyo.openiap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AmazonUserDataMappingTest {
+
+    @Test
+    fun `amazon purchases carry the RVS user data when provided`() {
+        val purchase = buildAmazonPurchase(
+            packageName = "dev.hyo.martie",
+            receiptId = "receipt-1",
+            receiptSku = "dev.hyo.martie.premium",
+            isSubscription = false,
+            purchaseDateMillis = 1_700_000_000_000.0,
+            isCanceled = false,
+            isDeferred = false,
+            userIdAmazon = "amazon-user-1",
+            userMarketplaceAmazon = "US"
+        )
+
+        assertEquals("amazon-user-1", purchase.userIdAmazon)
+        assertEquals("US", purchase.userMarketplaceAmazon)
+    }
+
+    @Test
+    fun `amazon purchases default to null user data when unavailable`() {
+        val purchase = buildAmazonPurchase(
+            packageName = "dev.hyo.martie",
+            receiptId = "receipt-2",
+            receiptSku = "dev.hyo.martie.premium",
+            isSubscription = false,
+            purchaseDateMillis = 1_700_000_000_000.0,
+            isCanceled = false,
+            isDeferred = false
+        )
+
+        assertNull(purchase.userIdAmazon)
+        assertNull(purchase.userMarketplaceAmazon)
+    }
+}

--- a/packages/gql/src/generated/Types.cs
+++ b/packages/gql/src/generated/Types.cs
@@ -2973,6 +2973,15 @@ public sealed record PurchaseAndroid : Purchase, PurchaseCommon
     public required double TransactionDate { get; init; }
     [JsonPropertyName("transactionId")]
     public string? TransactionId { get; init; }
+    /// <summary>Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).</summary>
+    /// <summary>Only populated on the Amazon flavor; required for server-side Amazon RVS</summary>
+    /// <summary>receipt verification (userId + receiptId). Null on Google Play and Horizon.</summary>
+    [JsonPropertyName("userIdAmazon")]
+    public string? UserIdAmazon { get; init; }
+    /// <summary>Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),</summary>
+    /// <summary>for example &quot;US&quot; or &quot;FR&quot;. Only populated on the Amazon flavor.</summary>
+    [JsonPropertyName("userMarketplaceAmazon")]
+    public string? UserMarketplaceAmazon { get; init; }
 }
 
 public sealed record PurchaseError

--- a/packages/gql/src/generated/Types.kt
+++ b/packages/gql/src/generated/Types.kt
@@ -2836,7 +2836,18 @@ public data class PurchaseAndroid(
      * Unix timestamp in milliseconds since January 1, 1970 UTC.
      */
     override val transactionDate: Double,
-    val transactionId: String? = null
+    val transactionId: String? = null,
+    /**
+     * Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+     * Only populated on the Amazon flavor; required for server-side Amazon RVS
+     * receipt verification (userId + receiptId). Null on Google Play and Horizon.
+     */
+    val userIdAmazon: String? = null,
+    /**
+     * Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+     * for example "US" or "FR". Only populated on the Amazon flavor.
+     */
+    val userMarketplaceAmazon: String? = null
 ) : PurchaseCommon, Purchase {
 
     companion object {
@@ -2863,6 +2874,8 @@ public data class PurchaseAndroid(
                 store = runCatching { (json["store"] as? String)?.let { IapStore.fromJson(it) } }.getOrNull() ?: IapStore.Unknown,
                 transactionDate = (json["transactionDate"] as? Number)?.toDouble() ?: 0.0,
                 transactionId = json["transactionId"] as? String,
+                userIdAmazon = json["userIdAmazon"] as? String,
+                userMarketplaceAmazon = json["userMarketplaceAmazon"] as? String,
             )
         }
     }
@@ -2890,6 +2903,8 @@ public data class PurchaseAndroid(
         "store" to store.toJson(),
         "transactionDate" to transactionDate,
         "transactionId" to transactionId,
+        "userIdAmazon" to userIdAmazon,
+        "userMarketplaceAmazon" to userMarketplaceAmazon,
     )
 }
 

--- a/packages/gql/src/generated/Types.swift
+++ b/packages/gql/src/generated/Types.swift
@@ -1058,6 +1058,13 @@ public struct PurchaseAndroid: Codable, PurchaseCommon {
     /// Unix timestamp in milliseconds since January 1, 1970 UTC.
     public var transactionDate: Double
     public var transactionId: String? = nil
+    /// Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+    /// Only populated on the Amazon flavor; required for server-side Amazon RVS
+    /// receipt verification (userId + receiptId). Null on Google Play and Horizon.
+    public var userIdAmazon: String? = nil
+    /// Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+    /// for example "US" or "FR". Only populated on the Amazon flavor.
+    public var userMarketplaceAmazon: String? = nil
 }
 
 public struct PurchaseError: Codable {

--- a/packages/gql/src/generated/types.dart
+++ b/packages/gql/src/generated/types.dart
@@ -2710,6 +2710,8 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
     required this.store,
     required this.transactionDate,
     this.transactionId,
+    this.userIdAmazon,
+    this.userMarketplaceAmazon,
     this.isAlternativeBilling,
   });
 
@@ -2745,6 +2747,13 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
   /// Unix timestamp in milliseconds since January 1, 1970 UTC.
   final double transactionDate;
   final String? transactionId;
+  /// Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+  /// Only populated on the Amazon flavor; required for server-side Amazon RVS
+  /// receipt verification (userId + receiptId). Null on Google Play and Horizon.
+  final String? userIdAmazon;
+  /// Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+  /// for example "US" or "FR". Only populated on the Amazon flavor.
+  final String? userMarketplaceAmazon;
   final bool? isAlternativeBilling;
 
   factory PurchaseAndroid.fromJson(Map<String, dynamic> json) {
@@ -2770,6 +2779,8 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
       store: IapStore.fromJson(json['store'] as String),
       transactionDate: (json['transactionDate'] as num).toDouble(),
       transactionId: json['transactionId'] as String?,
+      userIdAmazon: json['userIdAmazon'] as String?,
+      userMarketplaceAmazon: json['userMarketplaceAmazon'] as String?,
       isAlternativeBilling: json['isAlternativeBilling'] as bool?,
     );
   }
@@ -2799,6 +2810,8 @@ class PurchaseAndroid extends Purchase implements PurchaseCommon {
       'store': store.toJson(),
       'transactionDate': transactionDate,
       'transactionId': transactionId,
+      'userIdAmazon': userIdAmazon,
+      'userMarketplaceAmazon': userMarketplaceAmazon,
       'isAlternativeBilling': isAlternativeBilling,
     };
   }

--- a/packages/gql/src/generated/types.gd
+++ b/packages/gql/src/generated/types.gd
@@ -2059,6 +2059,10 @@ class PurchaseAndroid:
 	var is_suspended_android: Variant = null
 	## Pending purchase update for uncommitted subscription upgrade/downgrade (Android) Contains the new products and purchase token for the pending transaction. Returns null if no pending update exists. Available in Google Play Billing Library 5.0+
 	var pending_purchase_update_android: PendingPurchaseUpdateAndroid
+	## Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()). Only populated on the Amazon flavor; required for server-side Amazon RVS receipt verification (userId + receiptId). Null on Google Play and Horizon.
+	var user_id_amazon: Variant = null
+	## Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()), for example "US" or "FR". Only populated on the Amazon flavor.
+	var user_marketplace_amazon: Variant = null
 
 	static func from_dict(data: Dictionary) -> PurchaseAndroid:
 		var obj = PurchaseAndroid.new()
@@ -2120,6 +2124,10 @@ class PurchaseAndroid:
 				obj.pending_purchase_update_android = PendingPurchaseUpdateAndroid.from_dict(data["pendingPurchaseUpdateAndroid"])
 			else:
 				obj.pending_purchase_update_android = data["pendingPurchaseUpdateAndroid"]
+		if data.has("userIdAmazon") and data["userIdAmazon"] != null:
+			obj.user_id_amazon = data["userIdAmazon"]
+		if data.has("userMarketplaceAmazon") and data["userMarketplaceAmazon"] != null:
+			obj.user_marketplace_amazon = data["userMarketplaceAmazon"]
 		return obj
 
 	func to_dict() -> Dictionary:
@@ -2166,6 +2174,10 @@ class PurchaseAndroid:
 			dict["pendingPurchaseUpdateAndroid"] = pending_purchase_update_android.to_dict()
 		else:
 			dict["pendingPurchaseUpdateAndroid"] = pending_purchase_update_android
+		if user_id_amazon != null:
+			dict["userIdAmazon"] = user_id_amazon
+		if user_marketplace_amazon != null:
+			dict["userMarketplaceAmazon"] = user_marketplace_amazon
 		return dict
 
 class PurchaseError:

--- a/packages/gql/src/generated/types.ts
+++ b/packages/gql/src/generated/types.ts
@@ -1214,6 +1214,17 @@ export interface PurchaseAndroid extends PurchaseCommon {
   /** Unix timestamp in milliseconds since January 1, 1970 UTC. */
   transactionDate: number;
   transactionId?: (string | null);
+  /**
+   * Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+   * Only populated on the Amazon flavor; required for server-side Amazon RVS
+   * receipt verification (userId + receiptId). Null on Google Play and Horizon.
+   */
+  userIdAmazon?: (string | null);
+  /**
+   * Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+   * for example "US" or "FR". Only populated on the Amazon flavor.
+   */
+  userMarketplaceAmazon?: (string | null);
 }
 
 export interface PurchaseCommon {

--- a/packages/gql/src/type-android.graphql
+++ b/packages/gql/src/type-android.graphql
@@ -273,6 +273,17 @@ type PurchaseAndroid implements PurchaseCommon {
   Available in Google Play Billing Library 5.0+
   """
   pendingPurchaseUpdateAndroid: PendingPurchaseUpdateAndroid
+  """
+  Amazon Appstore user id (PurchaseResponse.getUserData().getUserId()).
+  Only populated on the Amazon flavor; required for server-side Amazon RVS
+  receipt verification (userId + receiptId). Null on Google Play and Horizon.
+  """
+  userIdAmazon: String
+  """
+  Amazon Appstore marketplace (PurchaseResponse.getUserData().getMarketplace()),
+  for example "US" or "FR". Only populated on the Amazon flavor.
+  """
+  userMarketplaceAmazon: String
 }
 
 """

--- a/scripts/audit-purchase-payload-parity.mjs
+++ b/scripts/audit-purchase-payload-parity.mjs
@@ -1479,6 +1479,10 @@ function checkReactNativePurchasePayloadContracts() {
           allowedSources.add("purchaseTokenAndroid");
           allowedSources.add("store");
         }
+        if (field === "userIdAmazon" || field === "userMarketplaceAmazon") {
+          // The bridge nulls Amazon identity metadata unless store === amazon.
+          allowedSources.add("store");
+        }
         expectOnlySourceReferences(
           typeScriptMemberReferences(
             expression,


### PR DESCRIPTION

## Problem
On the Amazon flavor, `PurchaseResponse.getUserData()` provides a `userId` and `marketplace`, but they are dropped when mapping to `PurchaseAndroid`. Apps that verify receipts **server-side via Amazon RVS** need `userId` + `receiptId`, so there is currently no supported way to obtain the Amazon `userId` from a purchase. OpenIAP already documents this exact id on `RequestVerifyPurchaseWithIapkitAmazonProps.userId`, but only for the built-in IAPKit verification path.

## Prior art: react-native-iap exposes these fields
For comparison, `react-native-iap` attaches the Amazon user data to **every purchase** it emits, so server-side RVS verification works out of the box. From its Amazon `Receipt.toMap(userData)`:

```kotlin
it.putString("purchaseToken", receiptId)
it.putString("userIdAmazon", userData.userId)
it.putString("userMarketplaceAmazon", userData.marketplace)
```

openiap receives the same `PurchaseResponse.userData` but does not forward `userId`/`marketplace`, so migrating from react-native-iap to openiap loses the ability to verify Amazon receipts on a backend. This PR restores parity.

## Change
- **Schema** (`type-android.graphql`): add nullable `userIdAmazon` and `userMarketplaceAmazon` to `PurchaseAndroid`, documented as Amazon-flavor-only (null on Google Play / Horizon).
- **Amazon mapper** (`OpenIapModule.kt`): cache `userId`/`marketplace` from `onUserDataResponse` (already fetched at init) and populate the new fields in `buildAmazonPurchase` / `toPurchase`.
- **Generated bindings**: regenerated via `bun run generate` (Kotlin, Swift, TS, Dart, C#, GDScript, kmp, expo-iap, react-native-iap).

## Notes
- Additive and non-breaking — both fields nullable, default `null`.
- Field names mirror react-native-iap (`userIdAmazon` / `userMarketplaceAmazon`) for easy migration; happy to adjust to match OpenIAP conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Amazon Appstore user ID and marketplace metadata to Android purchase records.
  * Preserved Amazon purchase details across supported platforms and APIs.
  * Improved Amazon receipt verification using purchaser identity and marketplace information.

* **Documentation**
  * Documented the new Amazon-specific purchase fields and their availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->