### PR TITLE
fix(rn): preserve iOS finish errors

### DIFF
--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -391,10 +391,15 @@ class HybridRnIap: HybridRnIapSpec {
                     self.purchasePayloadById.removeValue(forKey: iosParams.transactionId)
                 }
                 return .first(true)
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("finishTransaction", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
+            } catch let openIapException as OpenIapException {
+                RnIapLog.failure("finishTransaction", error: openIapException)
+                throw openIapException
             } catch {
                 RnIapLog.failure("finishTransaction", error: error)
-                let tid = iosParams.transactionId
-                throw OpenIapException.make(code: .purchaseError, message: "Transaction not found: \(tid)")
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -1398,7 +1398,10 @@ describe('Public API (src/index.ts)', () => {
 
       await expect(
         IAP.finishTransaction({purchase: {id: 'tid'} as any}),
-      ).rejects.toBe(error);
+      ).rejects.toMatchObject({
+        code: ErrorCode.ServiceError,
+        message: 'StoreKit network failure',
+      });
     });
 
     it('throws on unsupported platform', async () => {

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -1386,6 +1386,21 @@ describe('Public API (src/index.ts)', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('iOS: propagates native finish failures', async () => {
+      (Platform as any).OS = 'ios';
+      const error = new Error(
+        JSON.stringify({
+          code: 'service-error',
+          message: 'StoreKit network failure',
+        }),
+      );
+      mockIap.finishTransaction.mockRejectedValueOnce(error);
+
+      await expect(
+        IAP.finishTransaction({purchase: {id: 'tid'} as any}),
+      ).rejects.toBe(error);
+    });
+
     it('throws on unsupported platform', async () => {
       (Platform as any).OS = 'web';
       await expect(

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1952,11 +1952,11 @@ export const finishTransaction: MutationField<'finishTransaction'> = async (
     }
     return;
   } catch (error) {
+    const parsedError = parseErrorStringToJsonObj(error);
     // If iOS transaction has already been auto-finished natively, treat as success
     if (Platform.OS === 'ios') {
-      const err = parseErrorStringToJsonObj(error);
-      const msg = (err?.message || '').toString();
-      const code = (err?.code || '').toString();
+      const msg = (parsedError.message || '').toString();
+      const code = (parsedError.code || '').toString();
       if (
         msg.includes('Transaction not found') ||
         code === 'E_ITEM_UNAVAILABLE'
@@ -1965,8 +1965,15 @@ export const finishTransaction: MutationField<'finishTransaction'> = async (
         return;
       }
     }
-    RnIapConsole.error('Failed to finish transaction:', error);
-    throw error;
+    if (!isUserCancelledError(parsedError)) {
+      RnIapConsole.error('Failed to finish transaction:', error);
+    }
+    throw createPurchaseError({
+      code: parsedError.code,
+      message: parsedError.message,
+      responseCode: parsedError.responseCode,
+      debugMessage: parsedError.debugMessage,
+    });
   }
 };
 


### PR DESCRIPTION
## Summary

- Preserve structured `PurchaseError` failures from StoreKit/OpenIAP.
- Pass existing `OpenIapException` values through unchanged.
- Map genuinely unknown failures to `service-error` with their actual message.
- Add JavaScript API coverage proving native finish rejections propagate.

## Breaking changes

`finishTransaction` no longer rewrites every iOS failure as `purchase-error: Transaction not found`. Callers now receive the actual normalized error code and message.

## Verification

- Public index suite: 237 tests passed.
- TypeScript typecheck and lint passed.
- iOS simulator build passed.
- `git diff --check` passed.

## Preview

Not applicable: this is a nonvisual error-propagation correction. Automated coverage exercises the public rejection path.
