### PR TITLE
fix(godot): declare Apple-only GDExtension with include_tags

### DIFF
--- a/.github/workflows/ci-godot-iap.yml
+++ b/.github/workflows/ci-godot-iap.yml
@@ -75,8 +75,11 @@ jobs:
       - name: Verify GDExtension platform gating
         run: |
           EXT=addons/godot-iap/bin/godot_iap.gdextension
+          RELEASE=$GITHUB_WORKSPACE/.github/workflows/release-godot.yml
           grep -qx 'include_tags = \["ios", "macos"\]' "$EXT"
           grep -q "printf '%s\\\\n' 'include_tags = \[\"ios\", \"macos\"\]'" Makefile
+          grep -qF 'include_tags = ["ios", "macos"]' "$RELEASE"
+          grep -qF 'include_tags = ["ios"]' "$RELEASE"
           if git -C "$GITHUB_WORKSPACE" grep -nE 'supported_platforms[[:space:]]*=' \
             -- . ':!libraries/godot-iap/SwiftGodot'; then
             echo "supported_platforms is not a Godot .gdextension key; use include_tags"

--- a/.github/workflows/ci-godot-iap.yml
+++ b/.github/workflows/ci-godot-iap.yml
@@ -69,6 +69,21 @@ jobs:
           test -f addons/godot-iap/godot_iap.gd
           echo "All required plugin files exist"
 
+      # The same [configuration] block is written in three places: this
+      # tracked file, the Makefile that regenerates it, and the release
+      # workflow that builds the zip. They drifted once (#366), so pin them.
+      - name: Verify GDExtension platform gating
+        run: |
+          EXT=addons/godot-iap/bin/godot_iap.gdextension
+          grep -qx 'include_tags = \["ios", "macos"\]' "$EXT"
+          grep -q "printf '%s\\\\n' 'include_tags = \[\"ios\", \"macos\"\]'" Makefile
+          if git -C "$GITHUB_WORKSPACE" grep -nE 'supported_platforms[[:space:]]*=' \
+            -- . ':!libraries/godot-iap/SwiftGodot'; then
+            echo "supported_platforms is not a Godot .gdextension key; use include_tags"
+            exit 1
+          fi
+          echo "GDExtension platform gating is consistent"
+
       - name: Verify Android plugin files exist
         run: |
           test -f android/build.gradle.kts

--- a/.github/workflows/release-godot.yml
+++ b/.github/workflows/release-godot.yml
@@ -371,7 +371,7 @@ jobs:
           [configuration]
           entry_symbol = "godot_iap_entry_point"
           compatibility_minimum = "4.3"
-          supported_platforms = ["ios", "macos"]
+          include_tags = ["ios", "macos"]
 
           [libraries]
           ios.arm64 = "ios/GodotIap.framework/GodotIap"
@@ -388,7 +388,7 @@ jobs:
           [configuration]
           entry_symbol = "godot_iap_entry_point"
           compatibility_minimum = "4.3"
-          supported_platforms = ["ios"]
+          include_tags = ["ios"]
 
           [libraries]
           ios.arm64 = "ios/GodotIap.framework/GodotIap"
@@ -462,12 +462,12 @@ jobs:
           test -d "$VERIFY_DIR/addons/godot-iap/bin/ios/SwiftGodotRuntime.framework"
           bash scripts/verify-ios-toolchain.sh "$VERIFY_DIR/addons/godot-iap/bin/ios"
           if [ "$NOTARIZE_MACOS" = "true" ]; then
-            grep -q '^supported_platforms = \["ios", "macos"\]' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
+            grep -q '^include_tags = \["ios", "macos"\]' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
             grep -q '^macos\.' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
             codesign --verify --deep --strict --verbose=2 "$VERIFY_DIR/addons/godot-iap/bin/macos/SwiftGodotRuntime.framework"
             codesign --verify --deep --strict --verbose=2 "$VERIFY_DIR/addons/godot-iap/bin/macos/GodotIap.framework"
           else
-            grep -q '^supported_platforms = \["ios"\]' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
+            grep -q '^include_tags = \["ios"\]' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
             test ! -d "$VERIFY_DIR/addons/godot-iap/bin/macos"
             if grep -q '^macos\.' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"; then
               echo "Error: default release zip must not declare macOS libraries"

--- a/libraries/godot-iap/.claude/guides/03-ios-plugin.md
+++ b/libraries/godot-iap/.claude/guides/03-ios-plugin.md
@@ -40,7 +40,7 @@ Godot export doesn't embed frameworks automatically. The `scripts/fix_ios_embed.
 [configuration]
 entry_symbol = "godot_iap_entry_point"
 compatibility_minimum = "4.3"
-supported_platforms = ["ios", "macos"]
+include_tags = ["ios", "macos"]
 
 [libraries]
 ios.arm64 = "ios/GodotIap.framework/GodotIap"

--- a/libraries/godot-iap/Makefile
+++ b/libraries/godot-iap/Makefile
@@ -175,7 +175,7 @@ macos-build:
 		printf '%s\n' '[configuration]'; \
 		printf '%s\n' 'entry_symbol = "godot_iap_entry_point"'; \
 		printf '%s\n' 'compatibility_minimum = "4.3"'; \
-		printf '%s\n' 'supported_platforms = ["ios", "macos"]'; \
+		printf '%s\n' 'include_tags = ["ios", "macos"]'; \
 		printf '\n%s\n' '[libraries]'; \
 		printf '%s\n' 'ios.arm64 = "ios/GodotIap.framework/GodotIap"'; \
 		printf '%s\n' 'macos.arm64 = "macos/GodotIap.framework/GodotIap"'; \

--- a/libraries/godot-iap/addons/godot-iap/bin/godot_iap.gdextension
+++ b/libraries/godot-iap/addons/godot-iap/bin/godot_iap.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 entry_symbol = "godot_iap_entry_point"
 compatibility_minimum = "4.3"
-supported_platforms = ["ios", "macos"]
+include_tags = ["ios", "macos"]
 
 [libraries]
 ios.arm64 = "ios/GodotIap.framework/GodotIap"

--- a/packages/docs/src/pages/docs/setup/godot.tsx
+++ b/packages/docs/src/pages/docs/setup/godot.tsx
@@ -659,6 +659,46 @@ func _on_purchase_error(error):
           <a href="#ios-xcode">iOS: Xcode Framework Embedding</a> and run{' '}
           <code>fix_ios_embed.sh</code>.
         </p>
+
+        <h3 id="gdextension-non-apple-editor" className="anchor-heading">
+          GDExtension errors in the Windows or Linux editor
+          <a href="#gdextension-non-apple-editor" className="anchor-link">
+            #
+          </a>
+        </h3>
+        <p>
+          The bundled GDExtension ships Apple libraries only, so editors on
+          Windows and Linux log{' '}
+          <code>
+            No GDExtension library found for current OS and architecture
+          </code>{' '}
+          each time the project is scanned. Android is unaffected: it loads the
+          AAR plugin from <code>addons/godot-iap/android/</code>, and Android
+          exports keep working.
+        </p>
+        <p>
+          Godot 4.8 skips the extension silently, because the addon declares{' '}
+          <code>include_tags</code>. Godot 4.3 through 4.7 have no way to
+          suppress the message (
+          <a
+            href="https://github.com/godotengine/godot/issues/105615"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            godotengine/godot#105615
+          </a>
+          ). While developing for Android on a non-Apple machine, rename the
+          file:
+        </p>
+        <CodeBlock language="bash">
+          {`mv addons/godot-iap/bin/godot_iap.gdextension \\
+   addons/godot-iap/bin/godot_iap.gdextension.disabled`}
+        </CodeBlock>
+        <p>
+          Restore the name before building for iOS or macOS. Those builds
+          require a Mac, so nothing in <code>bin/</code> is usable from a
+          Windows or Linux machine in the meantime.
+        </p>
       </section>
 
       <section>


### PR DESCRIPTION
Closes #366.

## What was wrong

The addon's `.gdextension` declared:

```ini
supported_platforms = ["ios", "macos"]
```

`supported_platforms` is not part of the `.gdextension` format — Godot's loader never reads it. The documented keys are `entry_symbol`, `compatibility_minimum`, `compatibility_maximum`, `reloadable`, and `android_aar_plugin`. So the platform gate we thought we had never existed: on a Windows or Linux editor the loader fell straight through to the library search, found no matching entry, and printed the two errors in the report on every project scan.

## What changed

`include_tags = ["ios", "macos"]` replaces it in the checked-in addon, both release-zip variants, the release verification greps, and the iOS plugin guide. The loader evaluates `include_tags` *before* searching `[libraries]` and returns `ERR_SKIP`; `GDExtensionManager` maps that to `LOAD_STATUS_NOT_LOADED` and returns without logging, so both messages disappear.

## Honest limitation

`include_tags` only exists in Godot **master (4.8-dev)** — it is absent from the 4.3, 4.4, 4.5, 4.6, and 4.7 branches. The reporter's log line (`gdextension_library_loader.cpp:369`) matches the 4.7 branch exactly, so this change alone does not silence their editor today; upstream [godotengine/godot#105615](https://github.com/godotengine/godot/issues/105615) is still open with no released fix.

For 4.3–4.7 the Godot setup docs now carry the workaround the reporter found — renaming `godot_iap.gdextension` to `.disabled` while developing for Android — with the reason it is safe: iOS and macOS builds need a Mac, so nothing in `bin/` is usable from a Windows or Linux machine, and Android keeps loading the AAR from `addons/godot-iap/android/`.

The key is inert on older versions (unknown keys are ignored), so shipping it now means users get silent skipping for free when they upgrade to 4.8.

## Verification

- `bun run audit:docs`, `bun run audit:parity`, workflow security audit, docs typecheck — all clean.
- Release workflow verification greps updated in lockstep, so a future edit that drops the key fails the release job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Godot extension platform configuration for iOS and macOS releases.
  - Updated release checks to accurately verify Apple platform packages.
  - Added validation to prevent unsupported platform configuration keys.

- **Documentation**
  - Added troubleshooting guidance for GDExtension warnings in Windows and Linux editors.
  - Clarified Android behavior, Godot version differences, and a temporary workaround for non-Apple development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->