### PR TITLE
feat(docs): show IAPKit usage in app showcase

### DIFF
--- a/.claude/skills/add-showcase-app/SKILL.md
+++ b/.claude/skills/add-showcase-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-showcase-app
-description: Add an app to the OpenIAP "Who uses OpenIAP?" showcase — download and mask its icon, append the showcase-apps.json entry, refresh the review-count ordering metrics, and verify the docs build. Use when someone submits an app through issue #280, a showcase pull request, X, or email, or when the user asks to add or update an app on openiap.dev/showcase.
+description: Add one or more apps to the OpenIAP "Who uses OpenIAP?" showcase — record OpenIAP library and IAPKit usage, normalize icons, refresh ordering metrics, and verify the docs build. Use when someone submits apps through discussion #350, a showcase pull request, X, or email, or when the user asks to add or update apps on openiap.dev/showcase.
 ---
 
 # Add Showcase App (Claude Code)

--- a/.codex/skills/add-showcase-app/SKILL.md
+++ b/.codex/skills/add-showcase-app/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: add-showcase-app
-description: Add an app to the OpenIAP "Who uses OpenIAP?" showcase — download and mask its icon, append the showcase-apps.json entry, refresh the review-count ordering metrics, and verify the docs build. Use when someone submits an app through issue #280, a showcase pull request, X, or email, or when the user asks to add or update an app on openiap.dev/showcase.
+description: Add one or more apps to the OpenIAP "Who uses OpenIAP?" showcase — record OpenIAP library and IAPKit usage, normalize icons, refresh ordering metrics, and verify the docs build. Use when someone submits apps through discussion #350, a showcase pull request, X, or email, or when the user asks to add or update apps on openiap.dev/showcase.
 ---
 
 # Add Showcase App
 
-Turn an app submission into a rendered card on the home page and `/showcase`.
+Turn app submissions into rendered cards on the home page and `/showcase`.
 
 Everything lives in `packages/docs`:
 
-| Path                                        | Role                                     |
-| ------------------------------------------- | ---------------------------------------- |
-| `showcase-apps.json`                        | The list (SSOT for what renders)         |
-| `public/showcase/<slug>.webp`               | Masked 256×256 app icon                  |
-| `scripts/refresh-showcase-metrics.mjs`      | Fills `ratings` / `installs` for ordering |
-| `src/lib/showcase.ts`                       | Sorting + featured slice                 |
-| `src/components/ShowcaseCards.tsx`          | Card markup                              |
-| `SHOWCASE.md`                               | Public submission guide                  |
+| Path                                   | Role                                      |
+| -------------------------------------- | ----------------------------------------- |
+| `showcase-apps.json`                   | The list (SSOT for what renders)          |
+| `public/showcase/<slug>.webp`          | Masked 256×256 app icon                   |
+| `scripts/refresh-showcase-metrics.mjs` | Fills `ratings` / `installs` for ordering |
+| `src/lib/showcase.ts`                  | Sorting + featured slice                  |
+| `src/components/ShowcaseCards.tsx`     | Card markup                               |
+| `SHOWCASE.md`                          | Public submission guide                   |
 
 ## 1. Collect the submission
 
@@ -28,11 +28,15 @@ Required from the submitter:
 - **Store links** — App Store and/or Google Play; a website link is optional
 - **Library** — one of `expo-iap`, `react-native-iap`, `flutter_inapp_purchase`,
   `kmp-iap`, `maui-iap`, `godot-iap`
+- **IAPKit usage** — whether the app uses IAPKit for receipt validation
+
+When one submitter sends multiple apps, include every app in one pull request.
+Do not split the apps into separate pull requests.
 
 Only list an app when the submitter asked for it. A comment on
-[issue #280](https://github.com/hyodotdev/openiap/issues/280), a showcase PR, an
-email, or a public reply to the announcement all count as permission; a mention
-of the library somewhere else does not.
+[discussion #350](https://github.com/hyodotdev/openiap/discussions/350), a
+showcase PR, an email, or a public reply to the announcement all count as
+permission; a mention of the library somewhere else does not.
 
 If the icon is missing, pull it from the stores rather than asking again:
 
@@ -89,13 +93,16 @@ Ordering is computed at render time, so position in the file does not matter.
   "tagline": "One line about what the app does",
   "logo": "/showcase/your-app.webp",
   "library": "expo-iap",
+  "iapkit": true,
   "ios": "https://apps.apple.com/us/app/your-app/id0000000000",
   "android": "https://play.google.com/store/apps/details?id=com.example.yourapp"
 }
 ```
 
 `ios`, `android`, and `web` are each optional, but an entry with none of them is
-dropped at render time. Leave `ratings` and `installs` out — step 4 writes them.
+dropped at render time. Set `iapkit` to `true` only when the submitter confirms
+IAPKit usage; omit it otherwise. Leave `ratings` and `installs` out — step 4
+writes them.
 
 ## 4. Refresh the ordering metrics
 
@@ -140,7 +147,7 @@ link; `/showcase` lists everything.
 
 ## 6. Close the loop
 
-- Reply to the submission thread (issue #280 comment, PR, or email) confirming
+- Reply to the submission thread (discussion #350, PR, or email) confirming
   the app is listed, and note that updates or removal are available anytime.
 - Public GitHub replies must be in English — see
   `knowledge/internal/06-git-deployment.md`.

--- a/packages/docs/SHOWCASE.md
+++ b/packages/docs/SHOWCASE.md
@@ -4,7 +4,10 @@ Shipped an app with `react-native-iap`, `expo-iap`, `flutter_inapp_purchase`,
 `kmp-iap`, `maui-iap`, or `godot-iap`? Add it to the
 **[Who uses OpenIAP?](https://www.openiap.dev)** section on the home page.
 
-It's one entry in [`showcase-apps.json`](./showcase-apps.json).
+Each app is one entry in [`showcase-apps.json`](./showcase-apps.json).
+
+Submitting more than one app? Add every app and icon to the same pull request.
+Do not open one pull request per app.
 
 ## Open a pull request
 
@@ -17,6 +20,7 @@ It's one entry in [`showcase-apps.json`](./showcase-apps.json).
      "tagline": "One line about what your app does",
      "logo": "/showcase/your-app.webp",
      "library": "expo-iap",
+     "iapkit": true,
      "ios": "https://apps.apple.com/us/app/your-app/id0000000000",
      "android": "https://play.google.com/store/apps/details?id=com.example.yourapp"
    }
@@ -52,16 +56,17 @@ Leave `ratings` and `installs` out of your PR — the script fills them in.
 
 ## Fields
 
-| Field     | Required | Notes                                                                                  |
-| --------- | -------- | -------------------------------------------------------------------------------------- |
-| `name`    | ✅       | App name as it appears on the stores.                                                   |
-| `tagline` | ✅       | One short line. Keep it under ~70 characters so cards stay even.                         |
-| `logo`    | ✅       | Path under `packages/docs/public` (e.g. `/showcase/your-app.webp`) or a full https URL.  |
-| `ratings` / `installs` | — | Maintainer-managed ordering metrics. Leave these out.                       |
-| `library` | ✅       | One of `expo-iap`, `react-native-iap`, `flutter_inapp_purchase`, `kmp-iap`, `maui-iap`, `godot-iap`. |
-| `ios`     | —        | App Store URL.                                                                          |
-| `android` | —        | Google Play URL.                                                                        |
-| `web`     | —        | Website or other store, shown as "Website".                                             |
+| Field                  | Required | Notes                                                                                                |
+| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `name`                 | ✅       | App name as it appears on the stores.                                                                |
+| `tagline`              | ✅       | One short line. Keep it under ~70 characters so cards stay even.                                     |
+| `logo`                 | ✅       | Path under `packages/docs/public` (e.g. `/showcase/your-app.webp`) or a full https URL.              |
+| `ratings` / `installs` | —        | Maintainer-managed ordering metrics. Leave these out.                                                |
+| `library`              | ✅       | One of `expo-iap`, `react-native-iap`, `flutter_inapp_purchase`, `kmp-iap`, `maui-iap`, `godot-iap`. |
+| `iapkit`               | —        | Set to `true` only when the app uses IAPKit receipt validation. Omit it otherwise.                   |
+| `ios`                  | —        | App Store URL.                                                                                       |
+| `android`              | —        | Google Play URL.                                                                                     |
+| `web`                  | —        | Website or other store, shown as "Website".                                                          |
 
 At least one of `ios`, `android`, or `web` is required — entries without a link
 are skipped at render time.
@@ -70,7 +75,7 @@ are skipped at render time.
 
 Reply to [discussion #350](https://github.com/hyodotdev/openiap/discussions/350) or
 email **hyo@hyo.dev** with your app name, one-liner, logo, store links, and which
-library you use — we'll add it for you.
+library you use. Also tell us whether you use IAPKit for receipt validation.
 
 ## Removal and updates
 

--- a/packages/docs/src/components/ShowcaseCards.tsx
+++ b/packages/docs/src/components/ShowcaseCards.tsx
@@ -47,6 +47,14 @@ const storeLinkStyle: CSSProperties = {
   textDecoration: 'none',
 };
 
+const badgeStyle: CSSProperties = {
+  fontSize: '0.72rem',
+  color: 'var(--text-secondary)',
+  border: '1px solid var(--border-color)',
+  borderRadius: '0.75rem',
+  padding: '0.1rem 0.5rem',
+};
+
 export function ShowcaseAppCard({ app }: { app: ShowcaseApp }) {
   return (
     <div style={cardStyle}>
@@ -116,18 +124,20 @@ export function ShowcaseAppCard({ app }: { app: ShowcaseApp }) {
               <Globe size={15} strokeWidth={2} />
             </a>
           ) : null}
-          <span
-            style={{
-              fontSize: '0.72rem',
-              color: 'var(--text-secondary)',
-              border: '1px solid var(--border-color)',
-              borderRadius: '0.75rem',
-              padding: '0.1rem 0.5rem',
-              marginLeft: '0.25rem',
-            }}
-          >
+          <span style={{ ...badgeStyle, marginLeft: '0.25rem' }}>
             {app.library}
           </span>
+          {app.iapkit ? (
+            <span
+              style={{
+                ...badgeStyle,
+                color: 'var(--accent-color)',
+              }}
+              title="Uses IAPKit receipt validation"
+            >
+              IAPKit
+            </span>
+          ) : null}
         </div>
       </div>
     </div>
@@ -156,7 +166,7 @@ export function ShowcaseSubmitCard() {
           color: 'var(--text-secondary)',
         }}
       >
-        Send your app name, icon, and store links — we'll add it here.
+        Send your app details and IAPKit usage — we'll add it here.
       </div>
       <a
         href={SHOWCASE_DISCUSSION_URL}

--- a/packages/docs/src/lib/showcase.ts
+++ b/packages/docs/src/lib/showcase.ts
@@ -20,6 +20,8 @@ export type ShowcaseApp = {
   logo: string;
   /** Which OpenIAP library the app ships with. */
   library: FrameworkLibraryName;
+  /** Whether the app uses IAPKit for receipt validation. */
+  iapkit?: boolean;
   ios?: string;
   android?: string;
   web?: string;

--- a/packages/docs/src/pages/showcase.tsx
+++ b/packages/docs/src/pages/showcase.tsx
@@ -13,9 +13,9 @@ function Showcase() {
     <div className="home">
       <SEO
         title="Who uses OpenIAP?"
-        description="Apps shipping in-app purchases with OpenIAP libraries — expo-iap, react-native-iap, flutter_inapp_purchase, kmp-iap, maui-iap, and godot-iap."
+        description="Showcase of apps built with OpenIAP libraries, including apps that use IAPKit receipt validation."
         path="/showcase"
-        keywords="OpenIAP apps, expo-iap apps, react-native-iap apps, in-app purchase showcase"
+        keywords="OpenIAP apps, IAPKit apps, expo-iap apps, react-native-iap apps, in-app purchase showcase"
       />
       <section className="home-section">
         <div className="section-container" style={{ maxWidth: '960px' }}>
@@ -67,9 +67,10 @@ function Showcase() {
               >
                 showcase-apps.json
               </a>
-              , or email{' '}
+              . If you have multiple apps, include them in one pull request. You
+              can also email{' '}
               <a
-                href="mailto:hyo@hyo.dev?subject=OpenIAP Showcase Request&body=App Name:%0AOne-liner:%0AApp Icon (512x512 PNG, attached):%0AStore Links:%0A- iOS: %0A- Android: %0A%0AWhich OpenIAP library do you use?"
+                href="mailto:hyo@hyo.dev?subject=OpenIAP Showcase Request&body=App Name:%0AOne-liner:%0AApp Icon (512x512 PNG, attached):%0AStore Links:%0A- iOS: %0A- Android: %0AOpenIAP library:%0AUses IAPKit (yes/no):"
                 style={{ color: 'var(--accent-color)' }}
               >
                 hyo@hyo.dev
@@ -98,6 +99,10 @@ function Showcase() {
                 <strong>Library</strong> you ship with (expo-iap,
                 react-native-iap, flutter_inapp_purchase, kmp-iap, maui-iap,
                 godot-iap)
+              </li>
+              <li>
+                <strong>IAPKit</strong> — tell us whether you use it for receipt
+                validation
               </li>
             </ul>
             <p


### PR DESCRIPTION
## Summary

- display a distinct IAPKit receipt-validation badge for confirmed showcase apps
- ask submitters to include IAPKit usage in app metadata
- require multiple apps from one submitter to be grouped in a single pull request
- update the showcase skill and public submission guide around discussion #350

## Verification

- bun run audit:docs
- packages/docs: bun run typecheck
- packages/docs: bun run build
- Prettier check for changed files
- browser verification of DriBu and RescueDogs cards and submission copy
- review-self: two consecutive clean snapshots