### PR TITLE
fix(rn): preserve iOS query errors

### DIFF
--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -597,9 +597,12 @@ class HybridRnIap: HybridRnIapSpec {
                     RnIapLog.result("getAppTransactionIOS", nil)
                     return .first(.null)
                 }
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("getAppTransactionIOS", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
             } catch {
                 RnIapLog.failure("getAppTransactionIOS", error: error)
-                return .first(.null)
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }
@@ -692,9 +695,12 @@ class HybridRnIap: HybridRnIapSpec {
                     return NitroSubscriptionStatus(state: stateValue, platform: platform, renewalInfo: renewalInfo)
                 }
                 return .second(result)
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("subscriptionStatusIOS", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
             } catch {
                 RnIapLog.failure("subscriptionStatusIOS", error: error)
-                return .second([])
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }
@@ -718,9 +724,12 @@ class HybridRnIap: HybridRnIapSpec {
                 }
                 RnIapLog.result("currentEntitlementIOS", nil)
                 return .first(.null)
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("currentEntitlementIOS", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
             } catch {
                 RnIapLog.failure("currentEntitlementIOS", error: error)
-                throw OpenIapException.make(code: .skuNotFound, productId: sku)
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }
@@ -744,9 +753,12 @@ class HybridRnIap: HybridRnIapSpec {
                 }
                 RnIapLog.result("latestTransactionIOS", nil)
                 return .first(.null)
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("latestTransactionIOS", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
             } catch {
                 RnIapLog.failure("latestTransactionIOS", error: error)
-                throw OpenIapException.make(code: .skuNotFound, productId: sku)
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }
@@ -936,9 +948,12 @@ class HybridRnIap: HybridRnIapSpec {
                     return .second(jws)
                 }
                 return .first(.null)
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("getTransactionJwsIOS", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
             } catch {
                 RnIapLog.failure("getTransactionJwsIOS", error: error)
-                throw OpenIapException.make(code: .transactionValidationFailed, message: "Can't find transaction for sku \(sku)")
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }
@@ -953,9 +968,12 @@ class HybridRnIap: HybridRnIapSpec {
                     return .second(result)
                 }
                 return .first(.null)
+            } catch let purchaseError as PurchaseError {
+                RnIapLog.failure("beginRefundRequestIOS", error: purchaseError)
+                throw OpenIapException.from(purchaseError)
             } catch {
                 RnIapLog.failure("beginRefundRequestIOS", error: error)
-                return .first(.null)
+                throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
             }
         }
     }

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -1483,9 +1483,17 @@ describe('Public API (src/index.ts)', () => {
         /Unable to parse app transaction payload/,
       );
 
-      const nativeError = new Error('app transaction failed');
+      const nativeError = new Error(
+        JSON.stringify({
+          code: 'service-error',
+          message: 'App transaction failed',
+        }),
+      );
       mockIap.getAppTransactionIOS.mockRejectedValueOnce(nativeError);
-      await expect(IAP.getAppTransactionIOS()).rejects.toBe(nativeError);
+      await expect(IAP.getAppTransactionIOS()).rejects.toMatchObject({
+        code: ErrorCode.ServiceError,
+        message: 'App transaction failed',
+      });
     });
 
     it('presentCodeRedemptionSheetIOS returns the verified purchase', async () => {

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1170,8 +1170,16 @@ export const getAppTransactionIOS: QueryField<
 
     return null;
   } catch (error) {
-    RnIapConsole.error('Failed to get app transaction:', error);
-    throw error;
+    const parsedError = parseErrorAndLogIfNeeded(
+      'Failed to get app transaction:',
+      error,
+    );
+    throw createPurchaseError({
+      code: parsedError.code,
+      message: parsedError.message,
+      responseCode: parsedError.responseCode,
+      debugMessage: parsedError.debugMessage,
+    });
   }
 };
 


### PR DESCRIPTION
## Summary

- Preserve structured `PurchaseError` codes from six iOS query/refund bridge methods.
- Map unexpected native failures to `service-error` with their actual message instead of returning null/empty success values or fabricating SKU/validation failures.
- Keep valid absence and refund status results unchanged.

## Breaking changes

None to the API shape. **Observable correction:** native failures that were previously hidden as null/empty results, or rewritten with unrelated error codes, now reject with the normalized underlying error.

## Verification

- Full iOS simulator example build passed.
- `git diff --check` passed.

## Preview

Not applicable; this is non-visual native error propagation.