### PR TITLE
fix(rn): release Vega listeners on disconnect

### DIFF
--- a/libraries/react-native-iap/src/__tests__/vega-adapter.test.ts
+++ b/libraries/react-native-iap/src/__tests__/vega-adapter.test.ts
@@ -80,6 +80,38 @@ describe('Amazon Vega adapter', () => {
     expect(service.getUserData).not.toHaveBeenCalled();
   });
 
+  it('releases purchase listeners when the connection ends', async () => {
+    const service = createService();
+    const module = createVegaIapModule(service);
+    const staleUpdateListener = jest.fn();
+    const staleErrorListener = jest.fn();
+
+    const staleUpdateToken = module.addPurchaseUpdatedListener(
+      staleUpdateListener,
+    );
+    module.addPurchaseErrorListener(staleErrorListener);
+    await module.endConnection();
+
+    const activeUpdateListener = jest.fn();
+    const activeErrorListener = jest.fn();
+    const activeUpdateToken = module.addPurchaseUpdatedListener(
+      activeUpdateListener,
+    );
+    expect(activeUpdateToken).toBeGreaterThan(staleUpdateToken);
+    module.addPurchaseErrorListener(activeErrorListener);
+    module.removePurchaseUpdatedListener(staleUpdateToken);
+    await module.requestPurchase({google: {skus: ['coins_100']}});
+    service.purchase.mockRejectedValueOnce(new Error('purchase failed'));
+    await expect(
+      module.requestPurchase({google: {skus: ['coins_100']}}),
+    ).rejects.toThrow('purchase failed');
+
+    expect(staleUpdateListener).not.toHaveBeenCalled();
+    expect(staleErrorListener).not.toHaveBeenCalled();
+    expect(activeUpdateListener).toHaveBeenCalledTimes(1);
+    expect(activeErrorListener).toHaveBeenCalledTimes(1);
+  });
+
   it('returns the store-authoritative Amazon marketplace', async () => {
     const service = createService();
     const module = createVegaIapModule(service);

--- a/libraries/react-native-iap/src/vega-adapter.ts
+++ b/libraries/react-native-iap/src/vega-adapter.ts
@@ -1420,6 +1420,8 @@ export function createVegaIapModule(service: VegaPurchasingService): RnIap {
       productTypesBySku.clear();
       subscriptionBasesBySku.clear();
       subscriptionParentsBySku.clear();
+      purchaseUpdateListeners.clear();
+      purchaseErrorListeners.clear();
       cachedUserData = null;
       return true;
     },


### PR DESCRIPTION
## Summary

- Clear Amazon Vega purchase-update and purchase-error listeners when the connection ends.
- Keep update-listener tokens monotonic, so a stale remover cannot delete a listener registered after reconnect.
- Add regression coverage for stale callbacks, reconnect delivery, error delivery, and token ownership.

## Breaking changes

None. Listener registrations no longer survive an explicit `endConnection()` lifecycle boundary. Consumers should register fresh listeners after reconnect, matching the normal connection lifecycle.

## Verification

- Vega adapter suite: 85 tests passed.
- TypeScript typecheck passed.
- Targeted ESLint and `git diff --check` passed.

## Preview

Not applicable: this is a nonvisual connection/listener ownership correction. The focused adapter regression exercises disconnect and reconnect behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ending a purchase connection now properly removes previously registered purchase update and error listeners.
  * Prevents stale listeners from receiving events after the connection has ended.
  * New listeners registered after reconnecting continue to receive purchase events normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->