### PR TITLE
fix: isolate conformance version bump

### DIFF
--- a/.github/workflows/release-conformance.yml
+++ b/.github/workflows/release-conformance.yml
@@ -141,13 +141,13 @@ jobs:
           if [ "$VERSION_TYPE" = "current" ]; then
             NEW_VERSION=$(node -p "require('./package.json').version")
           elif [ "$VERSION_TYPE" = "rc-bump" ]; then
-            npm version prerelease --preid=rc --no-git-tag-version
+            npm version prerelease --preid=rc --no-git-tag-version --workspaces=false
             NEW_VERSION=$(node -p "require('./package.json').version")
           elif [ "$IS_PRERELEASE" = "true" ]; then
-            npm version "pre${VERSION_TYPE}" --preid=rc --no-git-tag-version
+            npm version "pre${VERSION_TYPE}" --preid=rc --no-git-tag-version --workspaces=false
             NEW_VERSION=$(node -p "require('./package.json').version")
           else
-            npm version "$VERSION_TYPE" --no-git-tag-version
+            npm version "$VERSION_TYPE" --no-git-tag-version --workspaces=false
             NEW_VERSION=$(node -p "require('./package.json').version")
           fi
 


### PR DESCRIPTION
## Summary

- keep `npm version` scoped to the conformance package instead of traversing the Bun monorepo workspace
- apply the same isolation to stable, initial RC, and RC-bump paths

## Context

The validated 1.0.1 release run stopped before tagging or publishing because npm 11 traversed the root workspace and rejected unrelated `workspace:*` dependencies. The release package itself has no workspace dependency.

## Verification

- isolated worktrees: `patch` → `1.0.1`, `prepatch` → `1.0.1-rc.0`, `prerelease` → `1.0.1-rc.0`
- each command changed only `packages/conformance/package.json`
- `bun --cwd packages/conformance test` (29 tests)
- `git diff --check`
