### PR TITLE
fix: stage generated Apple version metadata

### DIFF
--- a/.github/workflows/release-apple.yml
+++ b/.github/workflows/release-apple.yml
@@ -229,6 +229,7 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
         git add openiap-versions.json packages/*/openiap-versions.json
+        git add packages/apple/Sources/OpenIapGeneratedVersion.swift
         git add packages/docs/src/generated/version-metadata.json
         git add packages/gql/package.json packages/docs/package.json packages/google/package.json packages/apple/package.json
 
@@ -269,6 +270,7 @@ jobs:
               node scripts/release-branch-policy.mjs update-native apple "$VERSION"
               ./scripts/sync-release-generated.sh
               git add openiap-versions.json packages/*/openiap-versions.json
+              git add packages/apple/Sources/OpenIapGeneratedVersion.swift
               git add packages/docs/src/generated/version-metadata.json
               git add packages/gql/package.json packages/docs/package.json packages/google/package.json packages/apple/package.json
 
@@ -282,6 +284,7 @@ jobs:
             node scripts/release-branch-policy.mjs update-native apple "$VERSION"
             ./scripts/sync-release-generated.sh
             git add openiap-versions.json packages/*/openiap-versions.json
+            git add packages/apple/Sources/OpenIapGeneratedVersion.swift
             git add packages/docs/src/generated/version-metadata.json
             git add packages/gql/package.json packages/docs/package.json packages/google/package.json packages/apple/package.json
             if ! git diff --staged --quiet; then


### PR DESCRIPTION
## Summary

- stage `OpenIapGeneratedVersion.swift` in every Apple release version-sync path
- keep the release worktree clean before the retrying `git pull --rebase`

## Verification

- reproduced the 3.2.1 version sync in a clean detached worktree
- verified the corrected staging set leaves no uncommitted generated output after the version commit
- `git diff --check`
- `bun audit:release-state`

This fixes the release automation failure observed in [run 31758179251](https://github.com/hyodotdev/openiap/actions/runs/31758179251).