### PR TITLE
docs(rn): use current product price field

### DIFF
--- a/packages/docs/src/pages/docs/setup/react-native.tsx
+++ b/packages/docs/src/pages/docs/setup/react-native.tsx
@@ -252,7 +252,7 @@ function Store() {
       keyExtractor={(product) => product.id}
       renderItem={({ item }) => (
         <Button
-          title={\`\${item.title} - \${item.localizedPrice}\`}
+          title={\`\${item.title} - \${item.displayPrice}\`}
           onPress={() =>
             requestPurchase({
               request: {


### PR DESCRIPTION
## Summary

- Render the canonical v16 `Product.displayPrice` field in the primary React Native quick-start.
- Remove the stale `localizedPrice` reference, which no longer exists on the current product type.

## Breaking changes

None. This is a documentation-only correction.

## Verification

- Prettier and `git diff --check` passed.
- Docs-package typecheck could not run because this clone does not have that workspace's dependencies/`tsc` installed; the changed line is inside the displayed code string and is not compiled by that check regardless.

## Preview

Not applicable; only the code sample field name changes.