### PR TITLE
fix(hooks): allow product fetch before connect

### DIFF
--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -277,6 +277,36 @@ describe('hooks/useIAP (renderer)', () => {
     debug.mockRestore();
   });
 
+  it('delegates product fetches while the hook is disconnected', async () => {
+    jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(false as any);
+    mockFetchProducts.mockResolvedValueOnce([
+      {id: 'product1', type: 'in-app'},
+    ] as any);
+
+    let api: any;
+    const Harness = () => {
+      api = useIAP();
+      return null;
+    };
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+    expect(api.connected).toBe(false);
+
+    await act(async () => {
+      await api.fetchProducts({skus: ['product1']});
+    });
+
+    expect(mockFetchProducts).toHaveBeenCalledWith({
+      skus: ['product1'],
+      type: 'in-app',
+    });
+    expect(api.products).toEqual([
+      expect.objectContaining({id: 'product1'}),
+    ]);
+  });
+
   describe('onError callback', () => {
     it('calls onError when fetchProducts fails', async () => {
       const fetchError = new Error('Network error fetching products');

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -388,12 +388,6 @@ export function useIAP(options?: UseIapOptions): UseIap {
       skus: string[];
       type?: ProductQueryType | null;
     }): Promise<void> => {
-      if (!connectedRef.current) {
-        RnIapConsole.warn(
-          '[useIAP] fetchProducts called before connection; skipping',
-        );
-        return;
-      }
       try {
         const requestType = params.type ?? 'in-app';
         RnIapConsole.debug('[useIAP] Calling fetchProducts with:', {


### PR DESCRIPTION
## Summary

- Delegate `useIAP.fetchProducts` even while the hook reports a disconnected state.
- Let the native/root query initialize where supported or return its real connection failure instead of silently skipping the request.
- Add a regression that proves a disconnected hook still delegates and updates fetched products.

## Breaking changes

None to the API shape. **Observable correction:** formerly silent no-op calls now execute normally and may reject with the documented connection/store error.

## Verification

- Full focused hook suite: 30 tests passed.
- TypeScript typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual query behavior.