### PR TITLE
fix: harden remaining dependency release CI

### DIFF
--- a/.github/workflows/ci-flutter-inapp-purchase.yml
+++ b/.github/workflows/ci-flutter-inapp-purchase.yml
@@ -10,6 +10,7 @@ on:
       - "packages/apple/Package.swift"
       - "openiap-versions.json"
       - ".github/workflows/ci-flutter-inapp-purchase.yml"
+      - ".github/workflows/release-flutter.yml"
   push:
     branches: [main, next]
     paths:
@@ -19,6 +20,7 @@ on:
       - "packages/apple/Package.swift"
       - "openiap-versions.json"
       - ".github/workflows/ci-flutter-inapp-purchase.yml"
+      - ".github/workflows/release-flutter.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -80,3 +82,30 @@ jobs:
 
       - name: Build iOS and macOS examples with SwiftPM
         run: bash scripts/verify-apple-swiftpm-consumer-build.sh
+
+  apple-cocoapods:
+    name: iOS CocoaPods consumer (Flutter 3.44 + Xcode 16.4)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-15
+    timeout-minutes: 60
+    env:
+      XCODE_VERSION: 16.4
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: "3.44.9"
+          cache: true
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Build iOS CocoaPods consumer
+        run: bash scripts/verify-ios-cocoapods-consumer-build.sh

--- a/.github/workflows/release-flutter.yml
+++ b/.github/workflows/release-flutter.yml
@@ -111,41 +111,8 @@ jobs:
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
-      - name: Select CocoaPods fallback
-        run: |
-          perl -0pi -e \
-            's/enable-swift-package-manager: true/enable-swift-package-manager: false/' \
-            example/pubspec.yaml
-          grep -Fq "enable-swift-package-manager: false" example/pubspec.yaml
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Install example dependencies
-        working-directory: libraries/flutter_inapp_purchase/example
-        run: flutter pub get
-
-      - name: Prepare example env
-        working-directory: libraries/flutter_inapp_purchase/example
-        run: cp env.example env
-
-      - name: Install CocoaPods dependencies
-        working-directory: libraries/flutter_inapp_purchase/example/ios
-        run: |
-          pod install --repo-update
-          grep -Eq '^[[:space:]]+- openiap ' Podfile.lock
-
-      - name: Build iOS
-        working-directory: libraries/flutter_inapp_purchase/example/ios
-        run: |
-          set -o pipefail
-          xcodebuild build \
-            -workspace Runner.xcworkspace \
-            -scheme Runner \
-            -destination 'generic/platform=iOS Simulator' \
-            -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO \
-            COMPILER_INDEX_STORE_ENABLE=NO
+      - name: Build iOS CocoaPods consumer
+        run: bash scripts/verify-ios-cocoapods-consumer-build.sh
 
   validate-apple-swiftpm:
     needs: [release-branch]

--- a/libraries/flutter_inapp_purchase/scripts/verify-ios-cocoapods-consumer-build.sh
+++ b/libraries/flutter_inapp_purchase/scripts/verify-ios-cocoapods-consumer-build.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+package_root="$(cd "$script_dir/.." && pwd)"
+tmp_root="$(mktemp -d)"
+
+cleanup() {
+  if [ -n "${tmp_root:-}" ] && [ -d "$tmp_root" ]; then
+    rm -rf "$tmp_root"
+  fi
+}
+trap cleanup EXIT
+
+consumer_app="$tmp_root/openiap_cocoapods_consumer"
+podspec="$package_root/ios/flutter_inapp_purchase.podspec"
+minimum_ios_version="$(
+  sed -nE \
+    "s/^[[:space:]]*s\\.ios\\.deployment_target = '([^']+)'.*/\\1/p" \
+    "$podspec" | head -n 1
+)"
+if [ -z "$minimum_ios_version" ]; then
+  echo "Failed to read the minimum iOS version from $podspec" >&2
+  exit 1
+fi
+
+# Keep this fallback check independent from the developer's global Flutter
+# configuration and from the tracked example's SwiftPM integration.
+export XDG_CONFIG_HOME="$tmp_root/flutter-config"
+mkdir -p "$XDG_CONFIG_HOME"
+flutter config --no-enable-swift-package-manager
+
+flutter create \
+  --empty \
+  --platforms=ios \
+  --org dev.hyo \
+  --project-name openiap_cocoapods_consumer \
+  "$consumer_app"
+
+flutter pub add \
+  "flutter_inapp_purchase@{path: $package_root}" \
+  --directory "$consumer_app"
+
+podfile="$consumer_app/ios/Podfile"
+xcode_project="$consumer_app/ios/Runner.xcodeproj/project.pbxproj"
+
+perl -0pi -e \
+  "s/# platform :ios, '[0-9.]+'/platform :ios, '$minimum_ios_version'/" \
+  "$podfile"
+if ! grep -Fq "platform :ios, '$minimum_ios_version'" "$podfile"; then
+  echo "Failed to set the CocoaPods consumer deployment target" >&2
+  exit 1
+fi
+
+deployment_target_count="$(grep -Ec 'IPHONEOS_DEPLOYMENT_TARGET = [0-9.]+;' "$xcode_project")"
+if [ "$deployment_target_count" -eq 0 ]; then
+  echo "Generated Xcode project has no deployment targets" >&2
+  exit 1
+fi
+perl -0pi -e \
+  "s/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]+;/IPHONEOS_DEPLOYMENT_TARGET = $minimum_ios_version;/g" \
+  "$xcode_project"
+configured_target_count="$(
+  grep -Fc \
+    "IPHONEOS_DEPLOYMENT_TARGET = $minimum_ios_version;" \
+    "$xcode_project"
+)"
+if [ "$configured_target_count" -ne "$deployment_target_count" ]; then
+  echo "Failed to set the Xcode consumer deployment target" >&2
+  exit 1
+fi
+
+if grep -Eq \
+  'FlutterGeneratedPluginSwiftPackage|XCLocalSwiftPackageReference' \
+  "$xcode_project"; then
+  echo "CocoaPods consumer unexpectedly contains SwiftPM package references" >&2
+  exit 1
+fi
+
+(
+  cd "$consumer_app"
+  flutter build ios --simulator --debug --no-codesign
+)
+
+podfile_lock="$consumer_app/ios/Podfile.lock"
+grep -Eq '^[[:space:]]+- flutter_inapp_purchase ' "$podfile_lock"
+grep -Eq '^[[:space:]]+- openiap ' "$podfile_lock"

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -7959,30 +7959,69 @@ function checkXcode27StoreKitCoverage() {
       `${workflowPath} Flutter Xcode 27 SwiftPM example build`,
     );
   }
+  for (const workflowPath of [
+    ".github/workflows/ci-flutter-inapp-purchase.yml",
+    ".github/workflows/release-flutter.yml",
+  ]) {
+    expectIncludes(
+      workflowPath,
+      ["bash scripts/verify-ios-cocoapods-consumer-build.sh"],
+      `${workflowPath} Flutter CocoaPods consumer build`,
+    );
+  }
   expectIncludes(
     ".github/workflows/ci-flutter-inapp-purchase.yml",
     [
       "packages/apple/Sources/**",
       "packages/apple/Package.swift",
       "openiap-versions.json",
+      '".github/workflows/release-flutter.yml"',
+      "apple-cocoapods:",
+      "runs-on: macos-15",
+      "XCODE_VERSION: 16.4",
+      "maxim-lobanov/setup-xcode@v1",
+      "xcode-version: ${{ env.XCODE_VERSION }}",
     ],
-    "Flutter Xcode 27 SwiftPM trigger coverage",
+    "Flutter Apple dependency-manager trigger and toolchain coverage",
   );
   expectIncludes(
     ".github/workflows/release-flutter.yml",
     [
-      "Select CocoaPods fallback",
-      "enable-swift-package-manager: false",
-      "grep -Eq '^[[:space:]]+- openiap ' Podfile.lock",
+      "Build iOS CocoaPods consumer",
       "validate-apple-swiftpm",
       "needs: [validate-android, validate-ios, validate-apple-swiftpm]",
     ],
     "Flutter release Apple dependency-manager coverage",
   );
+  expectNotIncludes(
+    ".github/workflows/release-flutter.yml",
+    [
+      "Select CocoaPods fallback",
+      "enable-swift-package-manager: false",
+      "example/pubspec.yaml",
+    ],
+    "Flutter release must not mutate the tracked SwiftPM example into a CocoaPods consumer",
+  );
   expectIncludes(
     "libraries/flutter_inapp_purchase/example/pubspec.yaml",
     ["enable-swift-package-manager: true"],
     "Flutter example SwiftPM enablement",
+  );
+  expectIncludes(
+    "libraries/flutter_inapp_purchase/scripts/verify-ios-cocoapods-consumer-build.sh",
+    [
+      "XDG_CONFIG_HOME",
+      "flutter config --no-enable-swift-package-manager",
+      "flutter create",
+      "ios/flutter_inapp_purchase.podspec",
+      "minimum_ios_version=",
+      '"flutter_inapp_purchase@{path: $package_root}"',
+      "FlutterGeneratedPluginSwiftPackage|XCLocalSwiftPackageReference",
+      "flutter build ios --simulator --debug --no-codesign",
+      "flutter_inapp_purchase ",
+      "openiap ",
+    ],
+    "Flutter CocoaPods consumer build isolation",
   );
   expectIncludes(
     "libraries/flutter_inapp_purchase/scripts/verify-apple-swiftpm-consumer-build.sh",


### PR DESCRIPTION
## Summary

- validate the Flutter CocoaPods fallback with a freshly generated consumer app instead of mutating the tracked SwiftPM example
- run the same isolated CocoaPods consumer build in pull-request CI and the Flutter release gate
- guard both dependency-manager paths and their pinned toolchains with the parity audit

## Grouped release preflight

This is the single recovery PR for the remaining dependency release train. Before opening it, the Flutter, Godot, KMP, and MAUI release paths were audited together:

- the failed Flutter run completed Android and SwiftPM validation successfully; the CocoaPods validation failed before any version commit, tag, or pub.dev publication
- the Godot, KMP, and MAUI package CI runs passed on the dependency-update merge commit
- the planned Flutter 10.1.0, Godot 3.1.0, KMP 3.1.0, and MAUI 2.1.0 tags do not exist
- pub.dev, Maven Central, and NuGet report the planned versions as unpublished
- the remaining release workflows have their required repository secret names configured

No speculative changes were needed for Godot, KMP, or MAUI.

## Validation

- isolated CocoaPods consumer install and iOS Simulator build
- `flutter analyze`
- `flutter test` (290 tests)
- `bun run audit:parity`
- `bun run audit:release-state`
- release branch/head/tag tests
- shell syntax, Prettier, and diff checks

## Preview

Not applicable: this changes CI-only release validation. The isolated consumer build above is the relevant executable proof.
