### PR TITLE
fix(google): fall back to token for blank horizon order ids

### DIFF
--- a/libraries/react-native-iap/example/android/app/src/main/AndroidManifest.xml
+++ b/libraries/react-native-iap/example/android/app/src/main/AndroidManifest.xml
@@ -12,9 +12,9 @@
       android:supportsRtl="true">
 
       <!-- Horizon OS (Meta Quest) Configuration -->
-      <!-- <meta-data
+      <meta-data
         android:name="com.meta.horizon.platform.HORIZON_APP_ID"
-        android:value="31705015229097839" /> -->
+        android:value="31705015229097839" />
 
       <activity
         android:name=".MainActivity"

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/utils/BillingConverters.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/utils/BillingConverters.kt
@@ -125,13 +125,16 @@ internal object HorizonBillingConverters {
         val token = purchaseToken
         val productsList = products ?: emptyList()
         val state = PurchaseState.fromHorizonState(getPurchaseState())
-
         return PurchaseAndroid(
             autoRenewingAndroid = isAutoRenewing(),
             currentPlanId = basePlanId,
             dataAndroid = originalJson,
             developerPayloadAndroid = developerPayload,
-            id = orderId ?: token,
+            // Horizon reports a present-but-blank orderId (the module already
+            // logs orderIdPresent via isNullOrBlank), so a null-only fallback
+            // produced an empty id/transactionId that the SDKs' strict
+            // purchase decoders reject, failing the whole batch on device.
+            id = orderId?.takeIf { it.isNotBlank() } ?: token,
             ids = productsList,
             isAcknowledgedAndroid = isAcknowledged(),
             isAutoRenewing = isAutoRenewing(),
@@ -145,7 +148,7 @@ internal object HorizonBillingConverters {
             signatureAndroid = signature,
             store = IapStore.Horizon,
             transactionDate = (purchaseTime ?: 0L).toDouble(),
-            transactionId = orderId ?: token
+            transactionId = orderId?.takeIf { it.isNotBlank() } ?: token
         )
     }
 
@@ -158,7 +161,8 @@ internal object HorizonBillingConverters {
         purchaseToken = purchaseToken,
         purchaseTokenAndroid = purchaseToken,
         transactionDate = (purchaseTime ?: 0L).toDouble(),
-        transactionId = orderId ?: purchaseToken
+        // Same blank-orderId fallback as toPurchase above.
+        transactionId = orderId?.takeIf { it.isNotBlank() } ?: purchaseToken
     )
 
     fun PurchaseAndroid.toActiveSubscription(): ActiveSubscription = ActiveSubscription(

--- a/packages/google/openiap/src/testHorizon/java/dev/hyo/openiap/HorizonBlankOrderIdTest.kt
+++ b/packages/google/openiap/src/testHorizon/java/dev/hyo/openiap/HorizonBlankOrderIdTest.kt
@@ -1,0 +1,62 @@
+package dev.hyo.openiap
+
+import com.meta.horizon.billingclient.api.Purchase as HorizonPurchase
+import dev.hyo.openiap.utils.HorizonBillingConverters
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The Horizon billing-compatibility `Purchase.orderId` is a non-null String
+ * and arrives blank on device, so a null-only `orderId ?: token` fallback
+ * produced an empty `id`/`transactionId`. The SDKs' strict purchase decoders
+ * reject an empty id, which failed the whole available-purchases batch on a
+ * Quest 3 with real store data. These tests pin the blank-aware fallback.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [29])
+class HorizonBlankOrderIdTest {
+
+    private fun horizonPurchase(orderId: String): HorizonPurchase = HorizonPurchase(
+        5L,
+        "purchase-token",
+        listOf("product-id"),
+        "dev.hyo.openiap.test",
+        "",
+        orderId,
+        """{"purchaseState":0,"acknowledged":false,"autoRenewing":false}""",
+        1,
+        "signature",
+    )
+
+    @Test
+    fun `blank orderId falls back to the purchase token for id and transactionId`() {
+        val purchase = with(HorizonBillingConverters) {
+            horizonPurchase(orderId = "").toPurchase()
+        }
+
+        assertEquals("purchase-token", purchase.id)
+        assertEquals("purchase-token", purchase.transactionId)
+    }
+
+    @Test
+    fun `present orderId is preserved for id and transactionId`() {
+        val purchase = with(HorizonBillingConverters) {
+            horizonPurchase(orderId = "order-1").toPurchase()
+        }
+
+        assertEquals("order-1", purchase.id)
+        assertEquals("order-1", purchase.transactionId)
+    }
+
+    @Test
+    fun `blank orderId falls back to the purchase token for active subscriptions`() {
+        val subscription = with(HorizonBillingConverters) {
+            horizonPurchase(orderId = "").toActiveSubscription()
+        }
+
+        assertEquals("purchase-token", subscription.transactionId)
+    }
+}

--- a/scripts/audit-purchase-payload-parity.mjs
+++ b/scripts/audit-purchase-payload-parity.mjs
@@ -1835,7 +1835,8 @@ function checkGooglePurchasePayloadContracts() {
         productId: /^productsList\.firstOrNull\(\)\.orEmpty\(\)$/,
         purchaseToken: /^token$/,
         signatureAndroid: /^signature$/,
-        transactionId: /^orderId \?: token$/,
+        transactionId:
+          /^orderId\?\.takeIf \{ it\.isNotBlank\(\) \} \?: token$/,
       },
       intentionallyDefaultedFields: [
         "isSuspendedAndroid",


### PR DESCRIPTION
Found by running the Horizon device row that #276 reported as blocked — and it
is exactly the class of bug #276's strict decoders exist to catch.

## The bug

The Horizon billing-compatibility `Purchase.orderId` is a **non-null String**
(confirmed from the class file) and arrives **blank** on device, so the
converter's null-only `orderId ?: token` fallback never fired. Every Horizon
purchase reached the SDKs with an empty `id`/`transactionId`, and the strict
purchase decoders correctly rejected the whole batch:

```
getAvailablePurchases result: purchaseCount=2
NitroPurchase has invalid required field: id
PurchaseError: billing-response-json-parse-error
```

Under the pre-#276 lossy decoders this would have silently dropped or shipped
malformed purchases; now it failed loudly and pointed at the defective bridge.

## The fix

Blank-aware fallbacks in the Horizon converters — `toPurchase` (`id`,
`transactionId`) and `toActiveSubscription` (`transactionId`) — pinned by
regression tests that build the Meta `Purchase` with a blank and a present
`orderId`. The payload-parity audit's pinned source expression for the Horizon
`transactionId` is updated to the new canonical form (it rejected the first
draft of this change, which is that audit working as intended).

Also enables the commented-out `HORIZON_APP_ID` meta-data in the React Native
example manifest: without it the Horizon platform SDK cannot initialize, so
`initConnection` failed before any store call and the example was not runnable
on the device at all. The meta-data is inert on Play and FireOS builds.

## Device verification (Quest 3, real Horizon store data)

| Step | Before | After |
| --- | --- | --- |
| `initConnection` | fails (no App ID) | `true` |
| `getAvailablePurchases` | batch rejected at index 0 | **4 purchases decoded** |
| `getActiveSubscriptions` | — | **2 active subscriptions** |

With this, every store in the matrix has now decoded real payloads through the
strict pipeline on hardware: Play, App Store, Amazon, Vega runtime, and
Horizon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Horizon purchase handling when order IDs are blank by reliably using the purchase token instead.
  - Ensured purchase and active subscription transaction identifiers remain consistent and usable.
  - Enabled the required Horizon OS application metadata for Android builds.

- **Tests**
  - Added coverage for Horizon purchases and subscriptions with blank, missing, and populated order IDs.
  - Added validation to help maintain consistent purchase payloads across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->