### PR TITLE
fix: align Expo release with Swift 6.2

### DIFF
--- a/.github/workflows/release-expo.yml
+++ b/.github/workflows/release-expo.yml
@@ -103,10 +103,12 @@ jobs:
 
   validate-ios:
     needs: [release-branch]
-    runs-on: macos-15
+    # Expo SDK 57's expo-modules-jsi package declares Swift tools 6.2.
+    # Xcode 16.4 only ships Swift 6.1 and cannot resolve that manifest.
+    runs-on: macos-26
     timeout-minutes: 60
     env:
-      XCODE_VERSION: 16.4
+      XCODE_VERSION: "26.6"
     defaults:
       run:
         working-directory: libraries/expo-iap

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -5140,6 +5140,22 @@ function checkFrameworkDependencyHygiene() {
     );
   }
   expectIncludes(
+    ".github/workflows/release-expo.yml",
+    [
+      "Expo SDK 57's expo-modules-jsi package declares Swift tools 6.2",
+      "runs-on: macos-26",
+      'XCODE_VERSION: "26.6"',
+      "maxim-lobanov/setup-xcode@v1",
+      "xcode-version: ${{ env.XCODE_VERSION }}",
+    ],
+    "Expo release must use an Xcode version that can parse Expo SDK 57 Swift 6.2 manifests",
+  );
+  expectNotIncludes(
+    ".github/workflows/release-expo.yml",
+    ["XCODE_VERSION: 16.4"],
+    "Expo release must not regress to Xcode 16.4 and Swift 6.1",
+  );
+  expectIncludes(
     ".github/workflows/ci-maui-iap.yml",
     [
       "app-store-artifact:",


### PR DESCRIPTION
## Summary
- run Expo release iOS validation on macOS 26 with Xcode 26.6
- document the Expo SDK 57 / Swift tools 6.2 requirement
- add a parity guard that prevents regression to Xcode 16.4 / Swift 6.1

## Context
Expo release run 31261791286 passed Android validation but failed iOS while resolving `expo-modules-jsi@57.0.4`: its Apple package declares Swift tools 6.2, while Xcode 16.4 only supplies Swift 6.1. The regular Expo PR CI already validates on a newer Xcode lane.

## Verification
- `node --test scripts/release-branch-policy.test.mjs` (21/21)
- `bun run audit:parity`
- `bun run audit:release-state`
- Expo prebuild and CocoaPods install with Xcode 26.6
- `xcodebuild build` for `ExpoIAPExample` on an iOS Simulator destination with Xcode 26.6