### PR TITLE
fix: preserve error field fallbacks

### DIFF
--- a/libraries/react-native-iap/src/__tests__/utils/error.test.ts
+++ b/libraries/react-native-iap/src/__tests__/utils/error.test.ts
@@ -24,6 +24,20 @@ describe('Error utilities', () => {
       });
     });
 
+    it('should replace empty JSON error fields with fallbacks', () => {
+      const errorString = JSON.stringify({
+        code: '',
+        message: '',
+        responseCode: -1,
+      });
+
+      expect(parseErrorStringToJsonObj(errorString)).toEqual({
+        code: ErrorCode.Unknown,
+        message: errorString,
+        responseCode: -1,
+      });
+    });
+
     it('should handle Error object with JSON message', () => {
       const errorObj = {
         code: ErrorCode.NetworkError,
@@ -221,6 +235,13 @@ describe('Error utilities', () => {
       const result = parseErrorStringToJsonObj(errorObj);
 
       expect(result).toEqual(errorObj);
+    });
+
+    it('should replace empty structured error fields with fallbacks', () => {
+      expect(parseErrorStringToJsonObj({code: '', message: ''})).toEqual({
+        code: ErrorCode.Unknown,
+        message: 'Unknown error occurred',
+      });
     });
 
     it('should parse error code format "CODE: message"', () => {

--- a/libraries/react-native-iap/src/utils/error.ts
+++ b/libraries/react-native-iap/src/utils/error.ts
@@ -33,9 +33,9 @@ const parseJsonPayload = (
       if (typeof parsed === 'object' && parsed !== null) {
         const parsedError = parsed as Partial<IapError>;
         return {
+          ...parsedError,
           code: parsedError.code || ErrorCode.Unknown,
           message: parsedError.message || fallbackMessage,
-          ...parsedError,
         };
       }
     } catch {
@@ -118,11 +118,15 @@ const parseStructuredError = (error: object): IapError | null => {
 
   if (errorWithCode.code != null) {
     const {code, message, ...extraFields} = errorWithCode;
+    const normalizedCode = String(code);
 
     return {
       ...extraFields,
-      code: String(code),
-      message: typeof message === 'string' ? message : 'Unknown error occurred',
+      code: normalizedCode || ErrorCode.Unknown,
+      message:
+        typeof message === 'string' && message
+          ? message
+          : 'Unknown error occurred',
     };
   }
 


### PR DESCRIPTION
## Summary

- Apply parsed JSON fields before normalized error-code/message fallbacks so empty native fields cannot overwrite valid defaults.
- Apply the same non-empty normalization to plain structured error objects.
- Add regressions for empty JSON and structured error fields.

## Breaking changes

None. Invalid empty fields now produce the existing `unknown` code and fallback message instead of unusable empty strings.

## Verification

- Focused error utility suite: 28 tests passed.
- Library typecheck, targeted ESLint, and `git diff --check` passed.

## Preview

Not applicable; this is non-visual error normalization.