### PR TITLE
fix(rn): retry listeners after Nitro init

### DIFF
--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -31,6 +31,8 @@ const mockIap: any = {
   removeSubscriptionBillingIssueListener: jest.fn(),
   addUserChoiceBillingListenerAndroid: jest.fn(),
   removeUserChoiceBillingListenerAndroid: jest.fn(),
+  addDeveloperProvidedBillingListenerAndroid: jest.fn(),
+  removeDeveloperProvidedBillingListenerAndroid: jest.fn(),
 
   // iOS-only
   getAppTransactionIOS: jest.fn(async () => null),
@@ -699,6 +701,72 @@ describe('Public API (src/index.ts)', () => {
         isAutoRenewing: false,
       });
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      {
+        name: 'purchase updates',
+        platform: 'ios',
+        api: 'purchaseUpdatedListener',
+        nativeMethod: 'addPurchaseUpdatedListener',
+        options: undefined,
+      },
+      {
+        name: 'duplicate purchase updates',
+        platform: 'ios',
+        api: 'purchaseUpdatedListener',
+        nativeMethod: 'addPurchaseUpdatedListener',
+        options: {dedupeTransactionIOS: false},
+      },
+      {
+        name: 'purchase errors',
+        platform: 'ios',
+        api: 'purchaseErrorListener',
+        nativeMethod: 'addPurchaseErrorListener',
+        options: undefined,
+      },
+      {
+        name: 'promoted products',
+        platform: 'ios',
+        api: 'promotedProductListenerIOS',
+        nativeMethod: 'addPromotedProductListenerIOS',
+        options: undefined,
+      },
+      {
+        name: 'user-choice billing',
+        platform: 'android',
+        api: 'userChoiceBillingListenerAndroid',
+        nativeMethod: 'addUserChoiceBillingListenerAndroid',
+        options: undefined,
+      },
+      {
+        name: 'developer-provided billing',
+        platform: 'android',
+        api: 'developerProvidedBillingListenerAndroid',
+        nativeMethod: 'addDeveloperProvidedBillingListenerAndroid',
+        options: undefined,
+      },
+      {
+        name: 'subscription billing issues',
+        platform: 'ios',
+        api: 'subscriptionBillingIssueListener',
+        nativeMethod: 'addSubscriptionBillingIssueListener',
+        options: undefined,
+      },
+    ])('retries deferred $name after initConnection', async (testCase) => {
+      (Platform as any).OS = testCase.platform;
+      mockIap[testCase.nativeMethod] = jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Nitro runtime not installed');
+        });
+
+      IAP[testCase.api](jest.fn(), testCase.options);
+      expect(mockIap[testCase.nativeMethod]).toHaveBeenCalledTimes(1);
+
+      await IAP.initConnection();
+
+      expect(mockIap[testCase.nativeMethod]).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -668,6 +668,38 @@ describe('Public API (src/index.ts)', () => {
       expect(staleListener).not.toHaveBeenCalled();
       expect(currentListener).toHaveBeenCalledTimes(1);
     });
+
+    it('attaches a pre-init purchase listener after initConnection', async () => {
+      const createHybridObject = jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Nitro runtime not installed');
+        })
+        .mockImplementation(() => mockIap);
+      jest.resetModules();
+      jest.doMock('react-native-nitro-modules', () => ({
+        NitroModules: {createHybridObject},
+      }));
+      const freshIAP = require('../index');
+      const listener = jest.fn();
+
+      freshIAP.purchaseUpdatedListener(listener);
+      expect(mockIap.addPurchaseUpdatedListener).not.toHaveBeenCalled();
+
+      await freshIAP.initConnection();
+      expect(mockIap.addPurchaseUpdatedListener).toHaveBeenCalledTimes(1);
+      mockIap.addPurchaseUpdatedListener.mock.calls[0][0]({
+        id: 't1',
+        transactionId: 't1',
+        productId: 'p1',
+        transactionDate: Date.now(),
+        store: 'apple',
+        quantity: 1,
+        purchaseState: 'purchased',
+        isAutoRenewing: false,
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('fetchProducts', () => {
@@ -1810,16 +1842,24 @@ describe('Public API (src/index.ts)', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('keeps the listener inert while Nitro initializes', () => {
+    it('reattaches the listener after Nitro initializes', async () => {
       (Platform as any).OS = 'android';
       mockIap.addUserChoiceBillingListenerAndroid.mockImplementationOnce(() => {
         throw new Error('Nitro runtime not installed');
       });
 
-      expect(() =>
-        IAP.userChoiceBillingListenerAndroid(jest.fn()),
-      ).not.toThrow();
+      const listener = jest.fn();
+      IAP.userChoiceBillingListenerAndroid(listener);
       expect(console.warn).toHaveBeenCalled();
+
+      await IAP.initConnection();
+      expect(mockIap.addUserChoiceBillingListenerAndroid).toHaveBeenCalledTimes(
+        2,
+      );
+      mockIap.addUserChoiceBillingListenerAndroid.mock.calls[1][0]({
+        products: ['premium'],
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('surfaces unexpected native listener failures', () => {
@@ -1828,9 +1868,18 @@ describe('Public API (src/index.ts)', () => {
         throw new Error('native listener failed');
       });
 
-      expect(() => IAP.userChoiceBillingListenerAndroid(jest.fn())).toThrow(
+      const staleListener = jest.fn();
+      expect(() => IAP.userChoiceBillingListenerAndroid(staleListener)).toThrow(
         'native listener failed',
       );
+
+      const currentListener = jest.fn();
+      IAP.userChoiceBillingListenerAndroid(currentListener);
+      mockIap.addUserChoiceBillingListenerAndroid.mock.calls[1][0]({
+        products: ['premium'],
+      });
+      expect(staleListener).not.toHaveBeenCalled();
+      expect(currentListener).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -703,6 +703,18 @@ describe('Public API (src/index.ts)', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
+    it('does not attach a deferred listener removed before initConnection', async () => {
+      mockIap.addPurchaseUpdatedListener.mockImplementationOnce(() => {
+        throw new Error('Nitro runtime not installed');
+      });
+
+      const subscription = IAP.purchaseUpdatedListener(jest.fn());
+      subscription.remove();
+      await IAP.initConnection();
+
+      expect(mockIap.addPurchaseUpdatedListener).toHaveBeenCalledTimes(1);
+    });
+
     it.each([
       {
         name: 'purchase updates',

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -755,11 +755,9 @@ describe('Public API (src/index.ts)', () => {
       },
     ])('retries deferred $name after initConnection', async (testCase) => {
       (Platform as any).OS = testCase.platform;
-      mockIap[testCase.nativeMethod] = jest
-        .fn()
-        .mockImplementationOnce(() => {
-          throw new Error('Nitro runtime not installed');
-        });
+      mockIap[testCase.nativeMethod] = jest.fn().mockImplementationOnce(() => {
+        throw new Error('Nitro runtime not installed');
+      });
 
       IAP[testCase.api](jest.fn(), testCase.options);
       expect(mockIap[testCase.nativeMethod]).toHaveBeenCalledTimes(1);
@@ -3790,6 +3788,65 @@ describe('Public API (src/index.ts)', () => {
 
       expect(listener).toHaveBeenCalledTimes(1);
     });
+
+    it.each([
+      {
+        name: 'purchase updates',
+        platform: 'ios',
+        api: 'purchaseUpdatedListener',
+        nativeMethod: 'addPurchaseUpdatedListener',
+        payload: validPurchase,
+      },
+      {
+        name: 'purchase errors',
+        platform: 'ios',
+        api: 'purchaseErrorListener',
+        nativeMethod: 'addPurchaseErrorListener',
+        payload: {code: 'network-error', message: 'offline'},
+      },
+      {
+        name: 'promoted products',
+        platform: 'ios',
+        api: 'promotedProductListenerIOS',
+        nativeMethod: 'addPromotedProductListenerIOS',
+        payload: {
+          id: 'premium',
+          title: 'Premium',
+          description: 'Premium access',
+          displayName: 'Premium',
+          displayPrice: '$1.00',
+          currency: 'USD',
+          price: 1,
+          platform: 'ios',
+          type: 'in-app',
+        },
+      },
+      {
+        name: 'developer-provided billing',
+        platform: 'android',
+        api: 'developerProvidedBillingListenerAndroid',
+        nativeMethod: 'addDeveloperProvidedBillingListenerAndroid',
+        payload: {products: ['premium']},
+      },
+    ])(
+      'rolls back a failed $name registration',
+      ({platform, api, nativeMethod, payload}) => {
+        (Platform as any).OS = platform;
+        mockIap[nativeMethod].mockImplementationOnce(() => {
+          throw new Error('native listener failed');
+        });
+
+        const staleListener = jest.fn();
+        expect(() => IAP[api](staleListener)).toThrow('native listener failed');
+
+        const currentListener = jest.fn();
+        IAP[api](currentListener);
+        mockIap[nativeMethod].mock.calls[1][0](payload);
+
+        expect(staleListener).not.toHaveBeenCalled();
+        expect(currentListener).toHaveBeenCalledTimes(1);
+      },
+    );
 
     it.each([
       {

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -815,21 +815,12 @@ const subscriptionBillingIssueNativeHandler: NitroSubscriptionBillingIssueListen
 
 function tryAttachSubscriptionBillingIssueNative(): void {
   if (subscriptionBillingIssueNativeAttached) return;
-  try {
+  attachNativeListenerOrDefer('subscriptionBillingIssueListener', () => {
     IAP.instance.addSubscriptionBillingIssueListener(
       subscriptionBillingIssueNativeHandler,
     );
     subscriptionBillingIssueNativeAttached = true;
-  } catch (e) {
-    const msg = toErrorMessage(e);
-    if (msg.includes('Nitro runtime not installed')) {
-      RnIapConsole.warn(
-        '[subscriptionBillingIssueListener] Nitro not ready yet; will retry after initConnection()',
-      );
-    } else {
-      throw e;
-    }
-  }
+  });
 }
 
 export const subscriptionBillingIssueListener = (

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -264,19 +264,15 @@ const IAP = {
 // hyodotdev/openiap#382.
 // ============================================================================
 
-function attachNativeListenerOrDefer(
-  label: string,
-  attach: () => void,
-): boolean {
+function attachNativeListenerOrDefer(label: string, attach: () => void): void {
   try {
     attach();
-    return true;
   } catch (error) {
     if (toErrorMessage(error).includes('Nitro runtime not installed')) {
       RnIapConsole.warn(
         `[${label}] Nitro not ready yet; will retry after initConnection()`,
       );
-      return false;
+      return;
     }
     throw error;
   }

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -264,6 +264,24 @@ const IAP = {
 // hyodotdev/openiap#382.
 // ============================================================================
 
+function attachNativeListenerOrDefer(
+  label: string,
+  attach: () => void,
+): boolean {
+  try {
+    attach();
+    return true;
+  } catch (error) {
+    if (toErrorMessage(error).includes('Nitro runtime not installed')) {
+      RnIapConsole.warn(
+        `[${label}] Nitro not ready yet; will retry after initConnection()`,
+      );
+      return false;
+    }
+    throw error;
+  }
+}
+
 const purchaseUpdateJsListeners = new Set<(purchase: Purchase) => void>();
 const purchaseUpdateDuplicateJsListeners = new Set<
   (purchase: Purchase) => void
@@ -304,6 +322,38 @@ const purchaseUpdateDuplicateNativeHandler: NitroPurchaseListener = (
   );
 };
 
+function tryAttachPurchaseUpdateNative(
+  receiveDuplicateTransactionUpdatesIOS: boolean,
+): void {
+  const alreadyAttached = receiveDuplicateTransactionUpdatesIOS
+    ? purchaseUpdateDuplicateNativeAttached
+    : purchaseUpdateNativeAttached;
+  if (alreadyAttached) return;
+
+  attachNativeListenerOrDefer('purchaseUpdatedListener', () => {
+    const nativeOptions:
+      | (NitroPurchaseUpdatedListenerOptions &
+          NitroPurchaseUpdatedListenerOptionsParam)
+      | undefined = receiveDuplicateTransactionUpdatesIOS
+      ? {dedupeTransactionIOS: false}
+      : undefined;
+    const token = IAP.instance.addPurchaseUpdatedListener(
+      receiveDuplicateTransactionUpdatesIOS
+        ? purchaseUpdateDuplicateNativeHandler
+        : purchaseUpdateNativeHandler,
+      nativeOptions,
+    );
+    if (receiveDuplicateTransactionUpdatesIOS) {
+      purchaseUpdateDuplicateNativeToken =
+        typeof token === 'number' ? token : null;
+      purchaseUpdateDuplicateNativeAttached = true;
+    } else {
+      purchaseUpdateNativeToken = typeof token === 'number' ? token : null;
+      purchaseUpdateNativeAttached = true;
+    }
+  });
+}
+
 const purchaseErrorJsListeners = new Set<(error: PurchaseError) => void>();
 let purchaseErrorNativeAttached = false;
 const purchaseErrorNativeHandler: NitroPurchaseErrorListener = (error) => {
@@ -334,6 +384,14 @@ const purchaseErrorNativeHandler: NitroPurchaseErrorListener = (error) => {
   }
 };
 
+function tryAttachPurchaseErrorNative(): void {
+  if (purchaseErrorNativeAttached) return;
+  attachNativeListenerOrDefer('purchaseErrorListener', () => {
+    IAP.instance.addPurchaseErrorListener(purchaseErrorNativeHandler);
+    purchaseErrorNativeAttached = true;
+  });
+}
+
 const promotedProductJsListeners = new Set<(product: Product) => void>();
 let promotedProductNativeAttached = false;
 const promotedProductNativeHandler: NitroPromotedProductListener = (
@@ -355,6 +413,14 @@ const promotedProductNativeHandler: NitroPromotedProductListener = (
     );
   }
 };
+
+function tryAttachPromotedProductNative(): void {
+  if (promotedProductNativeAttached) return;
+  attachNativeListenerOrDefer('promotedProductListenerIOS', () => {
+    IAP.instance.addPromotedProductListenerIOS(promotedProductNativeHandler);
+    promotedProductNativeAttached = true;
+  });
+}
 
 /**
  * Reset all JS-level listener tracking state.
@@ -391,52 +457,11 @@ export const purchaseUpdatedListener = (
     : purchaseUpdateJsListeners;
 
   listeners.add(listener);
-
-  if (!purchaseUpdateNativeAttached && !receiveDuplicateTransactionUpdatesIOS) {
-    try {
-      const token = IAP.instance.addPurchaseUpdatedListener(
-        purchaseUpdateNativeHandler,
-      );
-      purchaseUpdateNativeToken = typeof token === 'number' ? token : null;
-      purchaseUpdateNativeAttached = true;
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (msg.includes('Nitro runtime not installed')) {
-        RnIapConsole.warn(
-          '[purchaseUpdatedListener] Nitro not ready yet; listener inert until initConnection()',
-        );
-      } else {
-        throw e;
-      }
-    }
-  }
-
-  if (
-    !purchaseUpdateDuplicateNativeAttached &&
-    receiveDuplicateTransactionUpdatesIOS
-  ) {
-    try {
-      const nativeOptions: NitroPurchaseUpdatedListenerOptions &
-        NitroPurchaseUpdatedListenerOptionsParam = {
-        dedupeTransactionIOS: false,
-      };
-      const token = IAP.instance.addPurchaseUpdatedListener(
-        purchaseUpdateDuplicateNativeHandler,
-        nativeOptions,
-      );
-      purchaseUpdateDuplicateNativeToken =
-        typeof token === 'number' ? token : null;
-      purchaseUpdateDuplicateNativeAttached = true;
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (msg.includes('Nitro runtime not installed')) {
-        RnIapConsole.warn(
-          '[purchaseUpdatedListener] Nitro not ready yet; listener inert until initConnection()',
-        );
-      } else {
-        throw e;
-      }
-    }
+  try {
+    tryAttachPurchaseUpdateNative(receiveDuplicateTransactionUpdatesIOS);
+  } catch (error) {
+    listeners.delete(listener);
+    throw error;
   }
 
   let removed = false;
@@ -485,21 +510,11 @@ export const purchaseErrorListener = (
   listener: (error: PurchaseError) => void,
 ): EventSubscription => {
   purchaseErrorJsListeners.add(listener);
-
-  if (!purchaseErrorNativeAttached) {
-    try {
-      IAP.instance.addPurchaseErrorListener(purchaseErrorNativeHandler);
-      purchaseErrorNativeAttached = true;
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (msg.includes('Nitro runtime not installed')) {
-        RnIapConsole.warn(
-          '[purchaseErrorListener] Nitro not ready yet; listener inert until initConnection()',
-        );
-      } else {
-        throw e;
-      }
-    }
+  try {
+    tryAttachPurchaseErrorNative();
+  } catch (error) {
+    purchaseErrorJsListeners.delete(listener);
+    throw error;
   }
 
   return {
@@ -548,21 +563,11 @@ export const promotedProductListenerIOS = (
   }
 
   promotedProductJsListeners.add(listener);
-
-  if (!promotedProductNativeAttached) {
-    try {
-      IAP.instance.addPromotedProductListenerIOS(promotedProductNativeHandler);
-      promotedProductNativeAttached = true;
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (msg.includes('Nitro runtime not installed')) {
-        RnIapConsole.warn(
-          '[promotedProductListenerIOS] Nitro not ready yet; listener inert until initConnection()',
-        );
-      } else {
-        throw e;
-      }
-    }
+  try {
+    tryAttachPromotedProductNative();
+  } catch (error) {
+    promotedProductJsListeners.delete(listener);
+    throw error;
   }
 
   return {
@@ -618,6 +623,16 @@ const userChoiceBillingNativeHandler: NitroUserChoiceBillingListener = (
   }
 };
 
+function tryAttachUserChoiceBillingNative(): void {
+  if (userChoiceBillingNativeAttached) return;
+  attachNativeListenerOrDefer('userChoiceBillingListenerAndroid', () => {
+    IAP.instance.addUserChoiceBillingListenerAndroid(
+      userChoiceBillingNativeHandler,
+    );
+    userChoiceBillingNativeAttached = true;
+  });
+}
+
 export const userChoiceBillingListenerAndroid = (
   listener: (details: UserChoiceBillingDetails) => void,
 ): EventSubscription => {
@@ -629,23 +644,11 @@ export const userChoiceBillingListenerAndroid = (
   }
 
   userChoiceBillingJsListeners.add(listener);
-
-  if (!userChoiceBillingNativeAttached) {
-    try {
-      IAP.instance.addUserChoiceBillingListenerAndroid(
-        userChoiceBillingNativeHandler,
-      );
-      userChoiceBillingNativeAttached = true;
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (msg.includes('Nitro runtime not installed')) {
-        RnIapConsole.warn(
-          '[userChoiceBillingListenerAndroid] Nitro not ready yet; listener inert until initConnection()',
-        );
-      } else {
-        throw e;
-      }
-    }
+  try {
+    tryAttachUserChoiceBillingNative();
+  } catch (error) {
+    userChoiceBillingJsListeners.delete(listener);
+    throw error;
   }
 
   let removed = false;
@@ -722,6 +725,16 @@ const developerProvidedBillingNativeHandler: NitroDeveloperProvidedBillingListen
     }
   };
 
+function tryAttachDeveloperProvidedBillingNative(): void {
+  if (developerProvidedBillingNativeAttached) return;
+  attachNativeListenerOrDefer('developerProvidedBillingListenerAndroid', () => {
+    IAP.instance.addDeveloperProvidedBillingListenerAndroid(
+      developerProvidedBillingNativeHandler,
+    );
+    developerProvidedBillingNativeAttached = true;
+  });
+}
+
 export const developerProvidedBillingListenerAndroid = (
   listener: (details: DeveloperProvidedBillingDetailsAndroid) => void,
 ): EventSubscription => {
@@ -733,23 +746,11 @@ export const developerProvidedBillingListenerAndroid = (
   }
 
   developerProvidedBillingJsListeners.add(listener);
-
-  if (!developerProvidedBillingNativeAttached) {
-    try {
-      IAP.instance.addDeveloperProvidedBillingListenerAndroid(
-        developerProvidedBillingNativeHandler,
-      );
-      developerProvidedBillingNativeAttached = true;
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (msg.includes('Nitro runtime not installed')) {
-        RnIapConsole.warn(
-          '[developerProvidedBillingListenerAndroid] Nitro not ready yet; listener inert until initConnection()',
-        );
-      } else {
-        throw e;
-      }
-    }
+  try {
+    tryAttachDeveloperProvidedBillingNative();
+  } catch (error) {
+    developerProvidedBillingJsListeners.delete(listener);
+    throw error;
   }
 
   return {
@@ -850,6 +851,30 @@ export const subscriptionBillingIssueListener = (
     },
   };
 };
+
+function tryAttachPendingNativeListeners(): void {
+  if (purchaseUpdateJsListeners.size > 0) {
+    tryAttachPurchaseUpdateNative(false);
+  }
+  if (purchaseUpdateDuplicateJsListeners.size > 0) {
+    tryAttachPurchaseUpdateNative(true);
+  }
+  if (purchaseErrorJsListeners.size > 0) {
+    tryAttachPurchaseErrorNative();
+  }
+  if (promotedProductJsListeners.size > 0) {
+    tryAttachPromotedProductNative();
+  }
+  if (userChoiceBillingJsListeners.size > 0) {
+    tryAttachUserChoiceBillingNative();
+  }
+  if (developerProvidedBillingJsListeners.size > 0) {
+    tryAttachDeveloperProvidedBillingNative();
+  }
+  if (subscriptionBillingIssueJsListeners.size > 0) {
+    tryAttachSubscriptionBillingIssueNative();
+  }
+}
 
 // ------------------------------
 // Query API
@@ -1573,9 +1598,7 @@ export const initConnection: MutationField<'initConnection'> = async (
     const result = await IAP.instance.initConnection(
       config as Record<string, unknown> | undefined,
     );
-    if (subscriptionBillingIssueJsListeners.size > 0) {
-      tryAttachSubscriptionBillingIssueNative();
-    }
+    tryAttachPendingNativeListeners();
     return result;
   } catch (error) {
     const parsedError = parseErrorAndLogIfNeeded(


### PR DESCRIPTION
## Summary

- Centralize native listener attachment and defer only the known pre-initialization Nitro failure.
- Retry every pending listener type after `initConnection()` succeeds.
- Roll back JS subscribers when an unexpected native attach failure is thrown.
- Add regressions for pre-init purchase/alternative-billing listeners and ghost-subscriber cleanup.

## Breaking changes

None. Listeners registered before Nitro initialization now become active after connection; unexpected attachment failures no longer leave an inert JS subscriber behind.

## Verification

- Public index suite: 237 tests passed.
- TypeScript typecheck and lint passed.
- `git diff --check` passed.

## Preview

Not applicable: this is a nonvisual listener-initialization correction. The focused regressions exercise deferred attachment, retry, delivery, and rollback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing event listener reliability during initialization.
  * Listeners registered before connection initialization now attach correctly after `initConnection()`.
  * Failed native listener attachments are retried automatically across purchase, error, promotion, billing, and subscription events.
  * Prevented stale listeners from receiving events after an attachment failure and recovery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->