### PR TITLE
fix(godot): verify notarization without stapling frameworks

### DIFF
--- a/.github/workflows/release-godot.yml
+++ b/.github/workflows/release-godot.yml
@@ -411,7 +411,6 @@ jobs:
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
-          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           if [ -z "$APP_STORE_CONNECT_API_KEY_BASE64" ] || \
              [ -z "$APP_STORE_CONNECT_API_KEY_ID" ] || \
@@ -423,6 +422,8 @@ jobs:
           API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
           echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$API_KEY_PATH"
           NOTARY_ZIP="$RUNNER_TEMP/godot-iap-macos-notary.zip"
+          NOTARY_RESULT="$RUNNER_TEMP/godot-iap-macos-notary-result.json"
+          NOTARY_LOG="$RUNNER_TEMP/godot-iap-macos-notary-log.json"
 
           cd dist/addons/godot-iap/bin
           zip -yr "$NOTARY_ZIP" macos
@@ -434,16 +435,20 @@ jobs:
             --key-id "$APP_STORE_CONNECT_API_KEY_ID" \
             --issuer "$APP_STORE_CONNECT_API_ISSUER_ID" \
             --wait \
-            --timeout 30m
+            --timeout 30m \
+            --output-format json > "$NOTARY_RESULT"
 
-          xcrun stapler staple -v dist/addons/godot-iap/bin/macos/SwiftGodotRuntime.framework
-          xcrun stapler staple -v dist/addons/godot-iap/bin/macos/GodotIap.framework
-          xcrun stapler validate -v dist/addons/godot-iap/bin/macos/SwiftGodotRuntime.framework
-          xcrun stapler validate -v dist/addons/godot-iap/bin/macos/GodotIap.framework
+          SUBMISSION_ID="$(jq -r '.id // empty' "$NOTARY_RESULT")"
+          test "$(jq -r '.status // empty' "$NOTARY_RESULT")" = "Accepted"
+          test -n "$SUBMISSION_ID"
 
-          rm "godot-iap-$VERSION.zip"
-          cd dist
-          zip -yr "../godot-iap-$VERSION.zip" addons
+          xcrun notarytool log \
+            "$SUBMISSION_ID" \
+            "$NOTARY_LOG" \
+            --key "$API_KEY_PATH" \
+            --key-id "$APP_STORE_CONNECT_API_KEY_ID" \
+            --issuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+          test "$(jq '[.issues[]? | select(.severity == "error")] | length' "$NOTARY_LOG")" = "0"
 
       - name: Verify release zip
         env:
@@ -461,10 +466,6 @@ jobs:
             grep -q '^macos\.' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
             codesign --verify --deep --strict --verbose=2 "$VERIFY_DIR/addons/godot-iap/bin/macos/SwiftGodotRuntime.framework"
             codesign --verify --deep --strict --verbose=2 "$VERIFY_DIR/addons/godot-iap/bin/macos/GodotIap.framework"
-            xcrun stapler validate -v "$VERIFY_DIR/addons/godot-iap/bin/macos/SwiftGodotRuntime.framework"
-            xcrun stapler validate -v "$VERIFY_DIR/addons/godot-iap/bin/macos/GodotIap.framework"
-            spctl -a -vv --type execute "$VERIFY_DIR/addons/godot-iap/bin/macos/SwiftGodotRuntime.framework"
-            spctl -a -vv --type execute "$VERIFY_DIR/addons/godot-iap/bin/macos/GodotIap.framework"
           else
             grep -q '^supported_platforms = \["ios"\]' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
             test ! -d "$VERIFY_DIR/addons/godot-iap/bin/macos"

--- a/scripts/release-branch-policy.test.mjs
+++ b/scripts/release-branch-policy.test.mjs
@@ -1572,6 +1572,15 @@ test("Godot imports and removes signing credentials around codesigning", () => {
   assert.match(workflow.slice(cleanup, mutation), /security delete-keychain/u);
 });
 
+test("Godot verifies notarization without stapling flat frameworks", () => {
+  const workflow = readWorkflow("release-godot.yml");
+  const notarize = extractNamedStep(workflow, "Notarize macOS frameworks");
+  assert.match(notarize.source, /--output-format json/u);
+  assert.match(notarize.source, /\.status \/\/ empty/u);
+  assert.match(notarize.source, /xcrun notarytool log/u);
+  assert.doesNotMatch(workflow, /xcrun stapler/u);
+});
+
 test("next receives the same core and framework CI coverage", () => {
   const coreCi = readWorkflow("ci.yml");
   assert.equal((coreCi.match(/^\s+- next$/gm) ?? []).length, 2);


### PR DESCRIPTION
## Summary

- capture and validate the structured `notarytool submit` result
- retrieve the notarization log and fail on any error-severity issue
- stop stapling flat `.framework` bundles, which `stapler` does not support

## Verification

- `actionlint .github/workflows/release-godot.yml`
- `node --test scripts/release-branch-policy.test.mjs` (35 passed)
- `bun run audit:release-state`
- accepted Apple notarization submission log verified with zero errors