### PR TITLE
fix(rn): preserve purchase type across bridge

### DIFF
--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -565,10 +565,15 @@ class HybridRnIap : HybridRnIapSpec() {
                     openIap.setActivity(activity)
                 }
 
-                val missingSkus = androidRequest.skus.filterNot { productTypeBySku.containsKey(it) }
-                if (missingSkus.isNotEmpty()) {
+                val queryType = request.type?.let { requestType ->
+                    when (requestType) {
+                        NitroPurchaseRequestType.SUBS -> ProductQueryType.Subs
+                        NitroPurchaseRequestType.IN_APP -> ProductQueryType.InApp
+                    }
+                } ?: run {
+                    val missingSkus = androidRequest.skus.filterNot { productTypeBySku.containsKey(it) }
                     missingSkus.forEach { sku ->
-                        RnIapLog.warn("requestPurchase missing cached type for $sku; attempting fetch")
+                        RnIapLog.warn("requestPurchase missing type hint for $sku; attempting fetch")
                         val fetched = runCatching {
                             openIap.fetchProducts(
                                 ProductRequest(listOf(sku), ProductQueryType.All)
@@ -583,10 +588,8 @@ class HybridRnIap : HybridRnIapSpec() {
                             return@async defaultResult
                         }
                     }
+                    parseProductQueryType(productTypeBySku[androidRequest.skus.first()] ?: "in-app")
                 }
-
-                val typeHint = androidRequest.skus.firstOrNull()?.let { productTypeBySku[it] } ?: "in-app"
-                val queryType = parseProductQueryType(typeHint)
 
                 try {
                     requireMatchingPurchaseOptions(

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -242,9 +242,14 @@ class HybridRnIap: HybridRnIapSpec {
                     iosPayload["winBackOffer"] = ["offerId": winBackOffer.offerId]
                 }
 
-                let cachedType = await MainActor.run { self.productTypeBySku[iosRequest.sku] }
-                let resolvedType = RnIapHelper.parseProductQueryType(cachedType)
-                let purchaseType: ProductQueryType = resolvedType == .all ? .inApp : resolvedType
+                let purchaseType: ProductQueryType
+                if let requestType = request.type {
+                    purchaseType = requestType == .subs ? .subs : .inApp
+                } else {
+                    let cachedType = await MainActor.run { self.productTypeBySku[iosRequest.sku] }
+                    let resolvedType = RnIapHelper.parseProductQueryType(cachedType)
+                    purchaseType = resolvedType == .all ? .inApp : resolvedType
+                }
                 await MainActor.run {
                     self.productTypeBySku[iosRequest.sku] = purchaseType.rawValue
                 }

--- a/libraries/react-native-iap/src/__tests__/index.kepler.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.kepler.test.ts
@@ -67,6 +67,7 @@ describe('Amazon Vega public API', () => {
     await IAP.requestPurchase(request);
 
     expect(requestPurchaseNative).toHaveBeenLastCalledWith({
+      type: 'in-app',
       google: {skus: ['coins']},
     });
   });

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -849,6 +849,7 @@ describe('Public API (src/index.ts)', () => {
         type: 'subs',
       });
       const passed = mockIap.requestPurchase.mock.calls.pop()?.[0];
+      expect(passed.type).toBe('subs');
       expect(
         passed.apple.andDangerouslyFinishTransactionAutomatically,
       ).toBeUndefined();
@@ -3682,6 +3683,7 @@ describe('Public API (src/index.ts)', () => {
       });
 
       expect(mockIap.requestPurchase).toHaveBeenCalledWith({
+        type: 'in-app',
         apple: {
           sku: 'premium',
           andDangerouslyFinishTransactionAutomatically: false,
@@ -3707,6 +3709,7 @@ describe('Public API (src/index.ts)', () => {
       });
 
       expect(mockIap.requestPurchase).toHaveBeenCalledWith({
+        type: 'in-app',
         google: {
           skus: ['coins'],
           obfuscatedAccountId: 'account-alias',

--- a/libraries/react-native-iap/src/__tests__/vega-adapter.test.ts
+++ b/libraries/react-native-iap/src/__tests__/vega-adapter.test.ts
@@ -844,6 +844,33 @@ describe('Amazon Vega adapter', () => {
     ]);
   });
 
+  it('uses the explicit request type when purchase metadata is unavailable', async () => {
+    const service = createService();
+    service.purchase.mockResolvedValueOnce({
+      responseCode: 0,
+      receipt: {
+        receiptId: 'sub-purchase',
+        sku: 'premium_monthly',
+      },
+    });
+    const module = createVegaIapModule(service);
+
+    await expect(
+      module.requestPurchase({
+        type: 'subs',
+        google: {skus: ['premium_monthly']},
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        productId: 'premium_monthly',
+        isAutoRenewing: true,
+        autoRenewingAndroid: true,
+      }),
+    ]);
+
+    expect(service.getProductData).not.toHaveBeenCalled();
+  });
+
   it('uses serialized subscription request context for direct Nitro calls', async () => {
     const service = createService();
     service.purchase.mockResolvedValueOnce({

--- a/libraries/react-native-iap/src/index.kepler.ts
+++ b/libraries/react-native-iap/src/index.kepler.ts
@@ -157,6 +157,7 @@ export const requestPurchase: MutationField<'requestPurchase'> = async (
   }
 
   const nitroRequest: NitroPurchaseRequest = {
+    type,
     google: androidRequest,
   };
   const result = await getModule().requestPurchase(nitroRequest);

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1722,7 +1722,7 @@ export const requestPurchase: MutationField<'requestPurchase'> = async (
       throw unsupportedPlatformError();
     }
 
-    const unifiedRequest: NitroPurchaseRequest = {};
+    const unifiedRequest: NitroPurchaseRequest = {type: normalizedType};
 
     if (Platform.OS === 'ios' && iosRequestSource) {
       const iosRequest = isSubs

--- a/libraries/react-native-iap/src/specs/RnIap.nitro.ts
+++ b/libraries/react-native-iap/src/specs/RnIap.nitro.ts
@@ -260,7 +260,11 @@ export interface NitroRequestPurchaseAndroid {
   subscriptionProductReplacementParams?: SubscriptionProductReplacementParamsAndroid | null;
 }
 
+export type NitroPurchaseRequestType = 'in-app' | 'subs';
+
 export interface NitroPurchaseRequest {
+  /** Canonical product type selected by the public request. */
+  type?: NitroPurchaseRequestType | null;
   /** Apple-specific purchase parameters */
   apple?: NitroRequestPurchaseIos | null;
   /** Google-specific purchase parameters */

--- a/libraries/react-native-iap/src/vega-adapter.ts
+++ b/libraries/react-native-iap/src/vega-adapter.ts
@@ -1450,11 +1450,13 @@ export function createVegaIapModule(service: VegaPurchasingService): RnIap {
       try {
         const androidRequest = selectGooglePurchaseRequest(request);
         sku = getSkuFromRequest(androidRequest);
-        const fallbackProductType = hasSubscriptionRequestContext(
-          androidRequest?.subscriptionOffers,
-        )
-          ? PRODUCT_TYPE_SUBSCRIPTION
-          : productTypesBySku.get(sku);
+        const explicitProductType =
+          request.type === 'subs' ? PRODUCT_TYPE_SUBSCRIPTION : request.type;
+        const fallbackProductType =
+          explicitProductType ??
+          (hasSubscriptionRequestContext(androidRequest?.subscriptionOffers)
+            ? PRODUCT_TYPE_SUBSCRIPTION
+            : productTypesBySku.get(sku));
         if (fallbackProductType != null) {
           productTypesBySku.set(sku, fallbackProductType);
         }


### PR DESCRIPTION
## Summary

- Carry the validated public purchase type through the React Native Nitro request.
- Let iOS purchase uncached subscriptions as subscriptions instead of falling back to in-app products.
- Let Android use the explicit type and avoid redundant product prefetches while retaining the cache-based fallback for direct or legacy native callers.
- Cover the forwarded type in the standard and Amazon Vega JavaScript paths.

## Breaking changes

None. The added native bridge field is optional, and callers that omit it retain the existing cache/fetch fallback.

## Verification

- Full React Native IAP JavaScript suite: 337 tests passed.
- TypeScript typecheck and targeted ESLint passed.
- Android unit tests and debug build passed.
- Full iOS simulator build passed.
- `git diff --check` passed.

## Preview

Not applicable; this is non-visual purchase routing behavior.