### PR TITLE
fix: keep release-generated metadata in sync

### DIFF
--- a/.github/workflows/release-google.yml
+++ b/.github/workflows/release-google.yml
@@ -210,6 +210,7 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
         git add openiap-versions.json packages/*/openiap-versions.json
+        git add packages/apple/Sources/OpenIapGeneratedVersion.swift
         git add packages/docs/src/generated/version-metadata.json
         git add packages/gql/package.json packages/docs/package.json packages/google/package.json packages/apple/package.json
         git add libraries/godot-iap/addons/godot-iap/android/GodotIap.gdap
@@ -251,6 +252,7 @@ jobs:
               node scripts/release-branch-policy.mjs update-native google "$VERSION"
               ./scripts/sync-release-generated.sh
               git add openiap-versions.json packages/*/openiap-versions.json
+              git add packages/apple/Sources/OpenIapGeneratedVersion.swift
               git add packages/docs/src/generated/version-metadata.json
               git add packages/gql/package.json packages/docs/package.json packages/google/package.json packages/apple/package.json
               git add libraries/godot-iap/addons/godot-iap/android/GodotIap.gdap
@@ -265,6 +267,7 @@ jobs:
             node scripts/release-branch-policy.mjs update-native google "$VERSION"
             ./scripts/sync-release-generated.sh
             git add openiap-versions.json packages/*/openiap-versions.json
+            git add packages/apple/Sources/OpenIapGeneratedVersion.swift
             git add packages/docs/src/generated/version-metadata.json
             git add packages/gql/package.json packages/docs/package.json packages/google/package.json packages/apple/package.json
             git add libraries/godot-iap/addons/godot-iap/android/GodotIap.gdap

--- a/packages/conformance/src/spec/generated-spec.mjs
+++ b/packages/conformance/src/spec/generated-spec.mjs
@@ -2,7 +2,7 @@
 // Do not edit. Copied from packages/gql so the published package is
 // self-contained; packages/gql remains the source of truth.
 
-export const SPEC_VERSION = "3.2.0";
+export const SPEC_VERSION = "3.2.1";
 
 export const CAPABILITY_STORES = Object.freeze(["Apple","Google","Amazon","Horizon"]);
 

--- a/scripts/sync-release-generated.sh
+++ b/scripts/sync-release-generated.sh
@@ -17,9 +17,12 @@ cd "$REPO_ROOT"
 
 ./scripts/sync-versions.sh
 
+(cd packages/conformance && bun run generate:ids)
+
 (cd scripts/agent && bun install --frozen-lockfile && bun run compile:ai)
 
 git add \
+  packages/conformance/src/spec/generated-spec.mjs \
   packages/docs/src/generated/version-metadata.json \
   packages/docs/public/llms.txt \
   packages/docs/public/llms-full.txt \


### PR DESCRIPTION
## Summary

- stage `OpenIapGeneratedVersion.swift` in every Google release version-sync path
- regenerate and stage the published conformance spec from the shared release sync script
- repair the `3.2.1` conformance version drift exposed by the Apple patch release

## Verification

- reproduced both Apple `3.2.1` and Google `3.3.1` syncs in clean detached worktrees
- verified the corrected Google staging set leaves no uncommitted generated output after the version commit
- conformance: 29 tests passed; generated IDs are in sync
- `bun audit:parity`
- `bun audit:release-state`
- `git diff --check`

This fixes the release automation failure observed in [run 31758969160](https://github.com/hyodotdev/openiap/actions/runs/31758969160) and prevents native spec bumps from leaving conformance metadata stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Google release version updates to ensure generated version information is consistently included during release commits and synchronization.
  * Updated the conformance specification to version 3.2.1.
  * Improved release synchronization so generated conformance metadata and documentation remain aligned with the latest specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->