### PR TITLE
fix(hooks): propagate product fetch errors

### DIFF
--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -596,12 +596,17 @@ describe('hooks/useIAP (renderer)', () => {
       });
       await act(async () => {});
 
-      // Call fetchProducts which should trigger onError
+      let thrown: unknown;
       await act(async () => {
-        await api.fetchProducts({skus: ['product1']});
+        try {
+          await api.fetchProducts({skus: ['product1']});
+        } catch (error) {
+          thrown = error;
+        }
       });
 
       expect(onError).toHaveBeenCalledWith(fetchError);
+      expect(thrown).toBe(fetchError);
     });
 
     it('calls onError when getAvailablePurchases fails', async () => {
@@ -845,12 +850,18 @@ describe('hooks/useIAP (renderer)', () => {
       });
       await act(async () => {});
 
+      let thrown: unknown;
       await act(async () => {
-        await api.fetchProducts({skus: ['product1']});
+        try {
+          await api.fetchProducts({skus: ['product1']});
+        } catch (error) {
+          thrown = error;
+        }
       });
 
       expect(onError).toHaveBeenCalledWith(expect.any(Error));
       expect(onError.mock.calls[0][0].message).toBe(stringError);
+      expect(thrown).toBe(stringError);
     });
 
     it('calls onError when initConnection fails', async () => {

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -457,6 +457,7 @@ export function useIAP(options?: UseIapOptions): UseIap {
       } catch (error) {
         RnIapConsole.error('Error fetching products:', error);
         invokeOnError(error);
+        throw error;
       } finally {
         for (const sku of params.skus) {
           if (productRequestOwnersRef.current.get(sku) === generation) {


### PR DESCRIPTION
## Summary

- Rethrow product fetch failures after reporting them through the hook's `onError` callback.
- Preserve the original rejection value for callers while retaining normalized callback errors.
- Add regressions for both `Error` and non-`Error` failures.

## Breaking changes

**Behavioral compatibility:** code that relied on a failed `fetchProducts()` promise resolving must now handle its rejection. This matches the method's documented `@throws` contract and the hook's other query helpers.

## Verification

- Full focused hook suite: 29 tests passed.
- TypeScript typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual error propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product-fetching errors are now propagated to callers, allowing applications to handle failures with standard `catch` or `finally` logic.
  * Error callbacks continue to be invoked while the original error is preserved and rethrown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->