### PR TITLE
fix(rn): preserve purchase listeners on Android

### DIFF
--- a/.github/workflows/ci-react-native-iap.yml
+++ b/.github/workflows/ci-react-native-iap.yml
@@ -121,6 +121,39 @@ jobs:
       - name: Consumer install smoke test
         run: yarn verify:consumer-install
 
+  android-unit:
+    name: Android unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable && corepack prepare yarn@3.6.1 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Generate Nitro bridge
+        run: yarn nitrogen
+
+      - name: Install JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Run Android unit tests
+        working-directory: libraries/react-native-iap/example/android
+        run: ./gradlew :react-native-iap:testDebugUnitTest --stacktrace
+
   ios-xcode-27:
     name: iOS example (Xcode 27)
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/release-react-native.yml
+++ b/.github/workflows/release-react-native.yml
@@ -102,9 +102,11 @@ jobs:
       - name: Accept Android SDK licenses
         run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses || true
 
-      - name: Build Android library
+      - name: Test and build Android library
         working-directory: libraries/react-native-iap/example/android
-        run: ./gradlew :react-native-iap:assembleDebug --stacktrace
+        run: >-
+          ./gradlew :react-native-iap:testDebugUnitTest
+          :react-native-iap:assembleDebug --stacktrace
 
   validate-ios:
     needs: [release-branch]

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -146,11 +146,6 @@ internal fun requireMatchingPurchaseOptions(
 private const val MAX_PENDING_EVENTS = 200
 
 class HybridRnIap : HybridRnIapSpec() {
-    private data class PurchaseUpdatedListenerRegistration(
-        val token: Double,
-        val listener: (NitroPurchase) -> Unit
-    )
-    
     // Get ReactApplicationContext lazily from NitroModules
     private val context: ReactApplicationContext by lazy {
         NitroModules.applicationContext as ReactApplicationContext
@@ -161,8 +156,7 @@ class HybridRnIap : HybridRnIapSpec() {
     private val productTypeBySku = mutableMapOf<String, String>()
 
     // Event listeners
-    private val purchaseUpdatedListeners = mutableListOf<PurchaseUpdatedListenerRegistration>()
-    private var nextPurchaseUpdatedListenerToken = 1.0
+    private val purchaseUpdatedListeners = TokenizedListenerRegistry<(NitroPurchase) -> Unit>()
     private val purchaseErrorListeners = mutableListOf<(NitroPurchaseResult) -> Unit>()
 
     // Pending purchase events buffered while ZERO bridge listeners are attached
@@ -441,7 +435,6 @@ class HybridRnIap : HybridRnIapSpec() {
                     // buffered events do not survive an explicit endConnection.
                     synchronized(purchaseUpdatedListeners) {
                         purchaseUpdatedListeners.clear()
-                        nextPurchaseUpdatedListenerToken = 1.0
                         pendingPurchaseUpdates.clear()
                     }
                     synchronized(purchaseErrorListeners) {
@@ -991,9 +984,7 @@ class HybridRnIap : HybridRnIapSpec() {
         options: PurchaseUpdatedListenerOptions?
     ): Double {
         val (token, shouldFlush) = synchronized(purchaseUpdatedListeners) {
-            val token = nextPurchaseUpdatedListenerToken
-            nextPurchaseUpdatedListenerToken += 1.0
-            purchaseUpdatedListeners.add(PurchaseUpdatedListenerRegistration(token, listener))
+            val token = purchaseUpdatedListeners.add(listener)
             val shouldFlush = pendingPurchaseUpdates.beginFlushIfNeeded()
             token to shouldFlush
         }
@@ -1016,7 +1007,7 @@ class HybridRnIap : HybridRnIapSpec() {
                     pendingPurchaseUpdates.takeBatchOrFinish()?.let { backlog ->
                         PendingEventDelivery(
                             events = backlog,
-                            listeners = purchaseUpdatedListeners.map { it.listener },
+                            listeners = purchaseUpdatedListeners.snapshot(),
                         )
                     }
                 }
@@ -1047,7 +1038,7 @@ class HybridRnIap : HybridRnIapSpec() {
 
     override fun removePurchaseUpdatedListener(token: Double) {
         synchronized(purchaseUpdatedListeners) {
-            purchaseUpdatedListeners.removeAll { it.token == token }
+            purchaseUpdatedListeners.remove(token)
         }
     }
 
@@ -1090,7 +1081,7 @@ class HybridRnIap : HybridRnIapSpec() {
             if (pendingPurchaseUpdates.enqueueIfNeeded(purchaseUpdatedListeners.isNotEmpty(), purchase)) {
                 emptyList()
             } else {
-                purchaseUpdatedListeners.map { it.listener }
+                purchaseUpdatedListeners.snapshot()
             }
         }
         snapshot.forEach { it(purchase) }

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/TokenizedListenerRegistry.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/TokenizedListenerRegistry.kt
@@ -1,0 +1,40 @@
+package com.margelo.nitro.iap
+
+/** Callers may also lock this registry to coordinate listener and queue state. */
+internal class TokenizedListenerRegistry<T> {
+    private data class Registration<T>(
+        val token: Double,
+        val listener: T,
+    )
+
+    private val registrations = mutableListOf<Registration<T>>()
+    private var nextToken = 1.0
+
+    @Synchronized
+    fun add(listener: T): Double {
+        val token = nextToken
+        nextToken += 1.0
+        registrations.add(Registration(token, listener))
+        return token
+    }
+
+    @Synchronized
+    fun remove(token: Double): Boolean {
+        val index = registrations.indexOfFirst { it.token == token }
+        if (index < 0) return false
+        registrations.removeAt(index)
+        return true
+    }
+
+    @Synchronized
+    fun isNotEmpty(): Boolean = registrations.isNotEmpty()
+
+    @Synchronized
+    fun snapshot(): List<T> = registrations.map { it.listener }
+
+    @Synchronized
+    fun clear() {
+        registrations.clear()
+        nextToken = 1.0
+    }
+}

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/TokenizedListenerRegistryTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/TokenizedListenerRegistryTest.kt
@@ -1,0 +1,45 @@
+package com.margelo.nitro.iap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TokenizedListenerRegistryTest {
+    @Test
+    fun `removing one token preserves the other listener`() {
+        val registry = TokenizedListenerRegistry<(String) -> Unit>()
+        val events = mutableListOf<String>()
+        val firstToken = registry.add { events.add("first:$it") }
+        val secondToken = registry.add { events.add("second:$it") }
+
+        assertEquals(2.0, secondToken, 0.0)
+        assertTrue(registry.remove(firstToken))
+        registry.snapshot().forEach { it("purchase") }
+
+        assertEquals(listOf("second:purchase"), events)
+    }
+
+    @Test
+    fun `removing an unknown token preserves all listeners`() {
+        val registry = TokenizedListenerRegistry<(String) -> Unit>()
+        registry.add { }
+        registry.add { }
+
+        assertFalse(registry.remove(999.0))
+
+        assertEquals(2, registry.snapshot().size)
+    }
+
+    @Test
+    fun `clear removes all listeners and resets token allocation`() {
+        val registry = TokenizedListenerRegistry<() -> Unit>()
+        registry.add { }
+        registry.add { }
+
+        registry.clear()
+
+        assertFalse(registry.isNotEmpty())
+        assertEquals(1.0, registry.add { }, 0.0)
+    }
+}

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -631,6 +631,43 @@ describe('Public API (src/index.ts)', () => {
 
       sub2.remove();
     });
+
+    it('clears pre-init listeners when ending without a native instance', async () => {
+      const createHybridObject = jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Nitro runtime not installed');
+        })
+        .mockImplementation(() => mockIap);
+      jest.resetModules();
+      jest.doMock('react-native-nitro-modules', () => ({
+        NitroModules: {createHybridObject},
+      }));
+      const freshIAP = require('../index');
+      const staleListener = jest.fn();
+
+      freshIAP.purchaseUpdatedListener(staleListener);
+      await expect(freshIAP.endConnection()).resolves.toBe(true);
+      await freshIAP.initConnection();
+
+      const currentListener = jest.fn();
+      freshIAP.purchaseUpdatedListener(currentListener);
+      const nativeHandler =
+        mockIap.addPurchaseUpdatedListener.mock.calls.at(-1)[0];
+      nativeHandler({
+        id: 't1',
+        transactionId: 't1',
+        productId: 'p1',
+        transactionDate: Date.now(),
+        store: 'apple',
+        quantity: 1,
+        purchaseState: 'purchased',
+        isAutoRenewing: false,
+      });
+
+      expect(staleListener).not.toHaveBeenCalled();
+      expect(currentListener).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('fetchProducts', () => {
@@ -3384,6 +3421,9 @@ describe('Public API (src/index.ts)', () => {
 
       replaceNativeMethod('initConnection', jest.fn().mockResolvedValue(true));
       expect(IAP.isNitroReady()).toBe(true);
+      (Platform as any).OS = 'android';
+      const staleListener = jest.fn();
+      IAP.purchaseUpdatedListener(staleListener);
       replaceNativeMethod(
         'endConnection',
         jest.fn().mockRejectedValueOnce(new Error('end failed')),
@@ -3391,6 +3431,25 @@ describe('Public API (src/index.ts)', () => {
       await expect(IAP.endConnection()).rejects.toMatchObject({
         message: 'end failed',
       });
+
+      await IAP.initConnection();
+      const currentListener = jest.fn();
+      IAP.purchaseUpdatedListener(currentListener);
+      expect(mockIap.addPurchaseUpdatedListener).toHaveBeenCalledTimes(2);
+
+      const nativeHandler = mockIap.addPurchaseUpdatedListener.mock.calls[1][0];
+      nativeHandler({
+        id: 't1',
+        transactionId: 't1',
+        productId: 'p1',
+        transactionDate: Date.now(),
+        store: 'google',
+        quantity: 1,
+        purchaseState: 'purchased',
+        isAutoRenewing: false,
+      });
+      expect(staleListener).not.toHaveBeenCalled();
+      expect(currentListener).toHaveBeenCalledTimes(1);
     });
 
     it.each([

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -259,11 +259,9 @@ const IAP = {
 // ============================================================================
 // EVENT LISTENERS
 //
-// Uses a singleton native listener per event type with JS-level fan-out.
-// This avoids the iOS bug where removePurchaseUpdatedListener calls
-// removeAll() instead of removing a specific listener, which caused ALL
-// listeners to be lost when any single useIAP instance unmounted.
-// See: https://github.com/hyochan/react-native-iap/issues/3150
+// Uses one native listener per event type with JS fan-out so removing one JS
+// subscriber cannot detach another. See hyochan/react-native-iap#3150 and
+// hyodotdev/openiap#382.
 // ============================================================================
 
 const purchaseUpdateJsListeners = new Set<(purchase: Purchase) => void>();
@@ -1593,9 +1591,7 @@ export const initConnection: MutationField<'initConnection'> = async (
 export const endConnection: MutationField<'endConnection'> = async () => {
   try {
     if (!iapRef) return true;
-    const result = await IAP.instance.endConnection();
-    resetListenerState();
-    return result;
+    return await IAP.instance.endConnection();
   } catch (error) {
     const parsedError = parseErrorAndLogIfNeeded(
       'Failed to end IAP connection:',
@@ -1607,6 +1603,8 @@ export const endConnection: MutationField<'endConnection'> = async () => {
       responseCode: parsedError.responseCode,
       debugMessage: parsedError.debugMessage,
     });
+  } finally {
+    resetListenerState();
   }
 };
 


### PR DESCRIPTION
## Summary

- preserve independent Android purchase-update registrations when one token is removed
- reset JS listener tracking on every connection-end path so listeners reattach after native cleanup or failure
- run Android JVM tests in pull-request CI and release validation

## Background

React Native IAP 14.7.0 and 14.7.11 cleared Android purchase-update registrations during native removal. Version 14.7.16 added JS singleton fan-out and changed Android native removal to callback-based removal, while token-based native removal became available from 15.2.4 onward.

The current 16.3.2 implementation already uses JS fan-out and native tokens. This change hardens that boundary with an isolated token registry, direct native regression coverage, and connection-failure reattachment tests.

Closes #382

## Test plan

- [x] React Native IAP Jest: 19 suites, 593 tests
- [x] TypeScript typecheck
- [x] Android JVM suite: 32 tests, including token removal and reconnect lifecycle regressions
- [x] Android library debug assembly
- [x] Play physical-device store connection and product loading
- [x] FireOS physical-device store connection and product loading
- [x] Horizon example build
- [x] parity, CI path-filter, workflow security, release-state, and pre-commit audits

No new store purchase was initiated or approved during device testing.

## Preview

Not applicable: this is a native listener-lifecycle fix with no visual UI change. The device-backed store-connection checks above cover the affected runtime surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved purchase event listener cleanup when ending or restarting a connection, including after initialization or shutdown failures.
  * Prevented stale listeners from receiving purchase updates after reconnection.
  * Improved listener management for more reliable event delivery.

* **Tests**
  * Added coverage for listener removal, cleanup, token handling, and connection lifecycle failure scenarios.
  * Android validation now runs unit tests before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->