### PR TITLE
fix(kit): surface application error codes to the dashboard

### DIFF
--- a/packages/kit/convex/utils/errors.test.ts
+++ b/packages/kit/convex/utils/errors.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, it } from "vitest";
 import { APP_ERROR_SCOPE, AppError, ErrorCode, createError } from "./errors";
 
 describe("AppError", () => {
-  // Convex serializes application errors by checking for this symbol; a plain
-  // Error fails the check and is redacted to "Server Error" in production.
+  // Convex gates application errors on this symbol; a plain Error is redacted.
   it("qualifies as a Convex application error", () => {
     const error = createError(ErrorCode.USER_NOT_REGISTERED);
     expect(Symbol.for("ConvexError") in error).toBe(true);

--- a/packages/kit/convex/utils/errors.test.ts
+++ b/packages/kit/convex/utils/errors.test.ts
@@ -1,0 +1,43 @@
+import { ConvexError } from "convex/values";
+import { describe, expect, it } from "vitest";
+import { APP_ERROR_SCOPE, AppError, ErrorCode, createError } from "./errors";
+
+describe("AppError", () => {
+  // Convex serializes application errors by checking for this symbol; a plain
+  // Error fails the check and is redacted to "Server Error" in production.
+  it("qualifies as a Convex application error", () => {
+    const error = createError(ErrorCode.USER_NOT_REGISTERED);
+    expect(Symbol.for("ConvexError") in error).toBe(true);
+    expect(error).toBeInstanceOf(ConvexError);
+    expect(error).toBeInstanceOf(AppError);
+  });
+
+  it("puts the code on the wire payload", () => {
+    expect(createError(ErrorCode.USER_ALREADY_MEMBER).data).toEqual({
+      code: ErrorCode.USER_ALREADY_MEMBER,
+      message: ErrorCode.USER_ALREADY_MEMBER,
+      scope: APP_ERROR_SCOPE,
+    });
+  });
+
+  it("carries details as the payload message without repeating the code", () => {
+    const error = createError(ErrorCode.INVALID_INPUT, "Sync job not found");
+    expect(error.data.message).toBe("Sync job not found");
+    expect(error.data.code).toBe(ErrorCode.INVALID_INPUT);
+  });
+
+  it("keeps server logs keyed by the code", () => {
+    expect(createError(ErrorCode.PROJECT_NOT_FOUND).message).toBe(
+      ErrorCode.PROJECT_NOT_FOUND,
+    );
+    expect(createError(ErrorCode.INVALID_INPUT, "missing id").message).toBe(
+      "INVALID_INPUT: missing id",
+    );
+  });
+
+  it("exposes the code as a field for server-side branching", () => {
+    expect(createError(ErrorCode.CANNOT_REMOVE_OWNER).code).toBe(
+      ErrorCode.CANNOT_REMOVE_OWNER,
+    );
+  });
+});

--- a/packages/kit/convex/utils/errors.ts
+++ b/packages/kit/convex/utils/errors.ts
@@ -1,3 +1,5 @@
+import { ConvexError } from "convex/values";
+
 // Error codes for consistent error handling across the application
 export enum ErrorCode {
   // Authentication & Authorization
@@ -38,22 +40,34 @@ export enum ErrorCode {
   SERVER_ERROR = "SERVER_ERROR",
 }
 
-export class AppError extends Error {
-  constructor(
-    public code: ErrorCode,
-    public message: string = "",
-    public statusCode: number = 400,
-  ) {
-    super(message || code);
+// Marks payloads meant for the dashboard. `/v1` route layers reject this
+// scope so internal codes stay out of the published response contract.
+export const APP_ERROR_SCOPE = "dashboard";
+
+/** Payload the client receives on `ConvexError.data`. */
+export interface AppErrorData {
+  code: ErrorCode;
+  message: string;
+  scope: string;
+  // Convex requires an index signature for structured error payloads.
+  [key: string]: string;
+}
+
+// Convex redacts plain `Error` messages to "Server Error" on production
+// deployments; only ConvexError data crosses to the client.
+export class AppError extends ConvexError<AppErrorData> {
+  readonly code: ErrorCode;
+
+  constructor(code: ErrorCode, details?: string) {
+    super({ code, message: details ?? code, scope: APP_ERROR_SCOPE });
     this.name = "AppError";
+    // Keep server logs keyed by the code rather than the JSON payload.
+    this.message = details ? `${code}: ${details}` : code;
+    this.code = code;
   }
 }
 
 // Helper function to create standardized errors
 export function createError(code: ErrorCode, details?: string): AppError {
-  // Always include the error code in the message so frontend can parse it
-  // Frontend will use the error code to display localized messages
-  const message = details ? `${code}: ${details}` : code;
-
-  return new AppError(code, message);
+  return new AppError(code, details);
 }

--- a/packages/kit/convex/utils/errors.ts
+++ b/packages/kit/convex/utils/errors.ts
@@ -40,8 +40,7 @@ export enum ErrorCode {
   SERVER_ERROR = "SERVER_ERROR",
 }
 
-// Marks payloads meant for the dashboard. `/v1` route layers reject this
-// scope so internal codes stay out of the published response contract.
+// `/v1` route layers reject this scope, keeping internal codes unpublished.
 export const APP_ERROR_SCOPE = "dashboard";
 
 /** Payload the client receives on `ConvexError.data`. */
@@ -53,8 +52,7 @@ export interface AppErrorData {
   [key: string]: string;
 }
 
-// Convex redacts plain `Error` messages to "Server Error" on production
-// deployments; only ConvexError data crosses to the client.
+// Convex redacts plain `Error` in production; only ConvexError data reaches the client.
 export class AppError extends ConvexError<AppErrorData> {
   readonly code: ErrorCode;
 

--- a/packages/kit/server/convex.test.ts
+++ b/packages/kit/server/convex.test.ts
@@ -87,9 +87,7 @@ describe("handleConvexError", () => {
     );
   });
 
-  // AppError reaches /v1 routes from every Convex function they call. Its
-  // payload is dashboard-facing, so routes must keep their generic fallback
-  // rather than start publishing internal codes and details.
+  // Every Convex function /v1 calls can throw AppError; none may reach the body.
   it("does not expose dashboard-scoped AppError payloads", () => {
     expect(handleConvexError(createError(ErrorCode.PROJECT_NOT_FOUND))).toBe(
       null,

--- a/packages/kit/server/convex.test.ts
+++ b/packages/kit/server/convex.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ConvexError } from "convex/values";
+import { ErrorCode, createError } from "../convex/utils/errors";
 
 process.env.VITE_KIT_CONVEX_URL ??= "https://placeholder.convex.cloud";
 
@@ -84,5 +85,19 @@ describe("handleConvexError", () => {
     expect(handleConvexError(new ConvexError("internal backend detail"))).toBe(
       null,
     );
+  });
+
+  // AppError reaches /v1 routes from every Convex function they call. Its
+  // payload is dashboard-facing, so routes must keep their generic fallback
+  // rather than start publishing internal codes and details.
+  it("does not expose dashboard-scoped AppError payloads", () => {
+    expect(handleConvexError(createError(ErrorCode.PROJECT_NOT_FOUND))).toBe(
+      null,
+    );
+    expect(
+      handleConvexError(
+        createError(ErrorCode.INVALID_INPUT, "Sync job not found"),
+      ),
+    ).toBe(null);
   });
 });

--- a/packages/kit/server/convex.ts
+++ b/packages/kit/server/convex.ts
@@ -42,9 +42,8 @@ export function handleConvexError(error: unknown): ApiError | null {
     return null;
   }
 
-  // Dashboard-scoped payloads keep the generic 500 fallback: `/v1` responses
-  // are a published contract that shipped SDKs decode, so internal codes and
-  // details must not start appearing there. See packages/kit/CONVENTION.md.
+  // `/v1` is a published contract shipped SDKs decode, so dashboard-scoped
+  // payloads keep the generic fallback. See packages/kit/CONVENTION.md.
   const data: unknown = error.data;
   if (
     typeof data === "object" &&

--- a/packages/kit/server/convex.ts
+++ b/packages/kit/server/convex.ts
@@ -1,6 +1,7 @@
 import { ConvexHttpClient } from "convex/browser";
 import { ConvexError } from "convex/values";
 import * as v from "valibot";
+import { APP_ERROR_SCOPE } from "../convex/utils/errors";
 
 export function resolveServerConvexUrl(
   env: Readonly<Record<string, string | undefined>> = process.env,
@@ -38,6 +39,18 @@ interface ApiError {
 
 export function handleConvexError(error: unknown): ApiError | null {
   if (error instanceof ConvexError === false) {
+    return null;
+  }
+
+  // Dashboard-scoped payloads keep the generic 500 fallback: `/v1` responses
+  // are a published contract that shipped SDKs decode, so internal codes and
+  // details must not start appearing there. See packages/kit/CONVENTION.md.
+  const data: unknown = error.data;
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { scope?: unknown }).scope === APP_ERROR_SCOPE
+  ) {
     return null;
   }
 

--- a/packages/kit/src/lib/appError.test.ts
+++ b/packages/kit/src/lib/appError.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCode, createError } from "../../convex/utils/errors";
+import { appErrorCode } from "./appError";
+
+describe("appErrorCode", () => {
+  it("reads the code an AppError actually puts on the wire", () => {
+    expect(
+      appErrorCode({ data: createError(ErrorCode.USER_NOT_REGISTERED).data }),
+    ).toBe(ErrorCode.USER_NOT_REGISTERED);
+  });
+
+  it("returns the enum member, not a bare string", () => {
+    expect(appErrorCode({ data: { code: "USER_ALREADY_MEMBER" } })).toBe(
+      ErrorCode.USER_ALREADY_MEMBER,
+    );
+  });
+
+  it("ignores codes the enum does not declare", () => {
+    expect(appErrorCode({ data: { code: "MADE_UP_CODE" } })).toBeUndefined();
+    expect(appErrorCode({ data: { code: 42 } })).toBeUndefined();
+  });
+
+  it("returns undefined for errors that carry no application data", () => {
+    expect(appErrorCode({ message: "Server Error" })).toBeUndefined();
+    expect(appErrorCode({ data: "plain string payload" })).toBeUndefined();
+    expect(appErrorCode(null)).toBeUndefined();
+    expect(appErrorCode(undefined)).toBeUndefined();
+    expect(appErrorCode({})).toBeUndefined();
+  });
+});

--- a/packages/kit/src/lib/appError.ts
+++ b/packages/kit/src/lib/appError.ts
@@ -1,0 +1,15 @@
+import { ErrorCode } from "../../convex/utils/errors";
+
+/**
+ * Reads the error code a Convex mutation reports on `ConvexError.data`.
+ *
+ * Production deployments redact plain Errors to "Server Error", so the code
+ * only survives as application-error data.
+ */
+export function appErrorCode(error: unknown): ErrorCode | undefined {
+  const data = (error as { data?: unknown } | null | undefined)?.data;
+  if (!data || typeof data !== "object" || !("code" in data)) return undefined;
+
+  const { code } = data as { code?: unknown };
+  return Object.values(ErrorCode).find((declared) => declared === code);
+}

--- a/packages/kit/src/lib/appError.ts
+++ b/packages/kit/src/lib/appError.ts
@@ -1,11 +1,6 @@
 import { ErrorCode } from "../../convex/utils/errors";
 
-/**
- * Reads the error code a Convex mutation reports on `ConvexError.data`.
- *
- * Production deployments redact plain Errors to "Server Error", so the code
- * only survives as application-error data.
- */
+/** Reads the code from `ConvexError.data`; production redacts plain Errors. */
 export function appErrorCode(error: unknown): ErrorCode | undefined {
   const data = (error as { data?: unknown } | null | undefined)?.data;
   if (!data || typeof data !== "object" || !("code" in data)) return undefined;

--- a/packages/kit/src/pages/auth/organization/settings.tsx
+++ b/packages/kit/src/pages/auth/organization/settings.tsx
@@ -6,6 +6,8 @@ import type { Id } from "@/convex";
 import { toast } from "sonner";
 import { CustomDropdown } from "../../../components/CustomDropdown";
 import { ButtonPrimary } from "@/components/ButtonPrimary";
+import { ErrorCode } from "../../../../convex/utils/errors";
+import { appErrorCode } from "@/lib/appError";
 import {
   Building2,
   Users,
@@ -104,20 +106,21 @@ export default function OrganizationSettings() {
       toast.success("Member invited successfully");
       setInviteEmail("");
       setInviteRole("member");
-    } catch (error: any) {
-      // Handle specific error codes with i18n - only show one toast
-      if (error?.message) {
-        if (error.message.includes("USER_NOT_REGISTERED")) {
+    } catch (error: unknown) {
+      switch (appErrorCode(error)) {
+        case ErrorCode.USER_NOT_REGISTERED:
           toast.error(
-            "This user is not registered on IAPKit. Please ask them to sign up first.",
+            "No IAPKit account for that email. Ask them to sign up at kit.openiap.dev, then invite them again.",
           );
-        } else if (error.message.includes("USER_ALREADY_MEMBER")) {
+          break;
+        case ErrorCode.USER_ALREADY_MEMBER:
           toast.error("This user is already a member of this organization.");
-        } else if (error.message.includes("INSUFFICIENT_PERMISSIONS")) {
+          break;
+        case ErrorCode.INSUFFICIENT_PERMISSIONS:
           toast.error("You don't have permission to perform this action.");
-        } else {
+          break;
+        default:
           toast.error("Failed to invite member");
-        }
       }
     } finally {
       setIsInviting(false);
@@ -141,20 +144,16 @@ export default function OrganizationSettings() {
         userId,
       });
       toast.success("Member removed successfully");
-    } catch (error: any) {
-      // Handle specific error codes with i18n
-      if (
-        error?.message &&
-        error.message.includes("INSUFFICIENT_PERMISSIONS")
-      ) {
-        toast.error("You don't have permission to perform this action.");
-      } else if (
-        error?.message &&
-        error.message.includes("CANNOT_REMOVE_OWNER")
-      ) {
-        toast.error("Cannot remove the last owner of the organization.");
-      } else {
-        toast.error("Failed to remove member");
+    } catch (error: unknown) {
+      switch (appErrorCode(error)) {
+        case ErrorCode.INSUFFICIENT_PERMISSIONS:
+          toast.error("You don't have permission to perform this action.");
+          break;
+        case ErrorCode.CANNOT_REMOVE_OWNER:
+          toast.error("Cannot remove the last owner of the organization.");
+          break;
+        default:
+          toast.error("Failed to remove member");
       }
     }
   };
@@ -349,7 +348,12 @@ export default function OrganizationSettings() {
             }}
             className="mb-6 p-4 bg-muted rounded border border-border"
           >
-            <h3 className="font-medium mb-3">{"Invite New Member"}</h3>
+            <h3 className="font-medium mb-1">{"Invite New Member"}</h3>
+            <p className="text-sm text-muted-foreground mb-3">
+              {
+                "The person needs an IAPKit account first. Ask them to sign up at kit.openiap.dev, then invite them with that email."
+              }
+            </p>
             <div className="flex gap-3">
               <input
                 type="email"


### PR DESCRIPTION
## Summary

- `AppError` extended plain `Error`, so Convex redacted it to a generic "Server Error" on production deployments and the error code never reached the browser. Every user-facing failure across **56 `createError` throw sites** fell through to a fallback message.
- Reported from Discord: inviting a teammate who has no IAPKit account showed **"Failed to invite member"** with no cause and no next step. The helpful copy already existed in `settings.tsx` — it just never ran, because `error.message.includes("USER_NOT_REGISTERED")` cannot match a redacted message.
- `AppError` now extends `ConvexError`, so the code travels on `error.data`. The dashboard reads it through a small `appErrorCode()` helper and switches on `ErrorCode` members.

## Keeping `/v1` unchanged

Making `AppError` a `ConvexError` has a side effect that is easy to miss: it also makes those errors pass `handleConvexError`, which the `/v1` product-sync routes use to decide between a client-safe body and their generic fallback.

Without a guard, `POST /v1/products/sync/:platform` with a bad key would have changed from `500 {code:"PRODUCT_SYNC_ENQUEUE_FAILED"}` to `400 {code:"PROJECT_NOT_FOUND", message:"..."}` — a status class change, a different `errors[0].code`, and internal detail text (`"INVALID_INPUT: Sync job not found"`) newly published. `CONVENTION.md` requires `/v1` changes to be additive and gated, and a kit deploy reaches every shipped SDK at once.

`AppError` payloads now carry a `scope: "dashboard"` marker that `handleConvexError` rejects, so those routes keep their existing fallback. Errors thrown as `new ConvexError({code, message})` directly (products query/regions/localizations) carry no marker and are untouched.

## Changes

### Backend
- `convex/utils/errors.ts` — `AppError extends ConvexError<AppErrorData>`; payload carries `code`, `message`, and the dashboard scope marker. `Error.message` still reads `CODE` / `CODE: details` so server logs stay greppable by code. Dropped the unread `statusCode` field, and `data.message` no longer repeats the code.
- `server/convex.ts` — `handleConvexError` returns `null` for dashboard-scoped payloads.

### Frontend
- `src/lib/appError.ts` — reads `data.code` and validates it against the `ErrorCode` enum.
- `src/pages/auth/organization/settings.tsx` — two catch blocks (five code branches) switch on `ErrorCode` members instead of substring matching. A typo is now a compile error. Invite errors name the cause and the next step, and the invite form states the account requirement before the attempt. Side effect: the old `if (error?.message)` guard showed **no** toast for a message-less rejection; the `default` branch now always fires.

## Test plan

- [x] `convex/utils/errors.test.ts` pins the producer, including `Symbol.for("ConvexError") in error` — the exact check Convex uses to decide redaction
- [x] `server/convex.test.ts` pins the `/v1` boundary
- [x] Regression-injected both guards: reverting `AppError` to `extends Error` fails 4 tests; removing the `/v1` guard fails 1
- [x] kit suite 1250 passed / 1 skipped; tsc, `convex typecheck`, eslint, production vite build
- [x] `bun run audit:kit-contract` plus layout / docs / agents / ci-paths / facts / parity
- [x] Dev deployment A/B on a live Convex deployment: same call returned `Error: … Server Error` before and `ConvexError: … Server Error` after
- [x] Browser E2E against the dev deployment — unregistered invite, successful invite, duplicate invite all show the correct message

## Device regression

Not applicable — the diff is confined to `packages/kit` and touches no `packages/apple`, `packages/google`, or `libraries/` path, no native build configuration, and no store metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable application error codes and details for consistent error handling.
  * Added guidance that invitees must have an IAPKit account before receiving invitations.
  * Improved messaging for users who are not registered.

* **Bug Fixes**
  * Prevented dashboard-specific error details from appearing in generic error responses.
  * Improved invite and member-removal error handling for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->