### PR TITLE
fix: route MCP sessions to their owning Fly machine and 404 lost sessions

### DIFF
--- a/.github/workflows/deploy-kit.yml
+++ b/.github/workflows/deploy-kit.yml
@@ -9,12 +9,17 @@ on:
     branches: [main]
     paths:
       - "packages/kit/**"
+      # kit.openiap.dev/mcp is served by kit's Fly binary importing
+      # @hyodotdev/openiap-mcp-server/web straight from source, so an
+      # MCP-server change must redeploy kit or it never ships (issue #287).
+      - "packages/mcp-server/**"
       - ".github/workflows/deploy-kit.yml"
       - "bun.lock"
       - "package.json"
   pull_request:
     paths:
       - "packages/kit/**"
+      - "packages/mcp-server/**"
       - ".github/workflows/deploy-kit.yml"
       - "bun.lock"
       - "package.json"
@@ -55,6 +60,15 @@ jobs:
 
       - name: Run tests (convex + server unit tests)
         run: bun run test
+
+      - name: Lint + test MCP server (served by kit's /mcp route)
+        # kit's Fly binary imports @hyodotdev/openiap-mcp-server/web from
+        # source, so its regressions ship with kit deploys. This workflow
+        # is the only CI that runs the MCP server's own suite.
+        working-directory: packages/mcp-server
+        run: |
+          bun run lint
+          bun run test
 
       - name: Vite build
         env:

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -21,6 +21,11 @@ import {
   IAPKIT_MCP_SERVER_NAME,
   IAPKIT_MCP_SERVER_VERSION,
 } from "./mcp.js";
+import {
+  buildSessionId,
+  currentMachineId,
+  routeUnknownSession,
+} from "./session-routing.js";
 
 const DEFAULT_MCP_PATH = "/mcp";
 const DEFAULT_PORT = 3939;
@@ -48,6 +53,13 @@ export interface RemoteMcpHttpServerOptions {
   allowedOrigins?: string[];
   /** Logger for lifecycle and request failures. Defaults to console. */
   logger?: Pick<Console, "error" | "info">;
+  /**
+   * Identity of this process for session affinity. Defaults to
+   * FLY_MACHINE_ID; session ids are prefixed with it so a follow-up
+   * request landing on a sibling machine can be replayed to the owner
+   * (GitHub issue #287). Undefined disables replay routing.
+   */
+  machineId?: string;
 }
 
 /** Runtime handle for an IAPKit remote MCP HTTP server. */
@@ -72,6 +84,7 @@ export function createRemoteMcpHttpServer(
   const allowedOrigins =
     options.allowedOrigins ??
     parseAllowedOrigins(process.env.IAPKIT_MCP_ALLOWED_ORIGINS);
+  const machineId = options.machineId ?? currentMachineId();
   const transports = new Map<string, StreamableHTTPServerTransport>();
 
   const server = createServer(async (req, res) => {
@@ -134,12 +147,13 @@ export function createRemoteMcpHttpServer(
           res,
           transports,
           logger,
+          machineId,
         );
         return;
       }
 
       if (req.method === "GET" || req.method === "DELETE") {
-        await handleExistingMcpSession(req, res, transports);
+        await handleExistingMcpSession(req, res, transports, machineId);
         return;
       }
 
@@ -223,6 +237,7 @@ async function handleMcpPost(
   res: ServerResponse,
   transports: Map<string, StreamableHTTPServerTransport>,
   logger: Pick<Console, "error" | "info">,
+  machineId: string | undefined,
 ): Promise<void> {
   const sessionId = headerString(req.headers["mcp-session-id"]);
   const body = await readJsonBody(req);
@@ -233,7 +248,12 @@ async function handleMcpPost(
     return;
   }
 
-  if (sessionId || !isInitializeRequest(body)) {
+  if (sessionId) {
+    writeUnknownSessionResponse(req, res, sessionId, machineId);
+    return;
+  }
+
+  if (!isInitializeRequest(body)) {
     writeJsonRpcError(
       res,
       400,
@@ -245,7 +265,7 @@ async function handleMcpPost(
 
   let transport!: StreamableHTTPServerTransport;
   transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
+    sessionIdGenerator: () => buildSessionId(machineId, randomUUID()),
     onsessioninitialized: (initializedSessionId) => {
       transports.set(initializedSessionId, transport);
       logger.info(`IAPKit MCP session initialized: ${initializedSessionId}`);
@@ -269,16 +289,58 @@ async function handleExistingMcpSession(
   req: IncomingMessage,
   res: ServerResponse,
   transports: Map<string, StreamableHTTPServerTransport>,
+  machineId: string | undefined,
 ): Promise<void> {
   const sessionId = headerString(req.headers["mcp-session-id"]);
   const transport = sessionId ? transports.get(sessionId) : undefined;
 
   if (!transport) {
+    if (sessionId) {
+      writeUnknownSessionResponse(req, res, sessionId, machineId);
+      return;
+    }
     writeJsonRpcError(res, 400, -32000, "Invalid or missing mcp-session-id");
     return;
   }
 
   await transport.handleRequest(req as AuthenticatedRequest, res);
+}
+
+/**
+ * Answers a request whose session id isn't in this process's transport
+ * map: replay it to the machine that minted the id when possible,
+ * otherwise 404 so a spec-compliant client transparently re-initializes.
+ * (The previous 400 "initialize first" reply broke that recovery path —
+ * GitHub issue #287.)
+ */
+function writeUnknownSessionResponse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  sessionId: string,
+  machineId: string | undefined,
+): void {
+  const routing = routeUnknownSession({
+    sessionId,
+    machineId,
+    alreadyReplayed: req.headers["fly-replay-src"] !== undefined,
+  });
+
+  if (routing.action === "replay") {
+    // Fly's proxy intercepts any response carrying `fly-replay` and
+    // re-sends the original request to the named machine; the client
+    // never sees this interim response.
+    res
+      .writeHead(204, { "fly-replay": `instance=${routing.targetMachineId}` })
+      .end();
+    return;
+  }
+
+  writeJsonRpcError(
+    res,
+    404,
+    -32001,
+    "Session not found — initialize a new MCP session.",
+  );
 }
 
 function attachAuthInfo(req: AuthenticatedRequest): void {

--- a/packages/mcp-server/src/session-routing.ts
+++ b/packages/mcp-server/src/session-routing.ts
@@ -1,0 +1,73 @@
+// MCP session ids are held in per-process memory (the transport object
+// itself is stateful — an SSE stream can't be serialized into a shared
+// store), so a session created on one Fly machine is invisible to its
+// siblings. Fix (GitHub issue #287): embed the creating machine's id in
+// the session id, and when a request lands on the wrong machine, answer
+// with a `fly-replay` header so Fly's proxy re-routes the original
+// request to the owner. Off Fly (no FLY_MACHINE_ID) session ids stay
+// plain UUIDs and routing always resolves to `not-found`.
+
+/**
+ * Fly machine ids are lowercase hex today, but only shape-check them:
+ * the prefix is attacker-controlled (it arrives inside the client's
+ * `mcp-session-id` header), so the pattern also guards the value we
+ * echo back inside the `fly-replay` response header.
+ */
+const MACHINE_ID_PATTERN = /^[A-Za-z0-9]{1,32}$/;
+
+const SESSION_MACHINE_SEPARATOR = ".";
+
+/** Reads the Fly machine identity, or undefined when not running on Fly. */
+export function currentMachineId(
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const raw = env.FLY_MACHINE_ID;
+  return raw && MACHINE_ID_PATTERN.test(raw) ? raw : undefined;
+}
+
+/** Builds a session id that carries the creating machine's identity. */
+export function buildSessionId(
+  machineId: string | undefined,
+  uuid: string,
+): string {
+  return machineId ? `${machineId}${SESSION_MACHINE_SEPARATOR}${uuid}` : uuid;
+}
+
+/** Routing decision for a session id this process doesn't recognize. */
+export type UnknownSessionRouting =
+  | { action: "replay"; targetMachineId: string }
+  | { action: "not-found" };
+
+/**
+ * Decides what to do with a session id that isn't in the local
+ * transport map.
+ *
+ * @param options.sessionId Session id from the `mcp-session-id` header.
+ * @param options.machineId This process's machine id (undefined off Fly).
+ * @param options.alreadyReplayed True when the request carries
+ *   `fly-replay-src`, i.e. it was already replayed once — never replay
+ *   again or two stale machines could bounce a request forever.
+ * @returns `replay` toward the owning machine, or `not-found` (the
+ *   caller answers 404 so the client re-initializes per the MCP spec).
+ */
+export function routeUnknownSession(options: {
+  sessionId: string;
+  machineId: string | undefined;
+  alreadyReplayed: boolean;
+}): UnknownSessionRouting {
+  if (!options.machineId || options.alreadyReplayed) {
+    return { action: "not-found" };
+  }
+
+  const separatorIndex = options.sessionId.indexOf(SESSION_MACHINE_SEPARATOR);
+  if (separatorIndex <= 0) return { action: "not-found" };
+
+  const prefix = options.sessionId.slice(0, separatorIndex);
+  if (!MACHINE_ID_PATTERN.test(prefix) || prefix === options.machineId) {
+    // Malformed prefix, or the session was minted by this very machine
+    // (map lost to a restart/deploy) — replaying to ourselves would loop.
+    return { action: "not-found" };
+  }
+
+  return { action: "replay", targetMachineId: prefix };
+}

--- a/packages/mcp-server/src/web.ts
+++ b/packages/mcp-server/src/web.ts
@@ -9,6 +9,11 @@ import {
   isPublishableApiKey,
 } from "./auth.js";
 import { createIapKitMcpServer } from "./mcp.js";
+import {
+  buildSessionId,
+  currentMachineId,
+  routeUnknownSession,
+} from "./session-routing.js";
 
 const MAX_MCP_BODY_BYTES = 1024 * 1024;
 const MCP_BODY_TOO_LARGE_ERROR = "MCP request body is too large";
@@ -24,6 +29,13 @@ const DEFAULT_ALLOWED_ORIGINS = [
 export interface IapKitWebMcpHandlerOptions {
   allowedOrigins?: string[];
   logger?: Pick<Console, "error" | "info">;
+  /**
+   * Identity of this process for session affinity. Defaults to
+   * FLY_MACHINE_ID; session ids are prefixed with it so a follow-up
+   * request landing on a sibling machine can be replayed to the owner
+   * (GitHub issue #287). Undefined disables replay routing.
+   */
+  machineId?: string;
 }
 
 export function createIapKitWebMcpHandler(
@@ -33,6 +45,7 @@ export function createIapKitWebMcpHandler(
   const allowedOrigins =
     options.allowedOrigins ??
     parseAllowedOrigins(process.env.IAPKIT_MCP_ALLOWED_ORIGINS);
+  const machineId = options.machineId ?? currentMachineId();
   const transports = new Map<
     string,
     WebStandardStreamableHTTPServerTransport
@@ -69,6 +82,7 @@ export function createIapKitWebMcpHandler(
           transports,
           logger,
           authInfo,
+          machineId,
         );
         return withCors(request, response, allowedOrigins);
       }
@@ -78,6 +92,7 @@ export function createIapKitWebMcpHandler(
           request,
           transports,
           authInfo,
+          machineId,
         );
         return withCors(request, response, allowedOrigins);
       }
@@ -117,6 +132,7 @@ async function handlePost(
   transports: Map<string, WebStandardStreamableHTTPServerTransport>,
   logger: Pick<Console, "error" | "info">,
   authInfo: AuthInfo | undefined,
+  machineId: string | undefined,
 ): Promise<Response> {
   const sessionId = request.headers.get("mcp-session-id") ?? undefined;
   const body = await readJsonBody(request);
@@ -129,7 +145,11 @@ async function handlePost(
     });
   }
 
-  if (sessionId || !isInitializeRequest(body)) {
+  if (sessionId) {
+    return unknownSessionResponse(request, sessionId, machineId);
+  }
+
+  if (!isInitializeRequest(body)) {
     return jsonRpcError(
       400,
       -32000,
@@ -139,7 +159,7 @@ async function handlePost(
 
   let transport!: WebStandardStreamableHTTPServerTransport;
   transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
+    sessionIdGenerator: () => buildSessionId(machineId, randomUUID()),
     onsessioninitialized: (initializedSessionId) => {
       transports.set(initializedSessionId, transport);
       logger.info(`IAPKit MCP session initialized: ${initializedSessionId}`);
@@ -167,15 +187,54 @@ async function handleExistingSession(
   request: Request,
   transports: Map<string, WebStandardStreamableHTTPServerTransport>,
   authInfo: AuthInfo | undefined,
+  machineId: string | undefined,
 ): Promise<Response> {
   const sessionId = request.headers.get("mcp-session-id") ?? undefined;
   const transport = sessionId ? transports.get(sessionId) : undefined;
 
   if (!transport) {
+    if (sessionId) {
+      return unknownSessionResponse(request, sessionId, machineId);
+    }
     return jsonRpcError(400, -32000, "Invalid or missing mcp-session-id");
   }
 
   return transport.handleRequest(request, { authInfo });
+}
+
+/**
+ * Answers a request whose session id isn't in this process's transport
+ * map: replay it to the machine that minted the id when possible,
+ * otherwise 404 so a spec-compliant client transparently re-initializes.
+ * (The previous 400 "initialize first" reply broke that recovery path —
+ * GitHub issue #287.)
+ */
+function unknownSessionResponse(
+  request: Request,
+  sessionId: string,
+  machineId: string | undefined,
+): Response {
+  const routing = routeUnknownSession({
+    sessionId,
+    machineId,
+    alreadyReplayed: request.headers.has("fly-replay-src"),
+  });
+
+  if (routing.action === "replay") {
+    // Fly's proxy intercepts any response carrying `fly-replay` and
+    // re-sends the original request to the named machine; the client
+    // never sees this interim response.
+    return new Response(null, {
+      status: 204,
+      headers: { "fly-replay": `instance=${routing.targetMachineId}` },
+    });
+  }
+
+  return jsonRpcError(
+    404,
+    -32001,
+    "Session not found — initialize a new MCP session.",
+  );
 }
 
 function authInfoFromRequest(request: Request): AuthInfo | undefined {

--- a/packages/mcp-server/test/http.test.ts
+++ b/packages/mcp-server/test/http.test.ts
@@ -599,6 +599,54 @@ describe("remote MCP HTTP server", () => {
     expect(payload.info).toContain("/v1/webhooks/{publishableKey}");
   });
 
+  it("replays foreign-machine sessions and 404s unrecoverable ones (issue #287)", async () => {
+    const baseUrl = await startServer({ machineId: "self42" });
+
+    const init = await postMcp(baseUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "vitest", version: "0.0.0" },
+      },
+    });
+    expect(init.headers.get("mcp-session-id")).toMatch(
+      /^self42\.[0-9a-f-]{36}$/,
+    );
+    await init.text();
+
+    const foreign = await postMcp(
+      baseUrl,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      "other77.7e33e2b1-9a45-4c8e-b1de-000000000000",
+    );
+    expect(foreign.status).toBe(204);
+    expect(foreign.headers.get("fly-replay")).toBe("instance=other77");
+
+    const replayed = await postMcp(
+      baseUrl,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      "other77.7e33e2b1-9a45-4c8e-b1de-000000000000",
+      { "fly-replay-src": "instance=other77;state=;t=1754400000000000" },
+    );
+    expect(replayed.status).toBe(404);
+    await expect(replayed.json()).resolves.toMatchObject({
+      error: {
+        code: -32001,
+        message: "Session not found — initialize a new MCP session.",
+      },
+    });
+
+    const lostOwn = await postMcp(
+      baseUrl,
+      { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+      "self42.7e33e2b1-9a45-4c8e-b1de-000000000000",
+    );
+    expect(lostOwn.status).toBe(404);
+  });
+
   it("returns client errors for invalid JSON and oversized payloads", async () => {
     const baseUrl = await startServer();
 
@@ -722,12 +770,13 @@ describe("remote MCP HTTP server", () => {
   });
 });
 
-async function startServer(): Promise<string> {
+async function startServer(options?: { machineId?: string }): Promise<string> {
   remote = createRemoteMcpHttpServer({
     logger: {
       error: () => undefined,
       info: () => undefined,
     },
+    ...options,
   });
 
   await new Promise<void>((resolve) => {

--- a/packages/mcp-server/test/session-routing.test.ts
+++ b/packages/mcp-server/test/session-routing.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSessionId,
+  currentMachineId,
+  routeUnknownSession,
+} from "../src/session-routing";
+
+describe("currentMachineId", () => {
+  it("reads a well-formed FLY_MACHINE_ID", () => {
+    expect(currentMachineId({ FLY_MACHINE_ID: "17811953c25489" })).toBe(
+      "17811953c25489",
+    );
+  });
+
+  it("returns undefined off Fly or for malformed ids", () => {
+    expect(currentMachineId({})).toBeUndefined();
+    expect(currentMachineId({ FLY_MACHINE_ID: "" })).toBeUndefined();
+    expect(currentMachineId({ FLY_MACHINE_ID: "bad.value" })).toBeUndefined();
+    expect(currentMachineId({ FLY_MACHINE_ID: "a".repeat(33) })).toBeUndefined();
+  });
+});
+
+describe("buildSessionId", () => {
+  it("prefixes the machine id when present", () => {
+    expect(buildSessionId("m1", "uuid-1")).toBe("m1.uuid-1");
+  });
+
+  it("returns the bare uuid off Fly", () => {
+    expect(buildSessionId(undefined, "uuid-1")).toBe("uuid-1");
+  });
+});
+
+describe("routeUnknownSession", () => {
+  it("replays to the machine that minted the session id", () => {
+    expect(
+      routeUnknownSession({
+        sessionId: "other77.uuid-1",
+        machineId: "self42",
+        alreadyReplayed: false,
+      }),
+    ).toEqual({ action: "replay", targetMachineId: "other77" });
+  });
+
+  it("never replays a request that was already replayed once", () => {
+    expect(
+      routeUnknownSession({
+        sessionId: "other77.uuid-1",
+        machineId: "self42",
+        alreadyReplayed: true,
+      }),
+    ).toEqual({ action: "not-found" });
+  });
+
+  it("never replays to itself (map lost to a restart)", () => {
+    expect(
+      routeUnknownSession({
+        sessionId: "self42.uuid-1",
+        machineId: "self42",
+        alreadyReplayed: false,
+      }),
+    ).toEqual({ action: "not-found" });
+  });
+
+  it("does not replay off Fly", () => {
+    expect(
+      routeUnknownSession({
+        sessionId: "other77.uuid-1",
+        machineId: undefined,
+        alreadyReplayed: false,
+      }),
+    ).toEqual({ action: "not-found" });
+  });
+
+  it("rejects unprefixed or malformed session ids", () => {
+    for (const sessionId of [
+      "plain-uuid-without-prefix",
+      ".uuid-1",
+      "bad prefix.uuid-1",
+      `${"a".repeat(33)}.uuid-1`,
+      "inject=1\r\n.uuid-1",
+    ]) {
+      expect(
+        routeUnknownSession({
+          sessionId,
+          machineId: "self42",
+          alreadyReplayed: false,
+        }),
+      ).toEqual({ action: "not-found" });
+    }
+  });
+});

--- a/packages/mcp-server/test/web.test.ts
+++ b/packages/mcp-server/test/web.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import { createIapKitWebMcpHandler } from "../src/web";
+
+// Regression suite for GitHub issue #287: the hosted /mcp endpoint kept
+// per-process session state, so a valid mcp-session-id landing on a
+// sibling Fly machine was rejected with 400 "initialize first". The web
+// handler must instead (a) mint machine-prefixed session ids, (b) replay
+// foreign-machine sessions via `fly-replay`, and (c) answer 404 (not
+// 400) for sessions it genuinely cannot serve so spec-compliant clients
+// transparently re-initialize.
+
+const silentLogger = { error: () => undefined, info: () => undefined };
+
+function createHandler(machineId?: string) {
+  return createIapKitWebMcpHandler({ logger: silentLogger, machineId });
+}
+
+function initializeRequest(sessionId?: string): Request {
+  return mcpRequest(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "vitest", version: "0.0.0" },
+      },
+    },
+    sessionId,
+  );
+}
+
+function toolsListRequest(
+  sessionId: string,
+  headers: Record<string, string> = {},
+): Request {
+  return mcpRequest(
+    { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    sessionId,
+    headers,
+  );
+}
+
+function mcpRequest(
+  body: unknown,
+  sessionId?: string,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("web MCP handler session routing", () => {
+  it("prefixes session ids with the machine id on Fly", async () => {
+    const handler = createHandler("self42");
+    const response = await handler(initializeRequest());
+
+    expect(response.status).toBe(200);
+    const sessionId = response.headers.get("mcp-session-id");
+    expect(sessionId).toMatch(/^self42\.[0-9a-f-]{36}$/);
+  });
+
+  it("keeps bare-UUID session ids off Fly", async () => {
+    const handler = createHandler(undefined);
+    const response = await handler(initializeRequest());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("mcp-session-id")).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("serves follow-up requests on a session it owns", async () => {
+    const handler = createHandler("self42");
+    const init = await handler(initializeRequest());
+    const sessionId = init.headers.get("mcp-session-id") ?? "";
+    await init.text();
+
+    const list = await handler(toolsListRequest(sessionId));
+    expect(list.status).toBe(200);
+  });
+
+  it("replays a foreign machine's session via fly-replay", async () => {
+    const handler = createHandler("self42");
+    const response = await handler(
+      toolsListRequest("other77.7e33e2b1-9a45-4c8e-b1de-000000000000"),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("fly-replay")).toBe("instance=other77");
+  });
+
+  it("returns 404 instead of replaying twice", async () => {
+    const handler = createHandler("self42");
+    const response = await handler(
+      toolsListRequest("other77.7e33e2b1-9a45-4c8e-b1de-000000000000", {
+        "fly-replay-src": "instance=other77;state=;t=1754400000000000",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: -32001,
+        message: "Session not found — initialize a new MCP session.",
+      },
+    });
+  });
+
+  it("returns 404 for its own session id after a restart wiped the map", async () => {
+    const handler = createHandler("self42");
+    const response = await handler(
+      toolsListRequest("self42.7e33e2b1-9a45-4c8e-b1de-000000000000"),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for unknown sessions off Fly", async () => {
+    const handler = createHandler(undefined);
+    const response = await handler(
+      toolsListRequest("7e33e2b1-9a45-4c8e-b1de-000000000000"),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: -32001 },
+    });
+  });
+
+  it("routes GET and DELETE for foreign sessions the same way", async () => {
+    const handler = createHandler("self42");
+
+    for (const method of ["GET", "DELETE"] as const) {
+      const response = await handler(
+        new Request("http://localhost/mcp", {
+          method,
+          headers: {
+            accept: "application/json, text/event-stream",
+            "mcp-session-id": "other77.7e33e2b1-9a45-4c8e-b1de-000000000000",
+          },
+        }),
+      );
+      expect(response.status).toBe(204);
+      expect(response.headers.get("fly-replay")).toBe("instance=other77");
+    }
+  });
+
+  it("still 400s a POST that has no session and is not initialize", async () => {
+    const handler = createHandler("self42");
+    const response = await handler(
+      mcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: -32000,
+        message:
+          "Bad Request: initialize first, then send mcp-session-id on follow-up requests.",
+      },
+    });
+  });
+
+  it("still 400s GET/DELETE without any session id", async () => {
+    const handler = createHandler("self42");
+    const response = await handler(
+      new Request("http://localhost/mcp", {
+        method: "DELETE",
+        headers: { accept: "application/json, text/event-stream" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #287 — `kit.openiap.dev/mcp` intermittently rejected a valid, freshly issued `mcp-session-id` with `400 "initialize first"` (13/20 failures in the issue repro).

**Root cause (verified):** `createIapKitWebMcpHandler` keeps StreamableHTTP transports in a per-process `Map` ([web.ts](packages/mcp-server/src/web.ts)). `fly.toml` sets `min_machines_running = 1`, which is a floor, not a cap — with N machines round-robining behind the Fly proxy, only the machine that served `initialize` recognizes the session. A ~35% success rate matches N=3 exactly. The SDK registers the session **before** the initialize response is sent, and no code path evicts sessions, so instance split-brain is the only mechanism consistent with the interleaved 200/400 pattern.

## Fix

1. **Machine-affinity session ids** — session ids are minted as `<FLY_MACHINE_ID>.<uuid>`. A request for a session owned by a sibling machine is answered with a `fly-replay: instance=<id>` header, so Fly's proxy re-sends the original request to the owner. No shared store or infra change; a live SSE transport can't be serialized into Redis anyway.
   - Loop-safe: never replays a request that already carries `fly-replay-src`, never replays to itself, and validates the attacker-controlled prefix (`^[A-Za-z0-9]{1,32}$`) before echoing it into a response header.
   - Off Fly (no `FLY_MACHINE_ID`), ids stay plain UUIDs and behavior is unchanged.
2. **404 instead of 400 for lost sessions** — per the MCP spec, clients transparently re-initialize on 404 (`-32001 Session not found`). The old 400 broke that recovery path, which is why clients hard-failed instead of self-healing after machine restarts/deploys.
3. **Deploy-coupling fix** — `deploy-kit.yml` did not trigger on `packages/mcp-server/**`, yet kit's Fly binary imports the MCP handler from source. An MCP-only fix would merge and silently never ship. Paths added, and the verify job now also runs the MCP server's own vitest suite (previously it ran in no CI at all).

Both entry points are covered: the production web handler (`web.ts`, mounted by kit's Hono server) and the standalone Node server (`http.ts`).

## Tests

- `packages/mcp-server`: 44 tests pass (`bun run lint` + `bun run test`) — new suites for the routing rules and for the web handler end-to-end (prefixed ids, replay, replay-once guard, self-restart 404, off-Fly 404, GET/DELETE parity, unchanged 400s for missing-session requests).
- `packages/kit`: 913 tests pass (kit mounts this handler in `server/mcp.ts`).

## Post-merge verification

After deploy, rerun the issue's repro (20× `tools/list` on one session) — expect 20/20, with cross-machine hops served via replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved MCP session reliability across multiple machines by routing requests to the machine that created the session.
  * Added automatic session affinity and recovery for requests involving remote sessions.
  * Added clearer handling for unavailable or invalid sessions, including appropriate 404 and 400 responses.

* **Bug Fixes**
  * Prevented session replay loops and inconsistent behavior across POST, GET, and DELETE requests.

* **Tests**
  * Expanded coverage for local, remote, invalid, and unavailable session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->