### PR TITLE
fix(rn): preserve unknown iOS purchase state

### DIFF
--- a/libraries/react-native-iap/ios/RnIapHelper.swift
+++ b/libraries/react-native-iap/ios/RnIapHelper.swift
@@ -397,7 +397,7 @@ enum RnIapHelper {
            let state = PurchaseState(fromString: purchaseStateString) {
             purchaseState = state
         } else {
-            purchaseState = .purchased
+            purchaseState = .unknown
         }
 
         // Handle offerIOS JSON serialization


### PR DESCRIPTION
## Summary

- Map missing or malformed native purchase-state strings to the existing `unknown` state.
- Stop promoting unrecognized data to `purchased`.

## Breaking changes

Malformed or missing native state now reports `unknown` instead of the incorrect `purchased` fallback. Valid pending and purchased states are unchanged.

## Verification

- iOS simulator build passed.
- `git diff --check` passed.

## Preview

Not applicable: this is a nonvisual native data-mapping correction verified by compilation of the changed Swift source.
