### PR TITLE
fix: harden dependency release CI

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -163,6 +163,19 @@ Use this gate whenever a release train upgrades package or framework
 dependencies. Treat the whole train as one validation loop rather than a set of
 independent version edits:
 
+- Use one dependency-modernization PR for the entire train. Keep dependency
+  upgrades, deprecation migrations, shared guards, and fixes found before merge
+  in that PR; do not split PRs by package, platform, or CI symptom.
+- Before merging that PR, preflight every affected release workflow together,
+  including repository-root path assumptions, runner/toolchain compatibility,
+  registry authentication and provenance, immutable tag recovery, and public
+  registry verification.
+- If an actual stable release from `main` exposes a previously unknowable CI
+  problem, pause the train and inspect all remaining release workflows before
+  writing a fix. Group every confirmed train-wide repair into one recovery PR;
+  never open one recovery PR per failed package. Add later findings to the
+  existing mutable recovery PR when one exists.
+
 1. Inventory every affected package's direct dependencies, build plugins,
    language/toolchain versions, lockfiles, and example-app dependencies. Compare
    them with authoritative upstream release and compatibility documentation.

--- a/.codex/skills/openiap-workflows/SKILL.md
+++ b/.codex/skills/openiap-workflows/SKILL.md
@@ -79,6 +79,11 @@ appropriate labels before merging.
 - For GraphQL schema/API changes, follow the SDK Parity Checklist in
   `knowledge/internal/04-platform-packages.md`.
 - Run the package-specific verification commands for touched paths.
+- For dependency modernization release trains, keep the entire train in one PR
+  and follow `.claude/commands/release.md` for the all-workflow preflight. If a
+  post-merge stable release reveals a CI-only blocker, pause the train, inspect
+  all remaining workflows, and group confirmed repairs into one recovery PR;
+  never create package-by-package or symptom-by-symptom recovery PRs.
 - For Android package work, compile Play, Horizon, and Amazon variants when relevant.
 - For docs/API/type docs changes, run `bun audit:docs` or the documented audit
   command before pushing.

--- a/.github/workflows/release-expo.yml
+++ b/.github/workflows/release-expo.yml
@@ -632,14 +632,16 @@ jobs:
         run: |
           RELEASE_TAG="expo-iap-$VERSION"
           VERIFIED=false
-          for attempt in {1..12}; do
+          # npm can expose package metadata before its attestation endpoint is
+          # ready. Allow five minutes for the immutable provenance to propagate.
+          for attempt in {1..30}; do
             if node "$GITHUB_WORKSPACE/scripts/verify-npm-release-provenance.mjs" \
               expo-iap "$VERSION" "$GITHUB_SHA" "$RELEASE_TAG" \
               release-expo.yml; then
               VERIFIED=true
               break
             fi
-            sleep 5
+            sleep 10
           done
           if [ "$VERIFIED" != "true" ]; then
             echo "::error::Published npm provenance did not become verifiable"

--- a/.github/workflows/release-react-native.yml
+++ b/.github/workflows/release-react-native.yml
@@ -633,14 +633,16 @@ jobs:
         run: |
           RELEASE_TAG="react-native-iap-$VERSION"
           VERIFIED=false
-          for attempt in {1..12}; do
+          # npm can expose package metadata before its attestation endpoint is
+          # ready. Allow five minutes for the immutable provenance to propagate.
+          for attempt in {1..30}; do
             if node "$GITHUB_WORKSPACE/scripts/verify-npm-release-provenance.mjs" \
               react-native-iap "$VERSION" "$GITHUB_SHA" "$RELEASE_TAG" \
               release-react-native.yml; then
               VERIFIED=true
               break
             fi
-            sleep 5
+            sleep 10
           done
           if [ "$VERIFIED" != "true" ]; then
             echo "::error::Published npm provenance did not become verifiable"

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -4750,6 +4750,9 @@ function checkFrameworkDependencyHygiene() {
         "Assert npm publish source is unchanged",
         "Verify published npm release provenance",
         "if: steps.check_npm.outputs.exists == 'false'",
+        "Allow five minutes for the immutable provenance to propagate",
+        "for attempt in {1..30}; do",
+        "sleep 10",
       ],
       `${npmReleaseWorkflow} must support npm release reruns`,
     );

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -4750,9 +4750,6 @@ function checkFrameworkDependencyHygiene() {
         "Assert npm publish source is unchanged",
         "Verify published npm release provenance",
         "if: steps.check_npm.outputs.exists == 'false'",
-        "Allow five minutes for the immutable provenance to propagate",
-        "for attempt in {1..30}; do",
-        "sleep 10",
       ],
       `${npmReleaseWorkflow} must support npm release reruns`,
     );
@@ -4768,6 +4765,24 @@ function checkFrameworkDependencyHygiene() {
       `${npmReleaseWorkflow} must not drift npm trusted-publishing CLI version`,
     );
     const npmReleaseSource = read(npmReleaseWorkflow);
+    const publishedProvenanceStep = extractNamedWorkflowStep(
+      npmReleaseSource,
+      "Verify published npm release provenance",
+    );
+    if (
+      !publishedProvenanceStep ||
+      !publishedProvenanceStep.source.includes(
+        "Allow five minutes for the immutable provenance to propagate",
+      ) ||
+      !/^\s*for attempt in \{1\.\.30\}; do\s*$/mu.test(
+        publishedProvenanceStep.source,
+      ) ||
+      !/^\s*sleep 10\s*$/mu.test(publishedProvenanceStep.source)
+    ) {
+      fail(
+        `${npmReleaseWorkflow} must wait up to five minutes for npm provenance inside its published-provenance step`,
+      );
+    }
     if (
       npmReleaseSource.indexOf(
         "- name: Check if npm package already published",

--- a/scripts/release-branch-policy.test.mjs
+++ b/scripts/release-branch-policy.test.mjs
@@ -897,16 +897,19 @@ test("framework release workflows refuse stale dispatch heads", () => {
       assert.ok(sourceAuthorizationIndex < finalSourceGuardIndex, filename);
       assert.ok(finalSourceGuardIndex < publishIndex, filename);
       assert.ok(publishIndex < publishedProvenanceIndex, filename);
-      const publishedProvenanceStep = workflow.slice(publishedProvenanceIndex);
+      const publishedProvenanceStep = extractNamedStep(
+        workflow,
+        "Verify published npm release provenance",
+      ).source;
       assert.match(
         publishedProvenanceStep,
         /Allow five minutes for the immutable provenance to propagate/,
       );
       assert.match(
         publishedProvenanceStep,
-        /for attempt in \{1\.\.30\}; do/,
+        /^\s*for attempt in \{1\.\.30\}; do\s*$/mu,
       );
-      assert.match(publishedProvenanceStep, /sleep 10/);
+      assert.match(publishedProvenanceStep, /^\s*sleep 10\s*$/mu);
     }
   }
 

--- a/scripts/release-branch-policy.test.mjs
+++ b/scripts/release-branch-policy.test.mjs
@@ -897,6 +897,16 @@ test("framework release workflows refuse stale dispatch heads", () => {
       assert.ok(sourceAuthorizationIndex < finalSourceGuardIndex, filename);
       assert.ok(finalSourceGuardIndex < publishIndex, filename);
       assert.ok(publishIndex < publishedProvenanceIndex, filename);
+      const publishedProvenanceStep = workflow.slice(publishedProvenanceIndex);
+      assert.match(
+        publishedProvenanceStep,
+        /Allow five minutes for the immutable provenance to propagate/,
+      );
+      assert.match(
+        publishedProvenanceStep,
+        /for attempt in \{1\.\.30\}; do/,
+      );
+      assert.match(publishedProvenanceStep, /sleep 10/);
     }
   }
 


### PR DESCRIPTION
## Summary

- allow npm provenance attestations up to five minutes to propagate after publish
- apply the same retry window to Expo and React Native releases
- guard the release workflows with scoped parity and policy regression checks
- require dependency modernization and any train-wide CI recovery to stay grouped instead of opening package-by-package PRs

## Verification

- `node --test scripts/release-branch-policy.test.mjs`
- `bun audit:parity`
- `quick_validate.py .codex/skills/openiap-workflows`
- recovered the existing `expo-iap@5.1.0` tag run after its attestation became public; no republish occurred