### PR TITLE
fix(hooks): deliver purchases before refresh

### DIFF
--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -247,6 +247,37 @@ describe('hooks/useIAP (renderer)', () => {
     consoleError.mockRestore();
   });
 
+  it('reports a post-purchase refresh failure after delivering success', async () => {
+    const refreshError = new Error('refresh failed');
+    const onPurchaseSuccess = jest.fn();
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+    const Harness = () => {
+      useIAP({onPurchaseSuccess});
+      return null;
+    };
+
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+    mockGetActiveSubscriptions.mockRejectedValueOnce(refreshError);
+
+    if (!capturedPurchaseListener) {
+      throw new Error('purchase listener was not initialized');
+    }
+    await act(async () => {
+      await capturedPurchaseListener({id: 't1', productId: 'p1'});
+    });
+
+    expect(onPurchaseSuccess).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[RN-IAP]',
+      '[useIAP] post-purchase refresh failed:',
+      refreshError,
+    );
+    consoleWarn.mockRestore();
+  });
+
   it('requestPurchase calls root API and returns void', async () => {
     const mockRequestPurchase = jest
       .spyOn(IAP, 'requestPurchase')

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -211,6 +211,42 @@ describe('hooks/useIAP (renderer)', () => {
     );
   });
 
+  it('refreshes purchase state when onPurchaseSuccess throws', async () => {
+    const callbackError = new Error('host callback failed');
+    const onPurchaseSuccess = jest.fn(() => {
+      throw callbackError;
+    });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const Harness = () => {
+      useIAP({onPurchaseSuccess});
+      return null;
+    };
+
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+    mockGetActiveSubscriptions.mockClear();
+    mockGetAvailablePurchases.mockClear();
+
+    if (!capturedPurchaseListener) {
+      throw new Error('purchase listener was not initialized');
+    }
+    await act(async () => {
+      await capturedPurchaseListener({id: 't1', productId: 'p1'});
+    });
+
+    expect(onPurchaseSuccess).toHaveBeenCalledTimes(1);
+    expect(mockGetActiveSubscriptions).toHaveBeenCalledTimes(1);
+    expect(mockGetAvailablePurchases).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      '[RN-IAP]',
+      '[useIAP] onPurchaseSuccess failed:',
+      callbackError,
+    );
+    consoleError.mockRestore();
+  });
+
   it('requestPurchase calls root API and returns void', async () => {
     const mockRequestPurchase = jest
       .spyOn(IAP, 'requestPurchase')

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -247,6 +247,42 @@ describe('hooks/useIAP (renderer)', () => {
     consoleError.mockRestore();
   });
 
+  it('refreshes purchase state when onPurchaseSuccess rejects', async () => {
+    const callbackError = new Error('async host callback failed');
+    const onPurchaseSuccess = jest.fn(async () => {
+      throw callbackError;
+    });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const Harness = () => {
+      useIAP({onPurchaseSuccess});
+      return null;
+    };
+
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+    mockGetActiveSubscriptions.mockClear();
+    mockGetAvailablePurchases.mockClear();
+
+    if (!capturedPurchaseListener) {
+      throw new Error('purchase listener was not initialized');
+    }
+    await act(async () => {
+      await capturedPurchaseListener({id: 't1', productId: 'p1'});
+    });
+
+    expect(onPurchaseSuccess).toHaveBeenCalledTimes(1);
+    expect(mockGetActiveSubscriptions).toHaveBeenCalledTimes(1);
+    expect(mockGetAvailablePurchases).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      '[RN-IAP]',
+      '[useIAP] onPurchaseSuccess failed:',
+      callbackError,
+    );
+    consoleError.mockRestore();
+  });
+
   it('reports a post-purchase refresh failure after delivering success', async () => {
     const refreshError = new Error('refresh failed');
     const onPurchaseSuccess = jest.fn();
@@ -260,6 +296,8 @@ describe('hooks/useIAP (renderer)', () => {
       TestRenderer.create(React.createElement(Harness));
     });
     await act(async () => {});
+    mockGetActiveSubscriptions.mockClear();
+    mockGetAvailablePurchases.mockClear();
     mockGetActiveSubscriptions.mockRejectedValueOnce(refreshError);
 
     if (!capturedPurchaseListener) {
@@ -270,6 +308,8 @@ describe('hooks/useIAP (renderer)', () => {
     });
 
     expect(onPurchaseSuccess).toHaveBeenCalledTimes(1);
+    expect(mockGetActiveSubscriptions).toHaveBeenCalledTimes(1);
+    expect(mockGetAvailablePurchases).toHaveBeenCalledTimes(1);
     expect(consoleWarn).toHaveBeenCalledWith(
       '[RN-IAP]',
       '[useIAP] post-purchase refresh failed:',

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -190,6 +190,11 @@ describe('hooks/useIAP (renderer)', () => {
     }
     const resolvePendingActiveSubscriptions = resolveActiveSubscriptions;
 
+    expect(onPurchaseSuccess).toHaveBeenCalledTimes(1);
+    expect(onPurchaseSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({id: 't1', productId: 'p1'}),
+    );
+
     await act(async () => {
       renderer.unmount();
     });
@@ -199,9 +204,7 @@ describe('hooks/useIAP (renderer)', () => {
       await purchaseUpdate;
     });
 
-    // The event entered while mounted, so the success callback still fires:
-    // it is where apps call finishTransaction, and a dropped event has no
-    // in-session redelivery.
+    // The pending state refresh does not redeliver the purchase callback.
     expect(onPurchaseSuccess).toHaveBeenCalledTimes(1);
     expect(onPurchaseSuccess).toHaveBeenCalledWith(
       expect.objectContaining({id: 't1', productId: 'p1'}),

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -609,19 +609,15 @@ export function useIAP(options?: UseIapOptions): UseIap {
     if (!subscriptionsRef.current.purchaseUpdate) {
       subscriptionsRef.current.purchaseUpdate = purchaseUpdatedListener(
         async (purchase: Purchase) => {
+          // Deliver first so store refresh latency cannot delay verification
+          // and transaction finalization in the host app.
+          optionsRef.current?.onPurchaseSuccess?.(purchase);
+
           try {
             await getActiveSubscriptionsInternal();
             await getAvailablePurchasesInternal();
           } catch (e) {
             RnIapConsole.warn('[useIAP] post-purchase refresh failed:', e);
-          }
-
-          // Deliver even if the hook unmounted while the refresh was pending:
-          // onPurchaseSuccess is where apps call finishTransaction, and a
-          // dropped event has no in-session redelivery. Internal setState is
-          // mount-guarded inside the refresh helpers.
-          if (optionsRef.current?.onPurchaseSuccess) {
-            optionsRef.current.onPurchaseSuccess(purchase);
           }
         },
         optionsRef.current?.purchaseUpdatedListenerOptions,

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -611,7 +611,11 @@ export function useIAP(options?: UseIapOptions): UseIap {
         async (purchase: Purchase) => {
           // Deliver first so store refresh latency cannot delay verification
           // and transaction finalization in the host app.
-          optionsRef.current?.onPurchaseSuccess?.(purchase);
+          try {
+            optionsRef.current?.onPurchaseSuccess?.(purchase);
+          } catch (e) {
+            RnIapConsole.error('[useIAP] onPurchaseSuccess failed:', e);
+          }
 
           try {
             await getActiveSubscriptionsInternal();

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -612,13 +612,21 @@ export function useIAP(options?: UseIapOptions): UseIap {
           // Deliver first so store refresh latency cannot delay verification
           // and transaction finalization in the host app.
           try {
-            optionsRef.current?.onPurchaseSuccess?.(purchase);
+            const callbackResult =
+              optionsRef.current?.onPurchaseSuccess?.(purchase);
+            void Promise.resolve(callbackResult).catch((e) => {
+              RnIapConsole.error('[useIAP] onPurchaseSuccess failed:', e);
+            });
           } catch (e) {
             RnIapConsole.error('[useIAP] onPurchaseSuccess failed:', e);
           }
 
           try {
             await getActiveSubscriptionsInternal();
+          } catch (e) {
+            RnIapConsole.warn('[useIAP] post-purchase refresh failed:', e);
+          }
+          try {
             await getAvailablePurchasesInternal();
           } catch (e) {
             RnIapConsole.warn('[useIAP] post-purchase refresh failed:', e);


### PR DESCRIPTION
## Summary

- Invoke `onPurchaseSuccess` as soon as the native purchase event arrives.
- Run subscription and available-purchase refreshes after delivery so store latency cannot delay verification or `finishTransaction`.
- Preserve exactly-once callback delivery when refresh is still pending or the hook unmounts.

## Breaking changes

None. **Observable correction:** the success callback now runs before post-purchase state refresh completes instead of waiting on two store queries.

## Verification

- Full focused hook suite: 29 tests passed.
- TypeScript typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual event timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase success callbacks are now delivered before post-purchase data refreshes.
  * Callback errors are handled without interrupting purchase processing.
  * Subscription and purchase refreshes now run independently, so one failure does not block the other.
  * Purchase success remains available when the app is unmounted during a pending refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->