### PR TITLE
docs(godot): clarify ios 17 requirement

### DIFF
--- a/.github/workflows/release-godot.yml
+++ b/.github/workflows/release-godot.yml
@@ -497,7 +497,11 @@ jobs:
 
           Download \`godot-iap-$VERSION.zip\` from the Assets section below and extract into your project's \`addons/\` directory, or install via the Godot Asset Library.
 
-          Minimum Godot version: **4.3**.
+          ### Minimum versions
+
+          - Godot **4.3**
+          - iOS **17.0** (SwiftGodot runtime)
+          - Android API **24**
 
           ### Documentation
 

--- a/libraries/godot-iap/README.md
+++ b/libraries/godot-iap/README.md
@@ -35,6 +35,12 @@ Visit the [documentation site](https://openiap.dev/docs/setup/godot) for [instal
 2. Extract and copy `addons/godot-iap/` to your project's `addons/` folder
 3. Enable the plugin in **Project → Project Settings → Plugins**
 
+> [!IMPORTANT]
+> For iOS exports, set `application/min_ios_version` to `17.0` or later. The
+> bundled `GodotIap.framework` and `SwiftGodotRuntime.framework` inherit the
+> SwiftGodot iOS 17 minimum; a lower export preset does not back-deploy them and
+> can terminate the app before startup.
+
 Native Apple API availability is fixed when the pre-built
 `GodotIap.framework` is compiled. Release artifacts use the current
 App Store-accepted stable Xcode toolchain; CI rejects frameworks carrying an

--- a/packages/docs/src/pages/docs/setup/godot.tsx
+++ b/packages/docs/src/pages/docs/setup/godot.tsx
@@ -43,6 +43,14 @@ function GodotSetup() {
             Android: Android SDK with <strong>API level 24+</strong>
           </li>
         </ul>
+        <Callout kind="warning" title="iOS 17 is required">
+          The release zip includes <code>GodotIap.framework</code> and{' '}
+          <code>SwiftGodotRuntime.framework</code> built for iOS 17 because
+          SwiftGodot requires that deployment target. Set{' '}
+          <code>application/min_ios_version</code> to <code>17.0</code> or
+          later. A lower export preset does not back-deploy the frameworks and
+          can cause the app to terminate before startup.
+        </Callout>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary

- make the iOS 17 deployment requirement prominent in the Godot setup guide and README
- explain that lower Godot export targets do not back-deploy the bundled SwiftGodot frameworks
- list Godot, iOS, and Android minimums in future godot-iap GitHub Release descriptions

Addresses the documentation gap reported in #322 without changing the SwiftGodot support floor.

## Test plan

- [x] `bunx prettier --check "src/**/*.{ts,tsx,js,jsx,css,json}"`
- [x] `cd packages/docs && bun run build`
- [x] `bun test scripts/audit-docs.test.ts`
- [x] `bun run audit:docs`
- [x] `bun run audit:release-state`
- [x] `actionlint .github/workflows/release-godot.yml`
- [x] `git diff --check`
- [x] verified the rendered Godot setup warning locally