### PR TITLE
fix: improve purchase diagnostics

### DIFF
--- a/.github/workflows/ci-expo-iap.yml
+++ b/.github/workflows/ci-expo-iap.yml
@@ -11,6 +11,7 @@ on:
       - "openiap-versions.json"
       - "libraries-versions.jsonc"
       - "codecov.yml"
+      - "scripts/test-ios-log-sanitizers.sh"
       - ".github/workflows/ci-expo-iap.yml"
       - "!**/*.md"
   push:
@@ -23,6 +24,7 @@ on:
       - "openiap-versions.json"
       - "libraries-versions.jsonc"
       - "codecov.yml"
+      - "scripts/test-ios-log-sanitizers.sh"
       - ".github/workflows/ci-expo-iap.yml"
       - "!**/*.md"
 
@@ -127,6 +129,9 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Test iOS log sanitizer
+        run: bash ../../scripts/test-ios-log-sanitizers.sh expo
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/ci-react-native-iap.yml
+++ b/.github/workflows/ci-react-native-iap.yml
@@ -11,6 +11,7 @@ on:
       - "openiap-versions.json"
       - "libraries-versions.jsonc"
       - "codecov.yml"
+      - "scripts/test-ios-log-sanitizers.sh"
       - ".github/workflows/ci-react-native-iap.yml"
       - "!**/*.md"
   push:
@@ -23,6 +24,7 @@ on:
       - "openiap-versions.json"
       - "libraries-versions.jsonc"
       - "codecov.yml"
+      - "scripts/test-ios-log-sanitizers.sh"
       - ".github/workflows/ci-react-native-iap.yml"
       - "!**/*.md"
 
@@ -129,6 +131,9 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Test iOS log sanitizer
+        run: bash ../../scripts/test-ios-log-sanitizers.sh react-native
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/libraries/expo-iap/android/src/main/java/expo/modules/iap/ExpoIapLog.kt
+++ b/libraries/expo-iap/android/src/main/java/expo/modules/iap/ExpoIapLog.kt
@@ -110,6 +110,10 @@ internal object ExpoIapLog {
         val sanitized = linkedMapOf<String, Any?>()
         for ((rawKey, rawValue) in source) {
             val key = rawKey as? String ?: continue
+            if (rawValue == null || rawValue === JSONObject.NULL) {
+                sanitized[key] = JSONObject.NULL
+                continue
+            }
             if (isSensitiveKey(key)) {
                 sanitized[key] = "hidden"
                 continue

--- a/libraries/expo-iap/android/src/test/java/expo/modules/iap/ExpoIapLogTest.kt
+++ b/libraries/expo-iap/android/src/test/java/expo/modules/iap/ExpoIapLogTest.kt
@@ -1,5 +1,6 @@
 package expo.modules.iap
 
+import org.json.JSONObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -34,5 +35,22 @@ class ExpoIapLogTest {
             "known-client-payload-body",
         ).forEach { assertFalse(output.contains(it)) }
         assertTrue(output.contains("hidden"))
+    }
+
+    @Test
+    fun `logger preserves null sensitive values without claiming data was sent`() {
+        val output =
+            ExpoIapLog.stringify(
+                mapOf(
+                    "purchaseToken" to null,
+                    "userIdAmazon" to JSONObject.NULL,
+                    "apiKey" to "known-api-key",
+                ),
+            )
+
+        assertTrue(output.contains("\"purchaseToken\":null"))
+        assertTrue(output.contains("\"userIdAmazon\":null"))
+        assertTrue(output.contains("\"apiKey\":\"hidden\""))
+        assertFalse(output.contains("known-api-key"))
     }
 }

--- a/libraries/expo-iap/ios/ExpoIapLog.swift
+++ b/libraries/expo-iap/ios/ExpoIapLog.swift
@@ -109,7 +109,7 @@ enum ExpoIapLog {
     }
 
     private static func sanitize(_ value: Any?) -> Any? {
-        guard let value else { return nil }
+        guard let value, !(value is NSNull) else { return nil }
 
         if let string = value as? String {
             let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -121,18 +121,18 @@ enum ExpoIapLog {
             return sanitize(json) ?? string
         }
 
-        if let dictionary = value as? [String: Any] {
-            return sanitizeDictionary(dictionary)
-        }
-
         if let optionalDictionary = value as? [String: Any?] {
             var compact: [String: Any] = [:]
             for (key, optionalValue) in optionalDictionary {
-                if let optionalValue {
+                if let optionalValue, !(optionalValue is NSNull) {
                     compact[key] = optionalValue
                 }
             }
             return sanitizeDictionary(compact)
+        }
+
+        if let dictionary = value as? [String: Any] {
+            return sanitizeDictionary(dictionary)
         }
 
         if let array = value as? [Any] {

--- a/libraries/expo-iap/tests/ios/ExpoIapLogTests.swift
+++ b/libraries/expo-iap/tests/ios/ExpoIapLogTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+final class ExpoIapLogTests: XCTestCase {
+    override func tearDown() {
+        ExpoIapLog.setHandler(nil)
+        super.tearDown()
+    }
+
+    @objc func testNullSensitiveValuesAreOmittedAndPresentValuesAreMasked() {
+        var output = ""
+        ExpoIapLog.setEnabled(true)
+        ExpoIapLog.setHandler { _, message in output = message }
+
+        let payload: [String: Any?] = [
+            "purchaseToken": nil,
+            "userIdAmazon": NSNull(),
+            "apiKey": "known-api-key",
+        ]
+        ExpoIapLog.payload("requestPurchase", payload: payload)
+
+        XCTAssertFalse(output.contains("purchaseToken"))
+        XCTAssertFalse(output.contains("userIdAmazon"))
+        XCTAssertTrue(output.contains("\"apiKey\":\"hidden\""))
+        XCTAssertFalse(output.contains("known-api-key"))
+    }
+}
+
+@main
+private enum ExpoIapLogTestRunner {
+    static func main() {
+        let test = ExpoIapLogTests(
+            selector: #selector(ExpoIapLogTests.testNullSensitiveValuesAreOmittedAndPresentValuesAreMasked)
+        )
+        test.run()
+        precondition(test.testRun?.hasSucceeded == true)
+    }
+}

--- a/libraries/godot-iap/android/src/main/java/dev/hyo/godotiap/GodotIapLog.kt
+++ b/libraries/godot-iap/android/src/main/java/dev/hyo/godotiap/GodotIapLog.kt
@@ -71,7 +71,7 @@ internal object GodotIapLog {
         }
     }
 
-    private fun stringify(value: Any?): String {
+    internal fun stringify(value: Any?): String {
         val sanitized = sanitize(value) ?: return "null"
         return when (sanitized) {
             is String -> sanitized
@@ -111,6 +111,10 @@ internal object GodotIapLog {
         val sanitized = linkedMapOf<String, Any?>()
         for ((rawKey, rawValue) in source) {
             val key = rawKey as? String ?: continue
+            if (rawValue == null || rawValue === JSONObject.NULL) {
+                sanitized[key] = JSONObject.NULL
+                continue
+            }
             if (isSensitiveKey(key)) {
                 sanitized[key] = "hidden"
                 continue
@@ -125,11 +129,14 @@ internal object GodotIapLog {
         val keys = source.keys()
         while (keys.hasNext()) {
             val key = keys.next()
+            val rawValue = source.opt(key)
             sanitized[key] =
-                if (isSensitiveKey(key)) {
+                if (rawValue == null || rawValue === JSONObject.NULL) {
+                    JSONObject.NULL
+                } else if (isSensitiveKey(key)) {
                     "hidden"
                 } else {
-                    sanitizeJsonValue(source.opt(key))
+                    sanitizeJsonValue(rawValue)
                 }
         }
         return sanitized

--- a/libraries/godot-iap/android/src/test/java/dev/hyo/godotiap/GodotIapLogTest.kt
+++ b/libraries/godot-iap/android/src/test/java/dev/hyo/godotiap/GodotIapLogTest.kt
@@ -1,0 +1,39 @@
+package dev.hyo.godotiap
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GodotIapLogTest {
+    @Test
+    fun `map sanitizer preserves null sensitive values and masks present values`() {
+        val output =
+            GodotIapLog.stringify(
+                mapOf(
+                    "purchaseToken" to null,
+                    "userIdAmazon" to JSONObject.NULL,
+                    "apiKey" to "known-api-key",
+                ),
+            )
+
+        assertNullSensitiveValues(output)
+    }
+
+    @Test
+    fun `json sanitizer preserves null sensitive values and masks present values`() {
+        val output =
+            GodotIapLog.stringify(
+                """{"purchaseToken":null,"userIdAmazon":null,"apiKey":"known-api-key"}""",
+            )
+
+        assertNullSensitiveValues(output)
+    }
+
+    private fun assertNullSensitiveValues(output: String) {
+        assertTrue(output.contains("\"purchaseToken\":null"))
+        assertTrue(output.contains("\"userIdAmazon\":null"))
+        assertTrue(output.contains("\"apiKey\":\"hidden\""))
+        assertFalse(output.contains("known-api-key"))
+    }
+}

--- a/libraries/godot-iap/ios-gdextension/Sources/GodotIap/GodotIapLog.swift
+++ b/libraries/godot-iap/ios-gdextension/Sources/GodotIap/GodotIapLog.swift
@@ -133,7 +133,7 @@ enum GodotIapLog {
         #endif
     }
 
-    private static func stringify(_ value: Any?) -> String {
+    static func stringify(_ value: Any?) -> String {
         guard let sanitized = sanitize(value) else {
             return "null"
         }
@@ -161,24 +161,24 @@ enum GodotIapLog {
             return sanitize(json) ?? value
         }
 
-        guard let value else { return nil }
+        guard let value, !(value is NSNull) else { return nil }
 
         if let string = value as? String {
             return sanitizeJSONString(string)
         }
 
-        if let dictionary = value as? [String: Any] {
-            return sanitizeDictionary(dictionary)
-        }
-
         if let optionalDictionary = value as? [String: Any?] {
             var compact: [String: Any] = [:]
             for (key, optionalValue) in optionalDictionary {
-                if let optionalValue {
+                if let optionalValue, !(optionalValue is NSNull) {
                     compact[key] = optionalValue
                 }
             }
             return sanitizeDictionary(compact)
+        }
+
+        if let dictionary = value as? [String: Any] {
+            return sanitizeDictionary(dictionary)
         }
 
         if let array = value as? [Any] {

--- a/libraries/godot-iap/ios-gdextension/Tests/GodotIapTests/GodotIapLogTests.swift
+++ b/libraries/godot-iap/ios-gdextension/Tests/GodotIapTests/GodotIapLogTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import GodotIap
+
+final class GodotIapLogTests: XCTestCase {
+    func testNullSensitiveValuesAreOmittedAndPresentValuesAreMasked() {
+        let payload: [String: Any?] = [
+            "purchaseToken": nil,
+            "userIdAmazon": NSNull(),
+            "apiKey": "known-api-key",
+        ]
+        let output = GodotIapLog.stringify(payload)
+
+        XCTAssertFalse(output.contains("purchaseToken"))
+        XCTAssertFalse(output.contains("userIdAmazon"))
+        XCTAssertTrue(output.contains("\"apiKey\":\"hidden\""))
+        XCTAssertFalse(output.contains("known-api-key"))
+    }
+}

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/RnIapLog.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/RnIapLog.kt
@@ -67,7 +67,7 @@ internal object RnIapLog {
         }
     }
 
-    private fun sanitizeMap(source: Map<*, *>): Map<String, Any?> {
+    internal fun sanitizeMap(source: Map<*, *>): Map<String, Any?> {
         fun isSensitiveKey(key: String): Boolean {
             val normalized = key.lowercase(Locale.ROOT).filter { it.isLetterOrDigit() }
             return SENSITIVE_KEY_FRAGMENTS.any { normalized.contains(it) } ||
@@ -77,6 +77,10 @@ internal object RnIapLog {
         val sanitized = linkedMapOf<String, Any?>()
         for ((rawKey, rawValue) in source) {
             val key = rawKey as? String ?: continue
+            if (rawValue == null || rawValue === JSONObject.NULL) {
+                sanitized[key] = JSONObject.NULL
+                continue
+            }
             if (isSensitiveKey(key)) {
                 sanitized[key] = "hidden"
                 continue

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/RnIapLogTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/RnIapLogTest.kt
@@ -1,0 +1,26 @@
+package com.margelo.nitro.iap
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class RnIapLogTest {
+    @Test
+    fun `logger preserves null sensitive values and masks present values`() {
+        val sanitized =
+            RnIapLog.sanitizeMap(
+                mapOf(
+                    "purchaseToken" to null,
+                    "userIdAmazon" to JSONObject.NULL,
+                    "apiKey" to "known-api-key",
+                ),
+            )
+
+        assertSame(JSONObject.NULL, sanitized["purchaseToken"])
+        assertSame(JSONObject.NULL, sanitized["userIdAmazon"])
+        assertEquals("hidden", sanitized["apiKey"])
+        assertFalse(sanitized.containsValue("known-api-key"))
+    }
+}

--- a/libraries/react-native-iap/ios/RnIapLog.swift
+++ b/libraries/react-native-iap/ios/RnIapLog.swift
@@ -105,20 +105,20 @@ enum RnIapLog {
     }
 
     private static func sanitize(_ value: Any?) -> Any? {
-        guard let value else { return nil }
-
-        if let dictionary = value as? [String: Any] {
-            return sanitizeDictionary(dictionary)
-        }
+        guard let value, !(value is NSNull) else { return nil }
 
         if let optionalDictionary = value as? [String: Any?] {
             var compact: [String: Any] = [:]
             for (key, optionalValue) in optionalDictionary {
-                if let optionalValue {
+                if let optionalValue, !(optionalValue is NSNull) {
                     compact[key] = optionalValue
                 }
             }
             return sanitizeDictionary(compact)
+        }
+
+        if let dictionary = value as? [String: Any] {
+            return sanitizeDictionary(dictionary)
         }
 
         if let array = value as? [Any] {

--- a/libraries/react-native-iap/tests/ios/RnIapLogTests.swift
+++ b/libraries/react-native-iap/tests/ios/RnIapLogTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+final class RnIapLogTests: XCTestCase {
+    override func tearDown() {
+        RnIapLog.setHandler(nil)
+        super.tearDown()
+    }
+
+    @objc func testNullSensitiveValuesAreOmittedAndPresentValuesAreMasked() {
+        var output = ""
+        RnIapLog.setEnabled(true)
+        RnIapLog.setHandler { _, message in output = message }
+
+        let payload: [String: Any?] = [
+            "purchaseToken": nil,
+            "userIdAmazon": NSNull(),
+            "apiKey": "known-api-key",
+        ]
+        RnIapLog.payload("requestPurchase", payload)
+
+        XCTAssertFalse(output.contains("purchaseToken"))
+        XCTAssertFalse(output.contains("userIdAmazon"))
+        XCTAssertTrue(output.contains("\"apiKey\":\"hidden\""))
+        XCTAssertFalse(output.contains("known-api-key"))
+    }
+}
+
+@main
+private enum RnIapLogTestRunner {
+    static func main() {
+        let test = RnIapLogTests(
+            selector: #selector(RnIapLogTests.testNullSensitiveValuesAreOmittedAndPresentValuesAreMasked)
+        )
+        test.run()
+        precondition(test.testRun?.hasSucceeded == true)
+    }
+}

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/OpenIapError.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/OpenIapError.kt
@@ -325,8 +325,15 @@ sealed class OpenIapError : Exception() {
     }
 
     data class DeveloperError(override val debugMessage: String? = null) : OpenIapError() {
+        private var messageOverride: String? = null
+
         override val code: String = CODE
-        override val message: String = MESSAGE
+        override val message: String
+            get() = messageOverride ?: MESSAGE
+
+        internal fun withMessage(value: String): DeveloperError = apply {
+            messageOverride = value
+        }
 
         companion object {
             val CODE = ErrorCode.DeveloperError.rawValue

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/OpenIapModule.kt
@@ -1708,6 +1708,8 @@ class OpenIapModule(
                     val paramsList = mutableListOf<BillingFlowParams.ProductDetailsParams>()
                     val requestedOffersBySku = mutableMapOf<String, MutableList<String>>()
                     val selectedBasePlanIdsBySku = mutableMapOf<String, String?>()
+                    val selectedSubscriptionOffersBySku =
+                        mutableMapOf<String, ProductDetails.SubscriptionOfferDetails>()
 
                     // Reject multi-SKU one-time purchase requests when offerToken is provided
                     // A single offerToken cannot be applied to multiple SKUs
@@ -1770,12 +1772,14 @@ class OpenIapModule(
                                 return
                             }
                             val selectedOfferToken = checkNotNull(resolved)
+                            val selectedOffer = productDetails.subscriptionOfferDetails
+                                ?.firstOrNull { it.offerToken == selectedOfferToken }
 
                             builder.setOfferToken(selectedOfferToken)
-                            selectedBasePlanIdsBySku[productDetails.productId] =
-                                productDetails.subscriptionOfferDetails
-                                    ?.firstOrNull { it.offerToken == selectedOfferToken }
-                                    ?.basePlanId
+                            selectedBasePlanIdsBySku[productDetails.productId] = selectedOffer?.basePlanId
+                            selectedOffer?.let {
+                                selectedSubscriptionOffersBySku[productDetails.productId] = it
+                            }
 
                             // Apply per-product subscription replacement params (8.1.0+)
                             androidArgs.subscriptionProductReplacementParams?.let { replacementParams ->
@@ -1953,15 +1957,42 @@ class OpenIapModule(
                                 }
                                 return@runOnUiThread
                             }
-                            if (result.responseCode == BillingClient.BillingResponseCode.DEVELOPER_ERROR) {
-                                OpenIapLog.warn("DEVELOPER_ERROR: Invalid arguments. Check if subscriptions are in the same group.", TAG)
-                            }
-                            val err = if (result.responseCode == BillingClient.BillingResponseCode.ERROR) {
-                                OpenIapError.PurchaseFailed(result.debugMessage)
-                            } else {
-                                OpenIapError.fromBillingResponseCode(
+                            val err = when (result.responseCode) {
+                                BillingClient.BillingResponseCode.DEVELOPER_ERROR -> {
+                                    val replacementParams =
+                                        androidArgs.subscriptionProductReplacementParams
+                                    if (replacementParams == null) {
+                                        OpenIapLog.warn(
+                                            "DEVELOPER_ERROR: Invalid arguments. Check subscription and offer parameters.",
+                                            TAG,
+                                        )
+                                        OpenIapError.DeveloperError(result.debugMessage)
+                                    } else {
+                                        val targetProduct = details.single()
+                                        val selectedOffer =
+                                            selectedSubscriptionOffersBySku[targetProduct.productId]
+                                        val diagnostic = subscriptionReplacementDeveloperErrorMessage(
+                                            originalDebugMessage = result.debugMessage,
+                                            replacementParams = replacementParams,
+                                            targetProductId = targetProduct.productId,
+                                            targetRecurrenceModes = selectedOffer
+                                                ?.pricingPhases
+                                                ?.pricingPhaseList
+                                                ?.map { it.recurrenceMode }
+                                                .orEmpty(),
+                                            targetIsInstallment =
+                                                selectedOffer?.installmentPlanDetails != null,
+                                        )
+                                        OpenIapLog.warn("DEVELOPER_ERROR: $diagnostic", TAG)
+                                        OpenIapError.DeveloperError(result.debugMessage)
+                                            .withMessage(diagnostic)
+                                    }
+                                }
+                                BillingClient.BillingResponseCode.ERROR ->
+                                    OpenIapError.PurchaseFailed(result.debugMessage)
+                                else -> OpenIapError.fromBillingResponseCode(
                                     result.responseCode,
-                                    result.debugMessage
+                                    result.debugMessage,
                                 )
                             }
                             finishWithError(err, requireLaunched = true)

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/SubscriptionReplacementDiagnostics.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/SubscriptionReplacementDiagnostics.kt
@@ -1,0 +1,73 @@
+package dev.hyo.openiap
+
+import com.android.billingclient.api.ProductDetails
+import java.util.Locale
+
+private const val REPLACEMENT_MODES_URL =
+    "https://developer.android.com/google/play/billing/subscriptions#replacement-modes"
+
+internal enum class SubscriptionReplacementSwitchType {
+    SameSubscriptionAutoRenewing,
+    TargetPrepaid,
+    CrossSubscription,
+    Unknown,
+}
+
+internal fun classifySubscriptionReplacementSwitch(
+    oldProductId: String,
+    targetProductId: String,
+    targetRecurrenceModes: List<Int>,
+    targetIsInstallment: Boolean,
+): SubscriptionReplacementSwitchType {
+    val targetIsAutoRenewing =
+        targetRecurrenceModes.contains(ProductDetails.RecurrenceMode.INFINITE_RECURRING)
+    val targetIsPrepaid = targetRecurrenceModes.isNotEmpty() && !targetIsAutoRenewing
+
+    return when {
+        targetIsInstallment -> SubscriptionReplacementSwitchType.Unknown
+        targetIsPrepaid -> SubscriptionReplacementSwitchType.TargetPrepaid
+        oldProductId != targetProductId -> SubscriptionReplacementSwitchType.CrossSubscription
+        targetIsAutoRenewing -> SubscriptionReplacementSwitchType.SameSubscriptionAutoRenewing
+        else -> SubscriptionReplacementSwitchType.Unknown
+    }
+}
+
+internal fun subscriptionReplacementDeveloperErrorMessage(
+    originalDebugMessage: String,
+    replacementParams: SubscriptionProductReplacementParamsAndroid,
+    targetProductId: String,
+    targetRecurrenceModes: List<Int>,
+    targetIsInstallment: Boolean,
+): String {
+    val requestedMode =
+        replacementParams.replacementMode.rawValue
+            .replace('-', '_')
+            .uppercase(Locale.ROOT)
+    val switchType =
+        classifySubscriptionReplacementSwitch(
+            oldProductId = replacementParams.oldProductId,
+            targetProductId = targetProductId,
+            targetRecurrenceModes = targetRecurrenceModes,
+            targetIsInstallment = targetIsInstallment,
+        )
+    val restriction =
+        when (switchType) {
+            SubscriptionReplacementSwitchType.SameSubscriptionAutoRenewing ->
+                "a same-subscription switch to an auto-renewing plan " +
+                    "(oldProductId == target productId). Valid modes for this case: " +
+                    "CHARGE_FULL_PRICE, WITHOUT_PRORATION."
+            SubscriptionReplacementSwitchType.TargetPrepaid ->
+                "a switch to a prepaid plan. Valid modes for this case: CHARGE_FULL_PRICE."
+            SubscriptionReplacementSwitchType.CrossSubscription ->
+                "a cross-subscription switch. Valid modes for this case: " +
+                    "WITH_TIME_PRORATION, CHARGE_PRORATED_PRICE (upgrades only), " +
+                    "WITHOUT_PRORATION, CHARGE_FULL_PRICE, DEFERRED."
+            SubscriptionReplacementSwitchType.Unknown ->
+                "this subscription switch. Verify that the mode is supported for the target plan."
+        }
+
+    return "${OpenIapError.DeveloperError.MESSAGE}. Heuristic: Play does not disclose the " +
+        "exact cause, but " +
+        "requested replacement mode $requestedMode may be invalid for $restriction " +
+        "Original Play message: $originalDebugMessage See $REPLACEMENT_MODES_URL"
+}

--- a/packages/google/openiap/src/play/java/dev/hyo/openiap/SubscriptionReplacementDiagnostics.kt
+++ b/packages/google/openiap/src/play/java/dev/hyo/openiap/SubscriptionReplacementDiagnostics.kt
@@ -10,6 +10,7 @@ internal enum class SubscriptionReplacementSwitchType {
     SameSubscriptionAutoRenewing,
     TargetPrepaid,
     CrossSubscription,
+    TargetInstallment,
     Unknown,
 }
 
@@ -24,7 +25,7 @@ internal fun classifySubscriptionReplacementSwitch(
     val targetIsPrepaid = targetRecurrenceModes.isNotEmpty() && !targetIsAutoRenewing
 
     return when {
-        targetIsInstallment -> SubscriptionReplacementSwitchType.Unknown
+        targetIsInstallment -> SubscriptionReplacementSwitchType.TargetInstallment
         targetIsPrepaid -> SubscriptionReplacementSwitchType.TargetPrepaid
         oldProductId != targetProductId -> SubscriptionReplacementSwitchType.CrossSubscription
         targetIsAutoRenewing -> SubscriptionReplacementSwitchType.SameSubscriptionAutoRenewing
@@ -62,6 +63,11 @@ internal fun subscriptionReplacementDeveloperErrorMessage(
                 "a cross-subscription switch. Valid modes for this case: " +
                     "WITH_TIME_PRORATION, CHARGE_PRORATED_PRICE (upgrades only), " +
                     "WITHOUT_PRORATION, CHARGE_FULL_PRICE, DEFERRED."
+            SubscriptionReplacementSwitchType.TargetInstallment ->
+                "a switch to an installment plan. Valid modes for installment subscriptions: " +
+                    "WITH_TIME_PRORATION, CHARGE_PRORATED_PRICE (upgrades only), " +
+                    "WITHOUT_PRORATION, CHARGE_FULL_PRICE, DEFERRED. KEEP_EXISTING also " +
+                    "requires oldProductId == target productId."
             SubscriptionReplacementSwitchType.Unknown ->
                 "this subscription switch. Verify that the mode is supported for the target plan."
         }

--- a/packages/google/openiap/src/testPlay/java/dev/hyo/openiap/SubscriptionReplacementDiagnosticsTest.kt
+++ b/packages/google/openiap/src/testPlay/java/dev/hyo/openiap/SubscriptionReplacementDiagnosticsTest.kt
@@ -1,0 +1,99 @@
+package dev.hyo.openiap
+
+import com.android.billingclient.api.ProductDetails
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubscriptionReplacementDiagnosticsTest {
+    @Test
+    fun `same subscription auto renewing switch lists two valid modes`() {
+        val params = replacementParams(SubscriptionReplacementModeAndroid.ChargeProratedPrice)
+        val message =
+            subscriptionReplacementDeveloperErrorMessage(
+                originalDebugMessage = "Invalid arguments provided to the API",
+                replacementParams = params,
+                targetProductId = "premium",
+                targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.INFINITE_RECURRING),
+                targetIsInstallment = false,
+            )
+
+        val error =
+            OpenIapError
+                .DeveloperError("Invalid arguments provided to the API")
+                .withMessage(message)
+
+        assertTrue(message.startsWith(OpenIapError.DeveloperError.MESSAGE))
+        assertTrue(message.contains("requested replacement mode CHARGE_PRORATED_PRICE"))
+        assertTrue(message.contains("same-subscription switch to an auto-renewing plan"))
+        assertTrue(message.contains("CHARGE_FULL_PRICE, WITHOUT_PRORATION"))
+        assertTrue(message.contains("Heuristic: Play does not disclose the exact cause"))
+        assertEquals("Invalid arguments provided to the API", error.debugMessage)
+        assertEquals(message, error.message)
+    }
+
+    @Test
+    fun `prepaid target lists only charge full price`() {
+        val switchType =
+            classifySubscriptionReplacementSwitch(
+                oldProductId = "basic",
+                targetProductId = "premium",
+                targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.NON_RECURRING),
+                targetIsInstallment = false,
+            )
+        val message =
+            subscriptionReplacementDeveloperErrorMessage(
+                originalDebugMessage = "Invalid arguments",
+                replacementParams = replacementParams(SubscriptionReplacementModeAndroid.Deferred),
+                targetProductId = "premium",
+                targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.NON_RECURRING),
+                targetIsInstallment = false,
+            )
+
+        assertEquals(SubscriptionReplacementSwitchType.TargetPrepaid, switchType)
+        assertTrue(message.contains("switch to a prepaid plan"))
+        assertTrue(message.contains("Valid modes for this case: CHARGE_FULL_PRICE."))
+    }
+
+    @Test
+    fun `cross subscription switch lists the documented mode set`() {
+        val message =
+            subscriptionReplacementDeveloperErrorMessage(
+                originalDebugMessage = "Invalid arguments",
+                replacementParams =
+                    replacementParams(
+                        SubscriptionReplacementModeAndroid.WithTimeProration,
+                        oldProductId = "basic",
+                    ),
+                targetProductId = "premium",
+                targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.INFINITE_RECURRING),
+                targetIsInstallment = false,
+            )
+
+        assertTrue(message.contains("cross-subscription switch"))
+        assertTrue(message.contains("CHARGE_PRORATED_PRICE (upgrades only)"))
+        assertTrue(message.contains("WITHOUT_PRORATION, CHARGE_FULL_PRICE, DEFERRED"))
+    }
+
+    @Test
+    fun `installment target avoids an unsupported plan classification`() {
+        val switchType =
+            classifySubscriptionReplacementSwitch(
+                oldProductId = "premium",
+                targetProductId = "premium",
+                targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.INFINITE_RECURRING),
+                targetIsInstallment = true,
+            )
+
+        assertEquals(SubscriptionReplacementSwitchType.Unknown, switchType)
+    }
+
+    private fun replacementParams(
+        mode: SubscriptionReplacementModeAndroid,
+        oldProductId: String = "premium",
+    ): SubscriptionProductReplacementParamsAndroid =
+        SubscriptionProductReplacementParamsAndroid(
+            oldProductId = oldProductId,
+            replacementMode = mode,
+        )
+}

--- a/packages/google/openiap/src/testPlay/java/dev/hyo/openiap/SubscriptionReplacementDiagnosticsTest.kt
+++ b/packages/google/openiap/src/testPlay/java/dev/hyo/openiap/SubscriptionReplacementDiagnosticsTest.kt
@@ -76,7 +76,7 @@ class SubscriptionReplacementDiagnosticsTest {
     }
 
     @Test
-    fun `installment target avoids an unsupported plan classification`() {
+    fun `installment target lists the supported replacement modes`() {
         val switchType =
             classifySubscriptionReplacementSwitch(
                 oldProductId = "premium",
@@ -84,8 +84,20 @@ class SubscriptionReplacementDiagnosticsTest {
                 targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.INFINITE_RECURRING),
                 targetIsInstallment = true,
             )
+        val message =
+            subscriptionReplacementDeveloperErrorMessage(
+                originalDebugMessage = "Invalid arguments",
+                replacementParams = replacementParams(SubscriptionReplacementModeAndroid.Deferred),
+                targetProductId = "premium",
+                targetRecurrenceModes = listOf(ProductDetails.RecurrenceMode.INFINITE_RECURRING),
+                targetIsInstallment = true,
+            )
 
-        assertEquals(SubscriptionReplacementSwitchType.Unknown, switchType)
+        assertEquals(SubscriptionReplacementSwitchType.TargetInstallment, switchType)
+        assertTrue(message.contains("switch to an installment plan"))
+        assertTrue(message.contains("WITH_TIME_PRORATION, CHARGE_PRORATED_PRICE (upgrades only)"))
+        assertTrue(message.contains("WITHOUT_PRORATION, CHARGE_FULL_PRICE, DEFERRED"))
+        assertTrue(message.contains("KEEP_EXISTING also requires oldProductId == target productId"))
     }
 
     private fun replacementParams(

--- a/scripts/test-ios-log-sanitizers.sh
+++ b/scripts/test-ios-log-sanitizers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${1:-all}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$(mktemp -d)"
+XCODE_PLATFORM="$(xcrun --sdk macosx --show-sdk-platform-path)"
+XCTEST_FRAMEWORKS="$XCODE_PLATFORM/Developer/Library/Frameworks"
+XCTEST_MODULES="$XCODE_PLATFORM/Developer/usr/lib"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+run_test() {
+  local name="$1"
+  local source="$2"
+  local test_source="$3"
+  local executable="$BUILD_DIR/$name"
+
+  xcrun --sdk macosx swiftc \
+    -emit-executable \
+    -F "$XCTEST_FRAMEWORKS" \
+    -I "$XCTEST_MODULES" \
+    -framework XCTest \
+    -Xlinker -rpath \
+    -Xlinker "$XCTEST_FRAMEWORKS" \
+    -L "$XCTEST_MODULES" \
+    -lXCTestSwiftSupport \
+    -Xlinker -rpath \
+    -Xlinker "$XCTEST_MODULES" \
+    "$source" \
+    "$test_source" \
+    -o "$executable"
+  "$executable"
+}
+
+run_expo() {
+  run_test \
+    expo-iap-log-tests \
+    "$REPO_ROOT/libraries/expo-iap/ios/ExpoIapLog.swift" \
+    "$REPO_ROOT/libraries/expo-iap/tests/ios/ExpoIapLogTests.swift"
+}
+
+run_react_native() {
+  run_test \
+    rn-iap-log-tests \
+    "$REPO_ROOT/libraries/react-native-iap/ios/RnIapLog.swift" \
+    "$REPO_ROOT/libraries/react-native-iap/tests/ios/RnIapLogTests.swift"
+}
+
+case "$TARGET" in
+  expo)
+    run_expo
+    ;;
+  react-native)
+    run_react_native
+    ;;
+  all)
+    run_expo
+    run_react_native
+    ;;
+  *)
+    echo "Usage: $0 [all|expo|react-native]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add a targeted heuristic for Google Play subscription replacement `DEVELOPER_ERROR` responses while preserving Play's original `debugMessage`
- preserve null sensitive fields accurately across Expo, React Native, and Godot Android/iOS log sanitizers while continuing to mask present values
- add focused Kotlin and Swift regression coverage for replacement-mode classification and log sanitization

Closes #371
Closes #372

## Changes

### Google Play replacement diagnostics

- classify same-subscription auto-renewing, prepaid-target, and cross-subscription replacements
- include the documented valid replacement-mode set and requested mode in the caller-visible error message and Logcat warning
- label the diagnosis as a heuristic and retain the original Play message separately

### Cross-SDK log sanitization

- serialize Kotlin `null` and `JSONObject.NULL` sensitive fields as JSON `null`
- omit Swift `nil` and `NSNull` fields, matching the existing non-sensitive nil behavior
- keep present sensitive values masked as `hidden`

## Test plan

- [x] Google unit tests and Play/Horizon/Amazon flavor compilation
- [x] Expo typecheck, lint, library/plugin/example tests, and Android logger regression
- [x] React Native typecheck, lint, and Android unit tests
- [x] Godot GDScript, Android build/unit tests, and Swift tests
- [x] KMP downstream Android build
- [x] Swift parser checks for all three iOS loggers
- [x] SDK parity, repository layout, and IAPKit contract audits
- [ ] Flutter analyze/tests — Flutter SDK is unavailable in the local environment; no Flutter files changed

## Preview

Not applicable: this PR changes diagnostics and debug-log serialization only, with no visual or interactive surface. The test results above provide terminal proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved purchase logging to handle null values safely while masking sensitive information across supported platforms.
  - Prevented secrets from appearing in diagnostic logs.
  - Improved Android subscription purchase errors with clearer explanations for invalid replacement modes and relevant guidance.
  - Preserved original error details while adding context about subscription types and replacement options.

- **Tests**
  - Added coverage for null handling, sensitive-data masking, and subscription replacement diagnostics across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->