### PR TITLE
fix(rn): ignore stale reconnect results

### DIFF
--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -1079,6 +1079,61 @@ describe('hooks/useIAP (renderer)', () => {
       expect(onError).not.toHaveBeenCalled();
     });
 
+    it('ignores an older reconnect success after a newer success', async () => {
+      let api: any;
+      const Harness = () => {
+        api = useIAP();
+        return null;
+      };
+
+      await act(async () => {
+        TestRenderer.create(React.createElement(Harness));
+      });
+      await act(async () => {});
+
+      (IAP.purchaseUpdatedListener as jest.Mock).mockClear();
+      (IAP.purchaseErrorListener as jest.Mock).mockClear();
+
+      let resolveFirst: ((value: boolean) => void) | undefined;
+      let resolveSecond: ((value: boolean) => void) | undefined;
+      jest
+        .spyOn(IAP, 'initConnection')
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveFirst = resolve;
+            }) as any,
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSecond = resolve;
+            }) as any,
+        );
+
+      let firstReconnect: Promise<boolean>;
+      let secondReconnect: Promise<boolean>;
+      act(() => {
+        firstReconnect = api.reconnect();
+        secondReconnect = api.reconnect();
+      });
+
+      await act(async () => {
+        resolveSecond?.(true);
+        expect(await secondReconnect!).toBe(true);
+      });
+      expect(api.connected).toBe(true);
+
+      await act(async () => {
+        resolveFirst?.(true);
+        expect(await firstReconnect!).toBe(false);
+      });
+
+      expect(api.connected).toBe(true);
+      expect(IAP.purchaseUpdatedListener).not.toHaveBeenCalled();
+      expect(IAP.purchaseErrorListener).not.toHaveBeenCalled();
+    });
+
     it('reconnect re-registers listeners after successful reconnection', async () => {
       let api: any;
       const onPurchaseSuccess = jest.fn();

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -1027,6 +1027,58 @@ describe('hooks/useIAP (renderer)', () => {
       expect(result).toBe(false);
     });
 
+    it('ignores an older reconnect failure after a newer success', async () => {
+      let api: any;
+      const onError = jest.fn();
+      const Harness = () => {
+        api = useIAP({onError});
+        return null;
+      };
+
+      await act(async () => {
+        TestRenderer.create(React.createElement(Harness));
+      });
+      await act(async () => {});
+
+      let rejectFirst: ((reason: Error) => void) | undefined;
+      let resolveSecond: ((value: boolean) => void) | undefined;
+      jest
+        .spyOn(IAP, 'initConnection')
+        .mockImplementationOnce(
+          () =>
+            new Promise((_, reject) => {
+              rejectFirst = reject;
+            }) as any,
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSecond = resolve;
+            }) as any,
+        );
+
+      let firstReconnect: Promise<boolean>;
+      let secondReconnect: Promise<boolean>;
+      act(() => {
+        firstReconnect = api.reconnect();
+        secondReconnect = api.reconnect();
+      });
+
+      await act(async () => {
+        resolveSecond?.(true);
+        await secondReconnect!;
+      });
+      expect(api.connected).toBe(true);
+
+      await act(async () => {
+        rejectFirst?.(new Error('stale reconnect failed'));
+        expect(await firstReconnect!).toBe(false);
+      });
+
+      expect(api.connected).toBe(true);
+      expect(onError).not.toHaveBeenCalled();
+    });
+
     it('reconnect re-registers listeners after successful reconnection', async () => {
       let api: any;
       const onPurchaseSuccess = jest.fn();

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -767,12 +767,16 @@ export function useIAP(options?: UseIapOptions): UseIap {
   );
 
   const reconnect = useCallback(async (): Promise<boolean> => {
+    const generation = ++initializationGenerationRef.current;
     const config = buildAndroidConfig();
 
     try {
       const result = await initConnection(config);
 
-      if (!isMountedRef.current) {
+      if (
+        !isMountedRef.current ||
+        initializationGenerationRef.current !== generation
+      ) {
         return false;
       }
 
@@ -785,6 +789,12 @@ export function useIAP(options?: UseIapOptions): UseIap {
       setConnected(false);
       return false;
     } catch (error) {
+      if (
+        !isMountedRef.current ||
+        initializationGenerationRef.current !== generation
+      ) {
+        return false;
+      }
       RnIapConsole.error('[useIAP] reconnect failed:', error);
       cleanupListeners();
       if (isMountedRef.current) {


### PR DESCRIPTION
## Summary

- Give every hook reconnect attempt an initialization generation.
- Ignore stale success/failure completions after a newer reconnect has taken ownership.
- Prevent an older failure from clearing current listeners, reporting `onError`, or flipping a newer successful connection to false.
- Add a deferred two-request race regression.

## Breaking changes

None. Superseded reconnect promises resolve `false`; the current attempt exclusively owns hook state.

## Verification

- Full focused hook suite: 30 tests passed.
- TypeScript typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual lifecycle concurrency.