### PR TITLE
fix(hooks): support late billing callbacks

### DIFF
--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.android.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.android.test.ts
@@ -25,6 +25,10 @@ const mockIap: any = {
   removePromotedProductListenerIOS: jest.fn(),
   addSubscriptionBillingIssueListener: jest.fn(),
   removeSubscriptionBillingIssueListener: jest.fn(),
+  addUserChoiceBillingListenerAndroid: jest.fn(),
+  removeUserChoiceBillingListenerAndroid: jest.fn(),
+  addDeveloperProvidedBillingListenerAndroid: jest.fn(),
+  removeDeveloperProvidedBillingListenerAndroid: jest.fn(),
   openRedeemOfferCodeAndroid: jest.fn(async () => true),
 };
 
@@ -163,6 +167,65 @@ describe('hooks/useIAP Android', () => {
     };
     listener?.(details);
 
+    expect(onDeveloperProvidedBillingAndroid).toHaveBeenCalledWith(details);
+  });
+
+  it('forwards alternative billing events to callbacks added after mount', async () => {
+    let userChoiceListener:
+      | Parameters<typeof IAP.userChoiceBillingListenerAndroid>[0]
+      | undefined;
+    let developerProvidedListener:
+      | Parameters<typeof IAP.developerProvidedBillingListenerAndroid>[0]
+      | undefined;
+    jest
+      .spyOn(IAP, 'userChoiceBillingListenerAndroid')
+      .mockImplementation((callback) => {
+        userChoiceListener = callback;
+        return {remove: jest.fn()};
+      });
+    jest
+      .spyOn(IAP, 'developerProvidedBillingListenerAndroid')
+      .mockImplementation((callback) => {
+        developerProvidedListener = callback;
+        return {remove: jest.fn()};
+      });
+
+    const onUserChoiceBillingAndroid = jest.fn();
+    const onDeveloperProvidedBillingAndroid = jest.fn();
+    let callbacks: Parameters<typeof useIAP>[0];
+    const Harness = () => {
+      useIAP(callbacks);
+      return null;
+    };
+
+    let root: Root;
+    await act(async () => {
+      root = TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+
+    callbacks = {
+      onUserChoiceBillingAndroid,
+      onDeveloperProvidedBillingAndroid,
+    };
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    const details: DeveloperProvidedBillingDetailsAndroid = {
+      externalTransactionToken: 'external-token',
+      products: [{id: 'premium', type: 'in-app'}],
+    };
+    userChoiceListener?.({
+      externalTransactionToken: 'choice-token',
+      products: ['premium'],
+    });
+    developerProvidedListener?.(details);
+
+    expect(onUserChoiceBillingAndroid).toHaveBeenCalledWith({
+      externalTransactionToken: 'choice-token',
+      products: ['premium'],
+    });
     expect(onDeveloperProvidedBillingAndroid).toHaveBeenCalledWith(details);
   });
 

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -657,7 +657,6 @@ export function useIAP(options?: UseIapOptions): UseIap {
 
     if (
       Platform.OS === 'android' &&
-      optionsRef.current?.onUserChoiceBillingAndroid &&
       !subscriptionsRef.current.userChoiceBillingAndroid
     ) {
       subscriptionsRef.current.userChoiceBillingAndroid =
@@ -670,7 +669,6 @@ export function useIAP(options?: UseIapOptions): UseIap {
 
     if (
       Platform.OS === 'android' &&
-      optionsRef.current?.onDeveloperProvidedBillingAndroid &&
       !subscriptionsRef.current.developerProvidedBillingAndroid
     ) {
       subscriptionsRef.current.developerProvidedBillingAndroid =


### PR DESCRIPTION
## Summary

- Register Android alternative-billing listeners independently of whether callbacks were supplied during the initial render.
- Continue reading callbacks through the existing options ref, so callbacks added after mount receive events.
- Add a hook regression covering late user-choice and developer-provided billing callbacks.

## Breaking changes

None. Existing callbacks behave unchanged; callbacks added after initialization now work consistently with the subscription-billing listener.

## Verification

- Focused hook suite: 8 tests passed.
- TypeScript typecheck passed.
- Lint and `git diff --check` passed.

## Preview

Not applicable: this is a nonvisual listener-lifecycle correction. The focused hook regression exercises the observable callback behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android alternative billing event handling.
  * User Choice Billing and Developer Provided Billing callbacks now receive events even when added after the billing hook is initialized.
  * Ensured billing listeners remain registered consistently on Android, including when callbacks are initially unavailable.

* **Tests**
  * Added coverage confirming alternative billing events are forwarded to callbacks provided after component mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->