### PR TITLE
fix(rn): keep Android listener tokens unique

### DIFF
--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/TokenizedListenerRegistry.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/TokenizedListenerRegistry.kt
@@ -35,6 +35,5 @@ internal class TokenizedListenerRegistry<T> {
     @Synchronized
     fun clear() {
         registrations.clear()
-        nextToken = 1.0
     }
 }

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/TokenizedListenerRegistryTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/TokenizedListenerRegistryTest.kt
@@ -38,6 +38,7 @@ class TokenizedListenerRegistryTest {
         registry.add { }
 
         registry.clear()
+        assertFalse(registry.isNotEmpty())
         val activeToken = registry.add { }
 
         assertEquals(3.0, activeToken, 0.0)

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/TokenizedListenerRegistryTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/TokenizedListenerRegistryTest.kt
@@ -32,14 +32,16 @@ class TokenizedListenerRegistryTest {
     }
 
     @Test
-    fun `clear removes all listeners and resets token allocation`() {
+    fun `stale remover cannot remove a listener added after clear`() {
         val registry = TokenizedListenerRegistry<() -> Unit>()
-        registry.add { }
+        val staleToken = registry.add { }
         registry.add { }
 
         registry.clear()
+        val activeToken = registry.add { }
 
-        assertFalse(registry.isNotEmpty())
-        assertEquals(1.0, registry.add { }, 0.0)
+        assertEquals(3.0, activeToken, 0.0)
+        assertFalse(registry.remove(staleToken))
+        assertTrue(registry.isNotEmpty())
     }
 }


### PR DESCRIPTION
## Summary

- Keep Android listener tokens monotonic across registry clears.
- Prevent a stale JavaScript remover from deleting a newly registered listener after disconnect/reconnect.
- Update the native registry regression to exercise the reused-token race directly.

## Breaking changes

None. Listener tokens are internal opaque identifiers; active listener removal remains unchanged.

## Verification

- Focused native registry regression passed.
- Full `:react-native-iap:testDebugUnitTest` passed.
- Kotlin compilation and `git diff --check` passed.

## Preview

Not applicable; this is non-visual listener lifecycle behavior.