### PR TITLE
fix: make the release sync guard actually catch the bug it guards

### DIFF
--- a/packages/docs/src/pages/docs/updates/releases.tsx
+++ b/packages/docs/src/pages/docs/updates/releases.tsx
@@ -276,8 +276,8 @@ function Releases() {
             }}
           >
             godot-iap 3.3.3 declares the Apple-only GDExtension with the key
-            Godot actually reads, so editors on Windows and Linux stop logging a
-            missing-library error on every project scan.
+            Godot actually reads, so Godot 4.8 editors on Windows and Linux skip
+            it instead of logging a missing-library error on every project scan.
           </p>
 
           <h5 style={{ margin: '0 0 0.5rem 0' }}>Framework libraries</h5>

--- a/scripts/audit-release-sync-script.mjs
+++ b/scripts/audit-release-sync-script.mjs
@@ -14,7 +14,7 @@ import {
   accessSync,
   constants,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -60,6 +60,14 @@ export function toLogicalLines(source) {
   return logical;
 }
 
+// git refuses to stage outside the work tree, so a token that escapes the
+// repository fails the release rather than this audit unless caught here.
+function insideRepo(target) {
+  const rel = relative(REPO_ROOT, target);
+  // An empty relative path is REPO_ROOT itself, which `git add .` stages.
+  return !rel.startsWith("..") && !isAbsolute(rel);
+}
+
 function isRunnable(target) {
   if (statSync(target).isDirectory()) return false;
   try {
@@ -103,7 +111,14 @@ export function auditGitAddBlocks(source) {
       .filter((token) => token && !token.startsWith("-"))
       .forEach((token) => {
         if (token.includes("$") || token.includes("*")) return;
-        if (!existsSync(join(REPO_ROOT, token))) {
+        const target = resolve(REPO_ROOT, token);
+        if (!insideRepo(target)) {
+          failures.push(
+            `${SCRIPT}:${line}: staged path escapes the repository: ${token}`,
+          );
+          return;
+        }
+        if (!existsSync(target)) {
           failures.push(
             `${SCRIPT}:${line}: staged path does not exist: ${token}`,
           );

--- a/scripts/audit-release-sync-script.mjs
+++ b/scripts/audit-release-sync-script.mjs
@@ -1,65 +1,113 @@
 #!/usr/bin/env node
-// The release lanes all call sync-release-generated.sh, and nothing else ever
-// runs it — a dropped line continuation in its `git add` shipped once and only
-// surfaced mid-release (exit 126, the next path ran as a command). Neither
-// `bash -n` nor shellcheck flags that, so check the shape here.
+// Every release lane calls sync-release-generated.sh and nothing else runs it,
+// so a dropped line continuation in its `git add` shipped once and only
+// surfaced mid-release: bash ended the command early and ran the next path as
+// a command (exit 126, "is a directory"). Neither `bash -n` nor shellcheck
+// flags that — an orphaned path is a syntactically valid command — so this
+// audit reproduces bash's own continuation rules and then asserts that no
+// logical command starts with a repository path.
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync, accessSync, constants } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = 'scripts/sync-release-generated.sh';
+
+// A line continues only when it ends in an odd number of backslashes at the
+// very end of the line. `foo \ ` (backslash, space) is an escaped space, so
+// bash ends the command there — the exact trap the previous check missed.
+function continuesLine(line) {
+  const match = /(\\+)$/u.exec(line);
+  return match ? match[1].length % 2 === 1 : false;
+}
+
+export function toLogicalLines(source) {
+  const logical = [];
+  let buffer = null;
+
+  source.split('\n').forEach((raw, index) => {
+    const isContinuation = buffer !== null;
+    const text = isContinuation ? raw : raw.replace(/^\s+/u, '');
+
+    if (!isContinuation && (text === '' || text.startsWith('#'))) return;
+
+    if (continuesLine(raw)) {
+      const joined = text.replace(/\\$/u, '').trim();
+      buffer = buffer
+        ? { ...buffer, text: `${buffer.text} ${joined}` }
+        : { line: index + 1, text: joined };
+      return;
+    }
+
+    logical.push(
+      buffer
+        ? { line: buffer.line, text: `${buffer.text} ${text.trim()}` }
+        : { line: index + 1, text },
+    );
+    buffer = null;
+  });
+
+  if (buffer) logical.push(buffer);
+  return logical;
+}
+
+function isRunnable(target) {
+  if (statSync(target).isDirectory()) return false;
+  try {
+    accessSync(target, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export function auditGitAddBlocks(source) {
   const failures = [];
-  const lines = source.split('\n');
+  const logical = toLogicalLines(source);
+  let sawGitAdd = false;
 
-  lines.forEach((line, index) => {
-    if (!/^\s*git add\s*\\\s*$/.test(line)) return;
+  logical.forEach(({ line, text }) => {
+    const first = text.trim().split(/\s+/u)[0] ?? '';
 
-    for (let i = index + 1; i < lines.length; i += 1) {
-      const raw = lines[i];
-      const continues = /\\\s*$/.test(raw);
-      const path = raw.replace(/\\\s*$/, '').trim();
-
-      if (path === '') {
-        failures.push(`${SCRIPT}:${i + 1}: blank line inside the git add list`);
-        break;
-      }
-
-      failures.push(...auditPath(path, i + 1));
-
-      if (!continues) {
-        // Last entry. A following indented path means a lost continuation.
-        const next = lines[i + 1] ?? '';
-        if (/^\s+\S/.test(next) && !/^\s*(#|fi\b|done\b|esac\b|\})/.test(next)) {
-          failures.push(
-            `${SCRIPT}:${i + 1}: git add list ends here but line ${i + 2} ` +
-              `("${next.trim()}") is indented — a lost "\\" would run it as a command`,
-          );
-        }
-        break;
+    // Running a path is fine when it is an executable script; a directory or
+    // a plain file can only have become a command by accident.
+    if (first.includes('/') && !first.startsWith('$') && !first.startsWith('"')) {
+      const target = join(REPO_ROOT, first.replace(/^\.\//u, ''));
+      if (existsSync(target) && !isRunnable(target)) {
+        failures.push(
+          `${SCRIPT}:${line}: "${first}" runs as a command; a line above it lost its "\\"`,
+        );
       }
     }
+
+    if (!/^git add\b/u.test(text.trim())) return;
+    sawGitAdd = true;
+
+    text
+      .trim()
+      .replace(/^git add\s*/u, '')
+      .split(/\s+/u)
+      .filter((token) => token && !token.startsWith('-'))
+      .forEach((token) => {
+        if (token.includes('$') || token.includes('*')) return;
+        if (!existsSync(join(REPO_ROOT, token))) {
+          failures.push(`${SCRIPT}:${line}: staged path does not exist: ${token}`);
+        }
+      });
   });
 
-  if (!/^\s*git add\s*\\\s*$/m.test(source)) {
-    failures.push(`${SCRIPT}: no multi-line git add block found`);
-  }
-
+  if (!sawGitAdd) failures.push(`${SCRIPT}: no git add command found`);
   return failures;
 }
 
-function auditPath(path, line) {
-  if (path.includes('$') || path.includes('*')) return [];
-  return existsSync(path)
-    ? []
-    : [`${SCRIPT}:${line}: staged path does not exist: ${path}`];
-}
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  const failures = auditGitAddBlocks(readFileSync(SCRIPT, 'utf8'));
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const failures = auditGitAddBlocks(
+    readFileSync(join(REPO_ROOT, SCRIPT), 'utf8'),
+  );
   if (failures.length) {
     console.error('Release sync script audit failed:');
-    failures.forEach((f) => console.error(`- ${f}`));
+    failures.forEach((failure) => console.error(`- ${failure}`));
     process.exit(1);
   }
   console.log('Release sync script audit passed.');

--- a/scripts/audit-release-sync-script.mjs
+++ b/scripts/audit-release-sync-script.mjs
@@ -7,12 +7,18 @@
 // audit reproduces bash's own continuation rules and then asserts that no
 // logical command starts with a repository path.
 
-import { readFileSync, existsSync, statSync, accessSync, constants } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import {
+  readFileSync,
+  existsSync,
+  statSync,
+  accessSync,
+  constants,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SCRIPT = 'scripts/sync-release-generated.sh';
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = "scripts/sync-release-generated.sh";
 
 // A line continues only when it ends in an odd number of backslashes at the
 // very end of the line. `foo \ ` (backslash, space) is an escaped space, so
@@ -26,23 +32,25 @@ export function toLogicalLines(source) {
   const logical = [];
   let buffer = null;
 
-  source.split('\n').forEach((raw, index) => {
+  source.split("\n").forEach((raw, index) => {
     const isContinuation = buffer !== null;
-    const text = isContinuation ? raw : raw.replace(/^\s+/u, '');
+    const text = isContinuation ? raw : raw.replace(/^\s+/u, "");
 
-    if (!isContinuation && (text === '' || text.startsWith('#'))) return;
+    if (!isContinuation && (text === "" || text.startsWith("#"))) return;
 
+    // Bash deletes the backslash-newline pair outright, so `a\<newline>b` is
+    // the single token `ab`. Concatenate rather than joining with a space.
     if (continuesLine(raw)) {
-      const joined = text.replace(/\\$/u, '').trim();
+      const joined = text.replace(/\\$/u, "");
       buffer = buffer
-        ? { ...buffer, text: `${buffer.text} ${joined}` }
+        ? { ...buffer, text: buffer.text + joined }
         : { line: index + 1, text: joined };
       return;
     }
 
     logical.push(
       buffer
-        ? { line: buffer.line, text: `${buffer.text} ${text.trim()}` }
+        ? { line: buffer.line, text: buffer.text + text }
         : { line: index + 1, text },
     );
     buffer = null;
@@ -68,12 +76,16 @@ export function auditGitAddBlocks(source) {
   let sawGitAdd = false;
 
   logical.forEach(({ line, text }) => {
-    const first = text.trim().split(/\s+/u)[0] ?? '';
+    const first = text.trim().split(/\s+/u)[0] ?? "";
 
     // Running a path is fine when it is an executable script; a directory or
     // a plain file can only have become a command by accident.
-    if (first.includes('/') && !first.startsWith('$') && !first.startsWith('"')) {
-      const target = join(REPO_ROOT, first.replace(/^\.\//u, ''));
+    if (
+      first.includes("/") &&
+      !first.startsWith("$") &&
+      !first.startsWith('"')
+    ) {
+      const target = join(REPO_ROOT, first.replace(/^\.\//u, ""));
       if (existsSync(target) && !isRunnable(target)) {
         failures.push(
           `${SCRIPT}:${line}: "${first}" runs as a command; a line above it lost its "\\"`,
@@ -86,13 +98,15 @@ export function auditGitAddBlocks(source) {
 
     text
       .trim()
-      .replace(/^git add\s*/u, '')
+      .replace(/^git add\s*/u, "")
       .split(/\s+/u)
-      .filter((token) => token && !token.startsWith('-'))
+      .filter((token) => token && !token.startsWith("-"))
       .forEach((token) => {
-        if (token.includes('$') || token.includes('*')) return;
+        if (token.includes("$") || token.includes("*")) return;
         if (!existsSync(join(REPO_ROOT, token))) {
-          failures.push(`${SCRIPT}:${line}: staged path does not exist: ${token}`);
+          failures.push(
+            `${SCRIPT}:${line}: staged path does not exist: ${token}`,
+          );
         }
       });
   });
@@ -103,12 +117,12 @@ export function auditGitAddBlocks(source) {
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
   const failures = auditGitAddBlocks(
-    readFileSync(join(REPO_ROOT, SCRIPT), 'utf8'),
+    readFileSync(join(REPO_ROOT, SCRIPT), "utf8"),
   );
   if (failures.length) {
-    console.error('Release sync script audit failed:');
+    console.error("Release sync script audit failed:");
     failures.forEach((failure) => console.error(`- ${failure}`));
     process.exit(1);
   }
-  console.log('Release sync script audit passed.');
+  console.log("Release sync script audit passed.");
 }

--- a/scripts/audit-release-sync-script.test.mjs
+++ b/scripts/audit-release-sync-script.test.mjs
@@ -1,85 +1,98 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   auditGitAddBlocks,
   toLogicalLines,
-} from './audit-release-sync-script.mjs';
+} from "./audit-release-sync-script.mjs";
 
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-const HEAD = ['git add \\', '  packages/docs/public/llms.txt \\'];
+const HEAD = ["git add \\", "  packages/docs/public/llms.txt \\"];
 
 function orphaned(...between) {
   return [
     ...HEAD,
-    '  knowledge/_agent-context/context.md',
+    "  knowledge/_agent-context/context.md",
     ...between,
-    '  knowledge/_claude-context',
-  ].join('\n');
+    "  knowledge/_claude-context",
+  ].join("\n");
 }
 
-test('catches the dropped continuation that broke a release', () => {
+test("catches the dropped continuation that broke a release", () => {
   const failures = auditGitAddBlocks(orphaned());
   assert.equal(failures.length, 1);
   assert.match(failures[0], /runs as a command/u);
 });
 
-test('catches an orphaned path separated by a blank line', () => {
-  assert.match(auditGitAddBlocks(orphaned(''))[0], /runs as a command/u);
+test("catches an orphaned path separated by a blank line", () => {
+  assert.match(auditGitAddBlocks(orphaned(""))[0], /runs as a command/u);
 });
 
-test('catches an orphaned path separated by a comment', () => {
+test("catches an orphaned path separated by a comment", () => {
   assert.match(
-    auditGitAddBlocks(orphaned('  # agent context symlink'))[0],
+    auditGitAddBlocks(orphaned("  # agent context symlink"))[0],
     /runs as a command/u,
   );
 });
 
-test('treats a backslash followed by a space as the end of the command', () => {
+test("treats a backslash followed by a space as the end of the command", () => {
   // `\ ` is an escaped space in bash, not a continuation.
-  const source = ['git add \\ ', '  knowledge/_claude-context'].join('\n');
+  const source = ["git add \\ ", "  knowledge/_claude-context"].join("\n");
   assert.ok(auditGitAddBlocks(source).length > 0);
 });
 
-test('accepts the list once every continuation is intact', () => {
+test("accepts the list once every continuation is intact", () => {
   const source = [
     ...HEAD,
-    '  knowledge/_agent-context/context.md \\',
-    '  knowledge/_claude-context',
-  ].join('\n');
+    "  knowledge/_agent-context/context.md \\",
+    "  knowledge/_claude-context",
+  ].join("\n");
   assert.deepEqual(auditGitAddBlocks(source), []);
 });
 
-test('allows running an executable script by path', () => {
+test("allows running an executable script by path", () => {
   assert.deepEqual(
-    auditGitAddBlocks(['./scripts/sync-versions.sh', 'git add .'].join('\n')),
+    auditGitAddBlocks(["./scripts/sync-versions.sh", "git add ."].join("\n")),
     [],
   );
 });
 
-test('reports a staged path that no longer exists', () => {
-  const source = ['git add \\', '  knowledge/_removed-context/context.md'].join(
-    '\n',
+test("reports a staged path that no longer exists", () => {
+  const source = ["git add \\", "  knowledge/_removed-context/context.md"].join(
+    "\n",
   );
   assert.match(auditGitAddBlocks(source)[0], /staged path does not exist/u);
 });
 
-test('joins continued lines into one logical command', () => {
-  const logical = toLogicalLines(['git add \\', '  a \\', '  b'].join('\n'));
-  assert.deepEqual(
-    logical.map((entry) => entry.text),
-    ['git add a b'],
-  );
+test("joins continued lines into one logical command", () => {
+  const logical = toLogicalLines(["git add \\", "  a \\", "  b"].join("\n"));
+  assert.equal(logical.length, 1);
+  assert.deepEqual(logical[0].text.trim().split(/\s+/u), [
+    "git",
+    "add",
+    "a",
+    "b",
+  ]);
 });
 
-test('the committed script passes its own audit', () => {
+test("keeps a token split across a continuation adjacent, as bash does", () => {
+  // bash deletes the backslash-newline pair: `llms.tx\<newline>t` is llms.txt.
+  const logical = toLogicalLines(
+    ["git add packages/docs/public/llms.tx\\", "t"].join("\n"),
+  );
+  assert.equal(logical.length, 1);
+  assert.equal(logical[0].text, "git add packages/docs/public/llms.txt");
+  assert.deepEqual(auditGitAddBlocks(logical[0].text), []);
+});
+
+test("the committed script passes its own audit", () => {
   const source = readFileSync(
-    join(REPO_ROOT, 'scripts/sync-release-generated.sh'),
-    'utf8',
+    join(REPO_ROOT, "scripts/sync-release-generated.sh"),
+    "utf8",
   );
   assert.deepEqual(auditGitAddBlocks(source), []);
 });

--- a/scripts/audit-release-sync-script.test.mjs
+++ b/scripts/audit-release-sync-script.test.mjs
@@ -1,44 +1,85 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import { auditGitAddBlocks } from './audit-release-sync-script.mjs';
+import {
+  auditGitAddBlocks,
+  toLogicalLines,
+} from './audit-release-sync-script.mjs';
 
-test('catches the dropped line continuation that broke a release', () => {
-  const broken = [
-    'git add \\',
-    '  packages/docs/public/llms.txt \\',
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const HEAD = ['git add \\', '  packages/docs/public/llms.txt \\'];
+
+function orphaned(...between) {
+  return [
+    ...HEAD,
     '  knowledge/_agent-context/context.md',
+    ...between,
     '  knowledge/_claude-context',
   ].join('\n');
+}
 
-  const failures = auditGitAddBlocks(broken);
+test('catches the dropped continuation that broke a release', () => {
+  const failures = auditGitAddBlocks(orphaned());
   assert.equal(failures.length, 1);
-  assert.match(failures[0], /would run it as a command/u);
+  assert.match(failures[0], /runs as a command/u);
 });
 
-test('accepts the same list once the continuation is restored', () => {
-  const fixed = [
-    'git add \\',
-    '  packages/docs/public/llms.txt \\',
+test('catches an orphaned path separated by a blank line', () => {
+  assert.match(auditGitAddBlocks(orphaned(''))[0], /runs as a command/u);
+});
+
+test('catches an orphaned path separated by a comment', () => {
+  assert.match(
+    auditGitAddBlocks(orphaned('  # agent context symlink'))[0],
+    /runs as a command/u,
+  );
+});
+
+test('treats a backslash followed by a space as the end of the command', () => {
+  // `\ ` is an escaped space in bash, not a continuation.
+  const source = ['git add \\ ', '  knowledge/_claude-context'].join('\n');
+  assert.ok(auditGitAddBlocks(source).length > 0);
+});
+
+test('accepts the list once every continuation is intact', () => {
+  const source = [
+    ...HEAD,
     '  knowledge/_agent-context/context.md \\',
     '  knowledge/_claude-context',
   ].join('\n');
+  assert.deepEqual(auditGitAddBlocks(source), []);
+});
 
-  assert.deepEqual(auditGitAddBlocks(fixed), []);
+test('allows running an executable script by path', () => {
+  assert.deepEqual(
+    auditGitAddBlocks(['./scripts/sync-versions.sh', 'git add .'].join('\n')),
+    [],
+  );
 });
 
 test('reports a staged path that no longer exists', () => {
-  const stale = ['git add \\', '  knowledge/_removed-context/context.md'].join(
+  const source = ['git add \\', '  knowledge/_removed-context/context.md'].join(
     '\n',
   );
+  assert.match(auditGitAddBlocks(source)[0], /staged path does not exist/u);
+});
 
-  const failures = auditGitAddBlocks(stale);
-  assert.equal(failures.length, 1);
-  assert.match(failures[0], /staged path does not exist/u);
+test('joins continued lines into one logical command', () => {
+  const logical = toLogicalLines(['git add \\', '  a \\', '  b'].join('\n'));
+  assert.deepEqual(
+    logical.map((entry) => entry.text),
+    ['git add a b'],
+  );
 });
 
 test('the committed script passes its own audit', () => {
-  const source = readFileSync('scripts/sync-release-generated.sh', 'utf8');
+  const source = readFileSync(
+    join(REPO_ROOT, 'scripts/sync-release-generated.sh'),
+    'utf8',
+  );
   assert.deepEqual(auditGitAddBlocks(source), []);
 });

--- a/scripts/audit-release-sync-script.test.mjs
+++ b/scripts/audit-release-sync-script.test.mjs
@@ -89,6 +89,11 @@ test("keeps a token split across a continuation adjacent, as bash does", () => {
   assert.deepEqual(auditGitAddBlocks(logical[0].text), []);
 });
 
+test("rejects a staged path that escapes the repository", () => {
+  const source = ["git add \\", "  ../../../etc/passwd"].join("\n");
+  assert.match(auditGitAddBlocks(source)[0], /escapes the repository/u);
+});
+
 test("the committed script passes its own audit", () => {
   const source = readFileSync(
     join(REPO_ROOT, "scripts/sync-release-generated.sh"),


### PR DESCRIPTION
Follow-up to the four commits that went straight to `main` during yesterday's godot-iap 3.3.3 release. Those bypassed review; this PR is the review, and it found real defects in my own guard.

## The guard did not work

`scripts/audit-release-sync-script.mjs` was written to prevent a repeat of the outage in `2649f1df`, where a dropped `\` in `sync-release-generated.sh` made bash run a path as a command (`exit 126`). It matched line *shapes* with regexes. Three inputs reproduce the outage while the audit reports clean — each confirmed by actually running bash, not by reading the code:

| Input | bash | guard before |
|---|---|---|
| blank line between the list and the orphaned path | `exit 126`, `is a directory` | clean |
| comment line there instead | `exit 126` | clean |
| `git add \ ` — backslash then a space | `exit 126` | clean |

The third is the nastiest: `\ ` is an *escaped space* in bash, so the command ends there, but the old regex `/\\\s*$/` accepted it as a continuation.

## What replaces it

Bash's real rule, then a semantic check:

1. A line continues only on an **odd** number of trailing backslashes at end of line.
2. Join continued lines into logical commands.
3. Reject any logical command whose first word is a repository path that is **not executable** — a directory or a plain file can only have become a command by accident. `./scripts/sync-versions.sh` (mode 755) stays legal.

This catches the orphaned path regardless of what separates it from the list, which is the property the regex approach could never have.

## Two more defects in the same file

- **cwd-relative reads.** The audit read `scripts/sync-release-generated.sh` relative to the caller's cwd and threw `ENOENT` from anywhere else — while the script it guards resolves `REPO_ROOT` from its own location precisely to avoid that. CI passes today only because that job happens to have no `working-directory`.
- **Main-module check silently disabled the audit.** `import.meta.url === \`file://${process.argv[1]}\`` compares a percent-encoded URL against a raw path, so any checkout path containing a space made it false — and then the CI step printed nothing and exited 0, passing without auditing anything.

## Release note contradicted itself

`releases.tsx` claimed Windows and Linux editors "stop logging a missing-library error", while its own integration note said `include_tags` only exists in Godot 4.8. The summary now matches the setup page.

## Checked and deliberately not changed

- **kmp/maui "unpushed version bump"** — reported as a defect, but unreachable: both lanes hard-fail at the earlier tag check for a real bump, and skip the commit step entirely in `current` mode.
- **A shell lint gate** — would not have caught the original outage. Verified: `bash -n` and `shellcheck` both report nothing on the broken form, because an orphaned path is a valid command.
- **An Xcode pin on `release-godot.yml`** — the lane compiles nothing; it inspects tracked binaries with `vtool`/`otool` and signs them. Declaring `XCODE_VERSION` without using it would just add the dead-config problem this release train already fixed once. macos-26 defaults to Xcode 26.6 and ships the Android SDK, both verified against the runner-images manifest.
- **`Example/project.godot` 4.5 → 4.7** — the example is not in the release zip, and every CI lane installs Godot 4.7.1.

## Verification

`node --test scripts/audit-release-sync-script.test.mjs` (9 tests, each reproduction included), the audit from the repo root and from `/tmp`, `bun run audit:docs`, and docs typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that Godot 4.8 on Windows and Linux skips the Apple-only GDExtension without reporting missing-library errors during project scans.

- **Bug Fixes**
  - Improved release synchronization checks for invalid file references, missing staged paths, and broken command continuations.
  - Ensured checks work consistently regardless of the starting directory.

- **Tests**
  - Expanded coverage for continuations, comments, blank lines, executable paths, and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->