### PR TITLE
fix(apple): gate storekit 26.5 symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,36 @@ jobs:
         working-directory: packages/apple
         run: swift test
 
+  test-ios-compiler-boundaries:
+    name: Build iOS guard boundary (Xcode ${{ matrix.xcode-version }})
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            xcode-version: "16.3"
+          - runner: macos-26
+            xcode-version: "26.0.1"
+          - runner: macos-26
+            xcode-version: "26.4.1"
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+
+      - name: Build in Swift 5 language mode
+        working-directory: packages/apple
+        run: swift build -Xswiftc -swift-version -Xswiftc 5
+
   test-docs:
     name: Test Docs
     runs-on: ubuntu-latest

--- a/packages/apple/Sources/Helpers/StoreKitTypesBridge.swift
+++ b/packages/apple/Sources/Helpers/StoreKitTypesBridge.swift
@@ -418,10 +418,9 @@ enum StoreKitTypesBridge {
 
         // Subscription-only options (only available on RequestSubscriptionIosProps)
         if let subscriptionProps = props as? RequestSubscriptionIosProps {
-            // Billing plan selection is available at runtime on iOS 26.4+, but
-            // compiling the StoreKit API requires the Xcode 26.5 SDK.
+            // Xcode 26.5 (Swift 6.3.2) is the first SDK with billing plan symbols.
             if let billingPlanType = subscriptionProps.billingPlanType {
-                #if compiler(>=6.3)
+                #if compiler(>=6.3.2)
                 if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
                     switch billingPlanType {
                     case .monthly:
@@ -446,7 +445,7 @@ enum StoreKitTypesBridge {
                 throw PurchaseError.make(
                     code: .featureNotSupported,
                     productId: props.sku,
-                    message: "billingPlanType requires Xcode 26.5+ / Swift 6.3 compiler+."
+                    message: "billingPlanType requires Xcode 26.5+ / Swift 6.3.2 compiler+."
                 )
                 #endif
             }
@@ -706,7 +705,7 @@ enum StoreKitTypesBridge {
     }
 
     static func renewalCommitmentInfoIOS(from info: StoreKit.Product.SubscriptionInfo.RenewalInfo) -> RenewalCommitmentInfoIOS? {
-        #if compiler(>=6.3)
+        #if compiler(>=6.3.2)
         if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             guard let commitment = info.commitmentInfo else { return nil }
             return RenewalCommitmentInfoIOS(
@@ -730,7 +729,7 @@ enum StoreKitTypesBridge {
     }
 
     static func renewalBillingPlanTypeIOS(from info: StoreKit.Product.SubscriptionInfo.RenewalInfo) -> SubscriptionBillingPlanTypeIOS? {
-        #if compiler(>=6.3)
+        #if compiler(>=6.3.2)
         if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             return info.renewalBillingPlanType.map { billingPlanTypeIOS(from: $0) }
         }
@@ -801,7 +800,7 @@ private extension StoreKitTypesBridge {
 
     static func makeSubscriptionPricingTerms(from info: StoreKit.Product.SubscriptionInfo?) -> [SubscriptionPricingTermsIOS]? {
         guard let info else { return nil }
-        #if compiler(>=6.3)
+        #if compiler(>=6.3.2)
         if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             let terms = info.pricingTerms.map { makeSubscriptionPricingTerm(from: $0) }
             return terms.isEmpty ? nil : terms
@@ -834,7 +833,7 @@ private extension StoreKitTypesBridge {
         return nil
     }
 
-    #if compiler(>=6.3)
+    #if compiler(>=6.3.2)
     @available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *)
     static func makeSubscriptionPricingTerm(from terms: StoreKit.Product.SubscriptionInfo.PricingTerms) -> SubscriptionPricingTermsIOS {
         let offers = terms.subscriptionOffers.compactMap { offer in
@@ -863,7 +862,7 @@ private extension StoreKitTypesBridge {
     }
     #endif
 
-    #if compiler(>=6.3)
+    #if compiler(>=6.3.2)
     @available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *)
     static func billingPlanTypeIOS(from type: StoreKit.Product.SubscriptionInfo.BillingPlanType) -> SubscriptionBillingPlanTypeIOS {
         if type == .monthly {
@@ -877,7 +876,7 @@ private extension StoreKitTypesBridge {
     #endif
 
     static func billingPlanTypeIOS(from transaction: StoreKit.Transaction) -> SubscriptionBillingPlanTypeIOS? {
-        #if compiler(>=6.3)
+        #if compiler(>=6.3.2)
         if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             return transaction.billingPlanType.map { billingPlanTypeIOS(from: $0) }
         }
@@ -886,7 +885,7 @@ private extension StoreKitTypesBridge {
     }
 
     static func transactionCommitmentInfoIOS(from transaction: StoreKit.Transaction) -> TransactionCommitmentInfoIOS? {
-        #if compiler(>=6.3)
+        #if compiler(>=6.3.2)
         if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             guard let commitment = transaction.commitmentInfo else { return nil }
             return TransactionCommitmentInfoIOS(

--- a/packages/apple/Sources/Helpers/StoreKitTypesBridge.swift
+++ b/packages/apple/Sources/Helpers/StoreKitTypesBridge.swift
@@ -1161,7 +1161,7 @@ private extension StoreKitTypesBridge {
     }
 
     static func revocationTypeIOS(from transaction: StoreKit.Transaction) -> String? {
-        #if compiler(>=6.4)
+        #if compiler(>=6.3.2)
         if #available(iOS 26.4, macOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             return transaction.revocationType?.rawValue
         }

--- a/packages/apple/Tests/OpenIapTests/CompilerGuardTests.swift
+++ b/packages/apple/Tests/OpenIapTests/CompilerGuardTests.swift
@@ -27,4 +27,32 @@ final class CompilerGuardTests: XCTestCase {
             )
         }
     }
+
+    func testXcode265StoreKitFeaturesUseSwift632Guard() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = packageRoot.appendingPathComponent(
+            "Sources/Helpers/StoreKitTypesBridge.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let sdkGuardCount = source.components(
+            separatedBy: "#if compiler(>=6.3.2)"
+        ).count - 1
+        let swift63GuardCount = source.components(
+            separatedBy: "#if compiler(>=6.3)"
+        ).count - 1
+
+        XCTAssertEqual(
+            sdkGuardCount,
+            8,
+            "Xcode 26.5 StoreKit paths must stay excluded from Xcode 26.4 builds."
+        )
+        XCTAssertEqual(
+            swift63GuardCount,
+            1,
+            "The Xcode 26.4-compatible JWS promotional offer must keep its Swift 6.3 guard."
+        )
+    }
 }

--- a/packages/apple/Tests/OpenIapTests/CompilerGuardTests.swift
+++ b/packages/apple/Tests/OpenIapTests/CompilerGuardTests.swift
@@ -28,7 +28,7 @@ final class CompilerGuardTests: XCTestCase {
         }
     }
 
-    func testXcode265StoreKitFeaturesUseSwift632Guard() throws {
+    func testStoreKitSDKSymbolsUseMinimumCompilerGuards() throws {
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -37,22 +37,53 @@ final class CompilerGuardTests: XCTestCase {
             "Sources/Helpers/StoreKitTypesBridge.swift"
         )
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
-        let sdkGuardCount = source.components(
-            separatedBy: "#if compiler(>=6.3.2)"
-        ).count - 1
-        let swift63GuardCount = source.components(
-            separatedBy: "#if compiler(>=6.3)"
-        ).count - 1
+        let xcode265Symbols = [
+            "options.insert(.billingPlanType(.monthly))",
+            "guard let commitment = info.commitmentInfo",
+            "return info.renewalBillingPlanType.map",
+            "let terms = info.pricingTerms.map",
+            "from terms: StoreKit.Product.SubscriptionInfo.PricingTerms",
+            "from type: StoreKit.Product.SubscriptionInfo.BillingPlanType",
+            "return transaction.billingPlanType.map",
+            "guard let commitment = transaction.commitmentInfo",
+            "return transaction.revocationType?.rawValue",
+        ]
 
+        for symbol in xcode265Symbols {
+            XCTAssertEqual(
+                compilerGuard(containing: symbol, in: source),
+                "#if compiler(>=6.3.2)",
+                "\(symbol) must stay excluded from Xcode 26.4 builds."
+            )
+        }
         XCTAssertEqual(
-            sdkGuardCount,
-            8,
-            "Xcode 26.5 StoreKit paths must stay excluded from Xcode 26.4 builds."
-        )
-        XCTAssertEqual(
-            swift63GuardCount,
-            1,
+            compilerGuard(containing: "compactJWS: jwsOffer.jws", in: source),
+            "#if compiler(>=6.3)",
             "The Xcode 26.4-compatible JWS promotional offer must keep its Swift 6.3 guard."
         )
+        XCTAssertEqual(
+            source.components(separatedBy: "#if compiler(>=6.3.2)").count - 1,
+            xcode265Symbols.count
+        )
+    }
+
+    private func compilerGuard(containing needle: String, in source: String) -> String? {
+        var conditions: [String?] = []
+
+        for line in source.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("#if ") {
+                conditions.append(
+                    trimmed.hasPrefix("#if compiler(") ? trimmed : nil
+                )
+            }
+            if line.contains(needle) {
+                return conditions.reversed().compactMap { $0 }.first
+            }
+            if trimmed.hasPrefix("#endif") {
+                conditions.removeLast()
+            }
+        }
+        return nil
     }
 }

--- a/scripts/audit-facts.test.mjs
+++ b/scripts/audit-facts.test.mjs
@@ -17,16 +17,15 @@ test("the committed tree passes", () => {
 });
 
 test("catches a runner image left behind on a bump", () => {
-  // The exact drift shipped in release-godot.yml until 2026-08-20.
   const failures = auditFacts(
     overlaying(".github/workflows/release-godot.yml", (text) =>
-      text.replace("runs-on: macos-26", "runs-on: macos-15"),
+      text.replace("runs-on: macos-26", "runs-on: macos-14"),
     ),
   );
   assert.equal(failures.length, 1);
   assert.match(
     failures[0],
-    /runner\.macos-image: .*release-godot.*"macos-15"/u,
+    /runner\.macos-image: .*release-godot.*"macos-14"/u,
   );
 });
 

--- a/scripts/facts.mjs
+++ b/scripts/facts.mjs
@@ -15,7 +15,12 @@ const WORKFLOWS = ".github/workflows/*.{yml,yaml}";
 export const FACTS = Object.freeze([
   {
     key: "toolchain.xcode",
-    values: { pinned: "26.6" },
+    values: {
+      pinned: "26.6",
+      swift61Boundary: "16.3",
+      swift62Boundary: "26.0.1",
+      swift631Boundary: "26.4.1",
+    },
     scanners: [
       {
         files: [WORKFLOWS],
@@ -25,7 +30,7 @@ export const FACTS = Object.freeze([
   },
   {
     key: "runner.macos-image",
-    values: { hosted: "macos-26" },
+    values: { hosted: "macos-26", swift61Boundary: "macos-15" },
     scanners: [{ files: [WORKFLOWS], pattern: /\b(macos-\d+)\b/g }],
   },
   {


### PR DESCRIPTION
## Summary

- Gate the eight StoreKit billing-plan and commitment paths on Swift 6.3.2, the compiler bundled with the Xcode 26.5 SDK.
- Move `Transaction.revocationType` from the overly strict Swift 6.4 guard to Swift 6.3.2 because the Xcode 26.5 SDK already declares it.
- Keep the JWS promotional-offer path on Swift 6.3 because that API is present in the Xcode 26.4 SDK.
- Verify each affected StoreKit symbol path instead of relying only on compiler-guard counts.
- Build the Apple package at the Swift 6.1, 6.2, and 6.3.1 SDK boundaries so future compiler/SDK guard mismatches fail CI.

Closes #386

## Test plan

- [x] `swift test --filter CompilerGuardTests` (2 tests)
- [x] `swift build -Xswiftc -swift-version -Xswiftc 5`
- [x] `swift test --filter OpenIapTests` (163 tests)
- [x] `bun run audit:parity`
- [x] `bun run audit:ci-paths`
- [x] `bun run audit:facts`
- [x] Workflow security and formatting checks
- [x] CI boundary builds with Xcode 16.3, 26.0.1, and 26.4.1

## Preview

No recording is applicable because this is a native compile-time compatibility fix with no visual or interactive surface. The build matrix and terminal verification above cover the changed behavior.
