### PR TITLE
fix(rn): preserve subscription query errors

### DIFF
--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -2500,14 +2500,14 @@ describe('Public API (src/index.ts)', () => {
         expect(result).toBe(false);
       });
 
-      it('should return false on error', async () => {
+      it('should reject when subscription status cannot be determined', async () => {
         (Platform as any).OS = 'ios';
         const error = new Error('Failed to fetch');
         mockIap.getActiveSubscriptions.mockRejectedValueOnce(error);
 
-        const result = await IAP.hasActiveSubscriptions();
-
-        expect(result).toBe(false);
+        await expect(IAP.hasActiveSubscriptions()).rejects.toThrow(
+          'Failed to fetch',
+        );
       });
     });
   });

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -2500,15 +2500,18 @@ describe('Public API (src/index.ts)', () => {
         expect(result).toBe(false);
       });
 
-      it('should reject when subscription status cannot be determined', async () => {
-        (Platform as any).OS = 'ios';
-        const error = new Error('Failed to fetch');
-        mockIap.getActiveSubscriptions.mockRejectedValueOnce(error);
+      it.each(['ios', 'android'] as const)(
+        'should reject when subscription status cannot be determined on %s',
+        async (platform) => {
+          (Platform as any).OS = platform;
+          const error = new Error('Failed to fetch');
+          mockIap.getActiveSubscriptions.mockRejectedValueOnce(error);
 
-        await expect(IAP.hasActiveSubscriptions()).rejects.toThrow(
-          'Failed to fetch',
-        );
-      });
+          await expect(IAP.hasActiveSubscriptions()).rejects.toThrow(
+            'Failed to fetch',
+          );
+        },
+      );
     });
   });
 

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -2663,20 +2663,15 @@ export const getActiveSubscriptions: QueryField<
  *
  * @param subscriptionIds - Optional array of subscription IDs to check
  * @returns Promise<boolean> - True if there are active subscriptions
+ * @throws When the store cannot determine subscription status
  *
  * @see {@link https://openiap.dev/docs/apis/has-active-subscriptions}
  */
 export const hasActiveSubscriptions: QueryField<
   'hasActiveSubscriptions'
 > = async (subscriptionIds) => {
-  try {
-    const activeSubscriptions = await getActiveSubscriptions(subscriptionIds);
-    return activeSubscriptions.length > 0;
-  } catch (error) {
-    // If there's an error getting subscriptions, return false
-    RnIapConsole.warn('Error checking active subscriptions:', error);
-    return false;
-  }
+  const activeSubscriptions = await getActiveSubscriptions(subscriptionIds);
+  return activeSubscriptions.length > 0;
 };
 
 // Type conversion utilities


### PR DESCRIPTION
## Summary

- Propagate `getActiveSubscriptions` failures from `hasActiveSubscriptions`.
- Keep a valid empty subscription result mapped to `false`.
- Document the query failure contract and update its regression.

## Breaking changes

**Behavioral compatibility:** callers that relied on store/connection failures resolving `false` must now catch the rejection. This prevents outages from being reported as a definitive lack of entitlement and matches the underlying OpenIAP/Expo query semantics.

## Verification

- Full public index suite: 236 tests passed.
- TypeScript typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual error propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription status checks now surface store or service errors instead of incorrectly reporting no active subscriptions when a check fails.
  * Updated error-handling behavior to provide more accurate results to callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->