### PR TITLE
fix(kit): guard production Convex target

### DIFF
--- a/.github/workflows/deploy-kit.yml
+++ b/.github/workflows/deploy-kit.yml
@@ -140,10 +140,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Validate required deployment secrets
+      - name: Validate deployment credentials
         env:
           FLY_API_TOKEN: ${{ secrets.KIT_FLY_API_TOKEN }}
-          VITE_KIT_CONVEX_URL: ${{ secrets.VITE_KIT_CONVEX_URL }}
         run: |
           if [ -z "$KIT_CONVEX_DEPLOY_KEY" ]; then
             echo "::error::KIT_CONVEX_DEPLOY_KEY secret not set."
@@ -151,10 +150,6 @@ jobs:
           fi
           if [ -z "$FLY_API_TOKEN" ]; then
             echo "::error::KIT_FLY_API_TOKEN secret not set."
-            exit 1
-          fi
-          if [ -z "$VITE_KIT_CONVEX_URL" ]; then
-            echo "::error::VITE_KIT_CONVEX_URL secret not set (production Convex URL)."
             exit 1
           fi
 
@@ -176,7 +171,13 @@ jobs:
             echo "Attempt $attempt failed. Retrying..."
             sleep 5
           done
-          bunx convex deploy --yes
+          # Convex resolves the canonical URL for the deployment selected by
+          # CONVEX_DEPLOY_KEY. Abort before pushing functions if it does not
+          # match the committed production SSOT, then pass that same resolved
+          # URL to the later Fly build through GITHUB_ENV.
+          bunx convex deploy --yes \
+            --cmd './scripts/verify-production-convex-target.sh && printf "VITE_KIT_CONVEX_URL=%s\n" "$VITE_KIT_CONVEX_URL" >> "$GITHUB_ENV"' \
+            --cmd-url-env-var-name VITE_KIT_CONVEX_URL
 
       - name: Setup flyctl
         # Pinned to the `1.6` release rather than `@master` so the action
@@ -192,7 +193,6 @@ jobs:
         # the lockfile — it lives at root, not under packages/kit/.
         env:
           FLY_API_TOKEN: ${{ secrets.KIT_FLY_API_TOKEN }}
-          VITE_KIT_CONVEX_URL: ${{ secrets.VITE_KIT_CONVEX_URL }}
           VITE_KIT_SENTRY_DSN: ${{ secrets.VITE_KIT_SENTRY_DSN }}
           VITE_KIT_MIXPANEL_TOKEN: ${{ secrets.VITE_KIT_MIXPANEL_TOKEN }}
         run: |

--- a/.github/workflows/deploy-kit.yml
+++ b/.github/workflows/deploy-kit.yml
@@ -59,6 +59,19 @@ jobs:
             sleep 5
           done
 
+      - name: Test production Convex target guard
+        run: |
+          set -a
+          source production.env
+          set +a
+          VITE_KIT_CONVEX_URL="$IAPKIT_PRODUCTION_CONVEX_URL" \
+            ./scripts/verify-production-convex-target.sh
+          if VITE_KIT_CONVEX_URL=https://invalid-dev.convex.cloud \
+            ./scripts/verify-production-convex-target.sh; then
+            echo "::error::Production target guard accepted a development deployment."
+            exit 1
+          fi
+
       - name: Lint (app + Convex typecheck + eslint)
         run: bun run lint
 

--- a/packages/kit/.env.example
+++ b/packages/kit/.env.example
@@ -6,21 +6,12 @@
 # Local development (`bun run dev:all`) reads `.env.local` and should use
 # your DEV Convex deployment URL.
 #
-# Manual prod deploys (`bun run deploy:prod` → scripts/deploy-prod.sh)
-# read `.env.production` instead, so the SPA bundle baked into the Fly
-# image points at the PROD Convex deployment. `.env.production` is
-# git-ignored too — copy the Convex-CLI-populated `.env.local` you'd
-# use against prod, or just:
-#
-#   echo "VITE_KIT_CONVEX_URL=https://<prod-slug>.convex.cloud" > .env.production
-#
-# CI doesn't use `.env.production` — the `deploy` job in
-# `.github/workflows/ci.yml` reads `VITE_KIT_CONVEX_URL` from the
-# `VITE_KIT_CONVEX_URL` GitHub secret and passes it as a Docker build-arg,
-# which is the source of truth for automated deploys. The
-# `.env.production` + `scripts/deploy-prod.sh` pair exists so that a
-# manual fallback deploy can't accidentally source `.env.local` (dev
-# URL) and publish a prod SPA bundle pointed at the dev backend.
+# Manual prod deploys (`bun run deploy:prod` → scripts/deploy-prod.sh) may
+# read credentials and optional analytics settings from `.env.production`.
+# The production Convex URL does not belong there: automated and manual deploys
+# obtain the canonical URL from the Convex CLI and require it to match the
+# committed `production.env` SSOT before publishing. CI therefore does not use
+# a mutable `VITE_KIT_CONVEX_URL` GitHub secret.
 
 # ────────────────────────────────────────────────────────────────
 # Convex (required for anything to work)
@@ -30,8 +21,9 @@
 # VITE_CONVEX_URL=https://<your-dev-deployment>.convex.cloud
 # VITE_CONVEX_SITE_URL=https://<your-dev-deployment>.convex.site
 
-# Optional explicit frontend override. Production builds require this
-# KIT-prefixed value so deployment cannot accidentally target a dev backend.
+# Optional explicit frontend override for local or self-hosted builds. The
+# official production deploy scripts ignore this value and use the verified
+# canonical URL selected by Convex instead.
 # VITE_KIT_CONVEX_URL=https://<your-production-project>.convex.cloud
 
 # Optional deploy key for non-interactive Convex deploys

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -517,23 +517,25 @@ SMOKE_PORT=3200 ./scripts/smoke-server.sh
 
 ```bash
 flyctl auth login
-# From the repository root, deploy the additive backend first.
-bun run deploy:kit
-# Then fill packages/kit/.env.production from .env.example and deploy Fly.
 cd packages/kit
+# Optionally fill .env.production from .env.example with a deploy key and
+# analytics settings when they are not already available in your environment.
 bun run deploy:prod
 ```
 
-Keep this order: the new Convex functions remain compatible with the currently
-running Fly app, while a new Fly app may depend on functions that are not yet
-deployed.
+The script deploys additive Convex functions first, then Fly. It asks the Convex
+CLI for the canonical URL selected by the current deploy credentials and checks
+that URL against the committed [`production.env`](production.env) SSOT before
+either deployment proceeds. A development deploy key therefore cannot publish a
+production Fly bundle.
 
 `VITE_*` values have to be passed at **build time**, not just runtime
 secrets — Vite inlines them into the SPA bundle at `bun run build`
-time. The deploy script sends `VITE_KIT_CONVEX_URL` and
-`VITE_KIT_SENTRY_DSN` as build args, and sends `VITE_KIT_MIXPANEL_TOKEN`
-as a BuildKit secret only to avoid Docker's TOKEN-named ARG/ENV warning.
-Omitting Sentry or Mixpanel is fine; the SPA skips those integrations.
+time. The deploy script sends the Convex-CLI-verified
+`VITE_KIT_CONVEX_URL` and `VITE_KIT_SENTRY_DSN` as build args, and sends
+`VITE_KIT_MIXPANEL_TOKEN` as a BuildKit secret only to avoid Docker's
+TOKEN-named ARG/ENV warning. Omitting Sentry or Mixpanel is fine; the SPA skips
+those integrations.
 
 Server-side runtime secrets (read by the compiled Bun binary at boot)
 are set once with `flyctl secrets set`:
@@ -558,24 +560,24 @@ namespace them away from other monorepo secrets):
 Manual workflow dispatches from non-`main` refs run verification only. Select
 `main` explicitly when a production redeploy is intended.
 
-> **Note**: `VITE_KIT_*` values are **not actually secret** — Vite
-> inlines them into the SPA bundle at build time, so anyone with
-> DevTools open can read them. They live in GitHub Actions secrets
-> for build-time injection convenience only. Treat them as public
-> configuration. Real secrets (deploy auth) are flagged below.
+The production Convex URL is public Vite configuration, so it is not stored in
+a GitHub secret. The workflow obtains the canonical URL from the Convex CLI and
+requires it to match [`production.env`](production.env) before deploying either
+surface. Optional `VITE_KIT_*` integrations are also inlined into the SPA and
+must be treated as public configuration even though Actions stores them as
+secrets for injection convenience.
 
 | Secret                    | Real secret? | Purpose                                                 |
 | ------------------------- | ------------ | ------------------------------------------------------- |
 | `KIT_FLY_API_TOKEN`       | ✅ yes       | `flyctl deploy` auth — keep private                     |
 | `KIT_CONVEX_DEPLOY_KEY`   | ✅ yes       | Convex function deploy                                  |
-| `VITE_KIT_CONVEX_URL`     | ⚠️ public    | Build arg for SPA — visible in deployed JS bundle       |
 | `VITE_KIT_SENTRY_DSN`     | ⚠️ public    | Build arg for SPA (optional — SPA skips init if absent) |
 | `VITE_KIT_MIXPANEL_TOKEN` | ⚠️ public    | BuildKit secret for SPA (optional — analytics opt-in)   |
 
-The workflow validates all required deployment values before changing either
-surface. A missing `KIT_CONVEX_DEPLOY_KEY`, `KIT_FLY_API_TOKEN`, or
-`VITE_KIT_CONVEX_URL` fails the deployment instead of publishing only half of
-the release. Set the Convex key with:
+The workflow validates both deployment credentials and the selected Convex
+target before changing either surface. A missing `KIT_CONVEX_DEPLOY_KEY` or
+`KIT_FLY_API_TOKEN`, or a Convex URL mismatch, fails the deployment instead of
+publishing only half of the release. Set the Convex key with:
 
 ```bash
 # Value from Convex dashboard → Settings → Deploy Keys

--- a/packages/kit/production.env
+++ b/packages/kit/production.env
@@ -1,0 +1,4 @@
+# Public SSOT for the official IAPKit production Convex deployment.
+# CI and the emergency deploy script both verify the Convex CLI's canonical
+# target against this URL before publishing a Fly image.
+IAPKIT_PRODUCTION_CONVEX_URL=https://healthy-kudu-836.convex.cloud

--- a/packages/kit/scripts/deploy-prod.sh
+++ b/packages/kit/scripts/deploy-prod.sh
@@ -3,17 +3,13 @@
 # Convex SPA bundle.
 #
 # Normally the `deploy` job in `.github/workflows/deploy-kit.yml`
-# handles prod deploys and reads `VITE_KIT_CONVEX_URL` /
-# `VITE_KIT_SENTRY_DSN` / `VITE_KIT_MIXPANEL_TOKEN` directly from
-# GitHub Actions secrets (KIT_-prefixed). This
-# script is only for the rare case where CI is unavailable (billing
-# pause, emergency revert, etc.) and a human has to run `flyctl deploy`
-# from their laptop. To keep that path from accidentally shipping a
-# dev SPA, it reads from `.env.production` — which is git-ignored and
-# MUST be created locally by the deployer before the first run (see
-# `.env.example`). Direct `source .env.local && flyctl deploy ...`
-# has baked the DEV Convex URL into kit.openiap.dev before; don't do
-# that again.
+# handles production deploys. This script is only for the rare case where CI
+# is unavailable (billing pause, emergency revert, etc.) and a human has to
+# deploy from their laptop. Both paths ask the Convex CLI for the canonical URL
+# selected by its deploy key, compare it with the committed `production.env`
+# SSOT, and pass that exact URL to Fly. `.env.production` is optional and may
+# contain only credentials or optional analytics settings; it never chooses
+# the production Convex deployment.
 #
 # Usage: bash scripts/deploy-prod.sh
 set -euo pipefail
@@ -25,36 +21,15 @@ KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_ROOT="$(cd "$KIT_DIR/../.." && pwd)"
 cd "$KIT_DIR"
 
-if [ ! -f .env.production ]; then
-  echo "error: .env.production missing. This file is git-ignored —"
-  echo "create it locally from .env.example and fill in the PROD"
-  echo "values (at minimum VITE_KIT_CONVEX_URL). Do NOT commit it."
-  exit 1
-fi
-
 # shellcheck disable=SC1091
 set -a
-source .env.production
+if [ -f .env.production ]; then
+  source .env.production
+fi
 if [ -f .env.production.local ]; then
   source .env.production.local
 fi
 set +a
-
-if [ -z "${VITE_KIT_CONVEX_URL:-}" ]; then
-  echo "error: VITE_KIT_CONVEX_URL not set after sourcing .env.production"
-  exit 1
-fi
-
-# Guard against ever sending a localhost or dev-labelled URL to Fly.
-case "$VITE_KIT_CONVEX_URL" in
-  *localhost*|*127.0.0.1*|*fabulous-gnat-876*)
-    echo "error: VITE_KIT_CONVEX_URL looks like a dev URL ($VITE_KIT_CONVEX_URL)."
-    echo "Refusing to deploy that to prod. Fix .env.production first."
-    exit 1
-    ;;
-esac
-
-echo "Deploying to Fly with VITE_KIT_CONVEX_URL=$VITE_KIT_CONVEX_URL"
 
 # The health response identifies the deployed Git revision. Refuse a manual
 # build from a dirty checkout, where that revision would not describe the
@@ -64,6 +39,21 @@ if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
   echo "Commit or remove tracked/untracked source changes first." >&2
   exit 1
 fi
+
+# Deploy Convex first and capture the canonical cloud URL selected by the same
+# credentials. `convex deploy` runs --cmd before pushing functions, so a target
+# mismatch stops both the Convex and Fly deployments.
+CONVEX_URL_FILE="$(mktemp)"
+trap 'rm -f "$CONVEX_URL_FILE"' EXIT
+export IAPKIT_CONVEX_URL_FILE="$CONVEX_URL_FILE"
+bunx convex deploy --yes \
+  --cmd './scripts/verify-production-convex-target.sh && printf "%s\n" "$VITE_KIT_CONVEX_URL" > "$IAPKIT_CONVEX_URL_FILE"' \
+  --cmd-url-env-var-name VITE_KIT_CONVEX_URL
+VITE_KIT_CONVEX_URL="$(tr -d '\r\n' < "$CONVEX_URL_FILE")"
+rm -f "$CONVEX_URL_FILE"
+trap - EXIT
+
+echo "Deploying to Fly with verified VITE_KIT_CONVEX_URL=$VITE_KIT_CONVEX_URL"
 
 IAPKIT_REVISION="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 BUILD_FLAGS=(

--- a/packages/kit/scripts/verify-production-convex-target.sh
+++ b/packages/kit/scripts/verify-production-convex-target.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../production.env"
+
+if [ -z "${VITE_KIT_CONVEX_URL:-}" ]; then
+  echo "error: Convex CLI did not provide its canonical deployment URL." >&2
+  exit 1
+fi
+
+if [ "$VITE_KIT_CONVEX_URL" != "$IAPKIT_PRODUCTION_CONVEX_URL" ]; then
+  echo "error: Convex deploy target $VITE_KIT_CONVEX_URL does not match production $IAPKIT_PRODUCTION_CONVEX_URL." >&2
+  exit 1
+fi
+
+echo "Verified production Convex target: $VITE_KIT_CONVEX_URL"

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -4527,20 +4527,41 @@ function checkFrameworkDependencyHygiene() {
     ".github/workflows/deploy-kit.yml",
     [
       "if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')",
-      "- name: Validate required deployment secrets",
+      "- name: Validate deployment credentials",
       "- name: Deploy Convex functions",
+      "verify-production-convex-target.sh",
+      "--cmd-url-env-var-name VITE_KIT_CONVEX_URL",
       "- name: Deploy",
     ],
-    "Kit deploy must be main-only and validate both deployment surfaces",
+    "Kit deploy must be main-only and bind Fly to the verified Convex target",
   );
   expectNotIncludes(
     ".github/workflows/deploy-kit.yml",
     [
       "if: ${{ env.KIT_CONVEX_DEPLOY_KEY != '' }}",
+      "secrets.VITE_KIT_CONVEX_URL",
       "--typecheck=disable",
       "--typecheck disable",
     ],
     "Kit production deploy must neither skip Convex nor disable its typecheck",
+  );
+  expectIncludes(
+    "packages/kit/production.env",
+    ["IAPKIT_PRODUCTION_CONVEX_URL=https://healthy-kudu-836.convex.cloud"],
+    "Kit production Convex target must have one committed public SSOT",
+  );
+  expectIncludes(
+    "packages/kit/scripts/verify-production-convex-target.sh",
+    ['source "$SCRIPT_DIR/../production.env"', "$IAPKIT_PRODUCTION_CONVEX_URL"],
+    "Kit deploy target guard must use the committed production SSOT",
+  );
+  expectIncludes(
+    "packages/kit/scripts/deploy-prod.sh",
+    [
+      "verify-production-convex-target.sh",
+      "--cmd-url-env-var-name VITE_KIT_CONVEX_URL",
+    ],
+    "Kit manual deploy must run the shared production target guard",
   );
   expectIncludes(
     "packages/kit/package.json",
@@ -4561,21 +4582,21 @@ function checkFrameworkDependencyHygiene() {
     "Convex typecheck must not hide test TypeScript",
   );
   const kitDeployWorkflow = read(".github/workflows/deploy-kit.yml");
-  const validateDeploySecrets = kitDeployWorkflow.indexOf(
-    "- name: Validate required deployment secrets",
+  const validateDeployCredentials = kitDeployWorkflow.indexOf(
+    "- name: Validate deployment credentials",
   );
   const deployConvex = kitDeployWorkflow.indexOf(
     "- name: Deploy Convex functions",
   );
   const deployFly = kitDeployWorkflow.indexOf("- name: Deploy\n");
   if (
-    validateDeploySecrets === -1 ||
+    validateDeployCredentials === -1 ||
     deployConvex === -1 ||
     deployFly === -1 ||
-    !(validateDeploySecrets < deployConvex && deployConvex < deployFly)
+    !(validateDeployCredentials < deployConvex && deployConvex < deployFly)
   ) {
     fail(
-      "Kit production deploy must validate secrets, then deploy Convex before Fly",
+      "Kit production deploy must validate credentials, then deploy Convex before Fly",
     );
   }
   expectIncludes(

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -4527,6 +4527,7 @@ function checkFrameworkDependencyHygiene() {
     ".github/workflows/deploy-kit.yml",
     [
       "if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')",
+      "- name: Test production Convex target guard",
       "- name: Validate deployment credentials",
       "- name: Deploy Convex functions",
       "verify-production-convex-target.sh",


### PR DESCRIPTION
## Summary

- remove the mutable `VITE_KIT_CONVEX_URL` GitHub secret from production deployment inputs
- resolve the canonical frontend URL from the same Convex deployment selected for function deployment
- abort before either Convex or Fly changes when that URL does not match the committed production SSOT
- apply the same guard to the manual fallback deploy and enforce it in the parity audit

## Test plan

- `bun run audit:parity`
- `bun run --filter @hyodotdev/openiap-kit lint`
- `bun run --filter @hyodotdev/openiap-kit test` (1,088 tests)
- `bun run --filter @hyodotdev/openiap-kit smoke:server`
- verify the target guard accepts production and rejects both the development deployment and a missing URL

## Preview

No visual or interactive UI surface changed. Terminal verification covers the production-target guard and the complete Kit CI-equivalent gate.
