### PR TITLE
fix(hooks): refresh cached products

### DIFF
--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -377,6 +377,70 @@ describe('hooks/useIAP (renderer)', () => {
     ]);
   });
 
+  it('ignores an older all-products response for the same SKUs', async () => {
+    type ProductResult = {id: string; type: string; displayPrice: string};
+    let resolveFirst: ((value: ProductResult[]) => void) | undefined;
+    let resolveSecond: ((value: ProductResult[]) => void) | undefined;
+    mockFetchProducts
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+
+    let api: any;
+    const Harness = () => {
+      api = useIAP();
+      return null;
+    };
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+
+    let firstFetch: Promise<void>;
+    let secondFetch: Promise<void>;
+    act(() => {
+      firstFetch = api.fetchProducts({
+        skus: ['product1', 'subscription1'],
+        type: 'all',
+      });
+      secondFetch = api.fetchProducts({
+        skus: ['product1', 'subscription1'],
+        type: 'all',
+      });
+    });
+
+    await act(async () => {
+      resolveSecond?.([
+        {id: 'product1', type: 'in-app', displayPrice: '$3.00'},
+        {id: 'subscription1', type: 'subs', displayPrice: '$4.00'},
+      ]);
+      await secondFetch!;
+    });
+
+    await act(async () => {
+      resolveFirst?.([
+        {id: 'product1', type: 'in-app', displayPrice: '$1.00'},
+        {id: 'subscription1', type: 'subs', displayPrice: '$2.00'},
+      ]);
+      await firstFetch!;
+    });
+
+    expect(api.products).toEqual([
+      expect.objectContaining({id: 'product1', displayPrice: '$3.00'}),
+    ]);
+    expect(api.subscriptions).toEqual([
+      expect.objectContaining({id: 'subscription1', displayPrice: '$4.00'}),
+    ]);
+  });
+
   it('delegates product fetches while the hook is disconnected', async () => {
     jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(false as any);
     mockFetchProducts.mockResolvedValueOnce([
@@ -402,9 +466,7 @@ describe('hooks/useIAP (renderer)', () => {
       skus: ['product1'],
       type: 'in-app',
     });
-    expect(api.products).toEqual([
-      expect.objectContaining({id: 'product1'}),
-    ]);
+    expect(api.products).toEqual([expect.objectContaining({id: 'product1'})]);
   });
 
   describe('onError callback', () => {

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -277,6 +277,107 @@ describe('hooks/useIAP (renderer)', () => {
     debug.mockRestore();
   });
 
+  it('refreshes an existing product when it is fetched again', async () => {
+    mockFetchProducts
+      .mockResolvedValueOnce([
+        {id: 'product1', type: 'in-app', displayPrice: '$1.00'},
+      ] as any)
+      .mockResolvedValueOnce([
+        {id: 'product1', type: 'in-app', displayPrice: '$2.00'},
+      ] as any);
+
+    let api: any;
+    const Harness = () => {
+      api = useIAP();
+      return null;
+    };
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      await api.fetchProducts({skus: ['product1']});
+    });
+    expect(api.products).toEqual([
+      expect.objectContaining({id: 'product1', displayPrice: '$1.00'}),
+    ]);
+
+    await act(async () => {
+      await api.fetchProducts({skus: ['product1']});
+    });
+    expect(api.products).toEqual([
+      expect.objectContaining({id: 'product1', displayPrice: '$2.00'}),
+    ]);
+  });
+
+  it('refreshes an existing subscription when it is fetched again', async () => {
+    mockFetchProducts
+      .mockResolvedValueOnce([
+        {id: 'subscription1', type: 'subs', displayPrice: '$1.00'},
+      ] as any)
+      .mockResolvedValueOnce([
+        {id: 'subscription1', type: 'subs', displayPrice: '$2.00'},
+      ] as any);
+
+    let api: any;
+    const Harness = () => {
+      api = useIAP();
+      return null;
+    };
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await api.fetchProducts({skus: ['subscription1'], type: 'subs'});
+      await api.fetchProducts({skus: ['subscription1'], type: 'subs'});
+    });
+
+    expect(api.subscriptions).toEqual([
+      expect.objectContaining({id: 'subscription1', displayPrice: '$2.00'}),
+    ]);
+  });
+
+  it('refreshes products and subscriptions fetched together', async () => {
+    mockFetchProducts
+      .mockResolvedValueOnce([
+        {id: 'product1', type: 'in-app', displayPrice: '$1.00'},
+        {id: 'subscription1', type: 'subs', displayPrice: '$2.00'},
+      ] as any)
+      .mockResolvedValueOnce([
+        {id: 'product1', type: 'in-app', displayPrice: '$3.00'},
+        {id: 'subscription1', type: 'subs', displayPrice: '$4.00'},
+      ] as any);
+
+    let api: any;
+    const Harness = () => {
+      api = useIAP();
+      return null;
+    };
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await api.fetchProducts({
+        skus: ['product1', 'subscription1'],
+        type: 'all',
+      });
+      await api.fetchProducts({
+        skus: ['product1', 'subscription1'],
+        type: 'all',
+      });
+    });
+
+    expect(api.products).toEqual([
+      expect.objectContaining({id: 'product1', displayPrice: '$3.00'}),
+    ]);
+    expect(api.subscriptions).toEqual([
+      expect.objectContaining({id: 'subscription1', displayPrice: '$4.00'}),
+    ]);
+  });
+
   describe('onError callback', () => {
     it('calls onError when fetchProducts fails', async () => {
       const fetchError = new Error('Network error fetching products');

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -309,6 +309,18 @@ export interface UseIapOptions {
   billingChoiceScreenTypeAndroid?: BillingChoiceScreenTypeAndroid;
 }
 
+function mergeByKey<T>(
+  existingItems: T[],
+  newItems: T[],
+  getKey: (item: T) => string,
+): T[] {
+  const merged = new Map(
+    existingItems.map((item) => [getKey(item), item] as const),
+  );
+  newItems.forEach((item) => merged.set(getKey(item), item));
+  return Array.from(merged.values());
+}
+
 /**
  * React Hook for managing In-App Purchases.
  * See documentation at https://react-native-iap.hyo.dev/docs/hooks/useIAP
@@ -325,27 +337,6 @@ export function useIAP(options?: UseIapOptions): UseIap {
 
   const optionsRef = useRef<UseIapOptions | undefined>(options);
   const connectedRef = useRef<boolean>(false);
-
-  // Helper function to merge arrays with duplicate checking
-  const mergeWithDuplicateCheck = useCallback(
-    <T>(
-      existingItems: T[],
-      newItems: T[],
-      getKey: (item: T) => string,
-    ): T[] => {
-      const merged = [...existingItems];
-      newItems.forEach((newItem) => {
-        const isDuplicate = merged.some(
-          (existingItem) => getKey(existingItem) === getKey(newItem),
-        );
-        if (!isDuplicate) {
-          merged.push(newItem);
-        }
-      });
-      return merged;
-    },
-    [],
-  );
 
   useEffect(() => {
     optionsRef.current = options;
@@ -414,7 +405,7 @@ export function useIAP(options?: UseIapOptions): UseIap {
         if (requestType === 'subs') {
           // All items are already subscriptions
           setSubscriptions((prevSubscriptions: ProductSubscription[]) =>
-            mergeWithDuplicateCheck(
+            mergeByKey(
               prevSubscriptions,
               items as ProductSubscription[],
               (subscription: ProductSubscription) => subscription.id,
@@ -433,14 +424,14 @@ export function useIAP(options?: UseIapOptions): UseIap {
           );
 
           setProducts((prevProducts: Product[]) =>
-            mergeWithDuplicateCheck(
+            mergeByKey(
               prevProducts,
               newProducts,
               (product: Product) => product.id,
             ),
           );
           setSubscriptions((prevSubscriptions: ProductSubscription[]) =>
-            mergeWithDuplicateCheck(
+            mergeByKey(
               prevSubscriptions,
               newSubscriptions,
               (subscription: ProductSubscription) => subscription.id,
@@ -451,7 +442,7 @@ export function useIAP(options?: UseIapOptions): UseIap {
 
         // For 'in-app' type, all items are already products
         setProducts((prevProducts: Product[]) =>
-          mergeWithDuplicateCheck(
+          mergeByKey(
             prevProducts,
             items as Product[],
             (product: Product) => product.id,
@@ -462,7 +453,7 @@ export function useIAP(options?: UseIapOptions): UseIap {
         invokeOnError(error);
       }
     },
-    [mergeWithDuplicateCheck, invokeOnError],
+    [invokeOnError],
   );
 
   const getAvailablePurchasesInternal = useCallback(

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -358,6 +358,8 @@ export function useIAP(options?: UseIapOptions): UseIap {
   // Track if component is mounted to prevent listener leaks on early unmount
   const isMountedRef = useRef<boolean>(false);
   const initializationGenerationRef = useRef(0);
+  const productRequestGenerationRef = useRef(0);
+  const productRequestOwnersRef = useRef(new Map<string, number>());
 
   const subscriptionsRefState = useRef<ProductSubscription[]>([]);
 
@@ -379,6 +381,11 @@ export function useIAP(options?: UseIapOptions): UseIap {
       skus: string[];
       type?: ProductQueryType | null;
     }): Promise<void> => {
+      const generation = ++productRequestGenerationRef.current;
+      for (const sku of params.skus) {
+        productRequestOwnersRef.current.set(sku, generation);
+      }
+
       try {
         const requestType = params.type ?? 'in-app';
         RnIapConsole.debug('[useIAP] Calling fetchProducts with:', {
@@ -393,7 +400,12 @@ export function useIAP(options?: UseIapOptions): UseIap {
           '[useIAP] fetchProducts count:',
           result?.length ?? 0,
         );
-        const items = (result ?? []) as (Product | ProductSubscription)[];
+        const items = (
+          (result ?? []) as (Product | ProductSubscription)[]
+        ).filter(
+          (item) => productRequestOwnersRef.current.get(item.id) === generation,
+        );
+        if (items.length === 0) return;
 
         // fetchProducts already returns properly filtered results based on type
         if (requestType === 'subs') {
@@ -445,6 +457,12 @@ export function useIAP(options?: UseIapOptions): UseIap {
       } catch (error) {
         RnIapConsole.error('Error fetching products:', error);
         invokeOnError(error);
+      } finally {
+        for (const sku of params.skus) {
+          if (productRequestOwnersRef.current.get(sku) === generation) {
+            productRequestOwnersRef.current.delete(sku);
+          }
+        }
       }
     },
     [invokeOnError],


### PR DESCRIPTION
## Summary

- Replace previously cached product/subscription entries when the same SKU is fetched again.
- Preserve merged batch order while allowing current prices, offers, and metadata to refresh.
- Replace repeated linear duplicate scans with a shared `Map` merge, reducing batch merge work from O(n × m) to O(n + m).
- Cover refreshed products, subscriptions, and mixed `type: all` results.

## Breaking changes

None. Existing entries keep their position; their data now reflects the latest successful fetch.

## Verification

- Full focused hook suite with patch coverage: 32 tests passed.
- TypeScript typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual cache behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refetching in-app products and subscriptions now updates stale product information correctly.
  * Prevented duplicate product entries when refreshed data is returned.
* **Tests**
  * Added coverage for refreshing individual products, subscriptions, and mixed product sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->