### PR TITLE
fix(android): preserve coroutine cancellation

### DIFF
--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -139,6 +139,17 @@ internal fun requireMatchingPurchaseOptions(
     }
 }
 
+internal inline fun <T> catchNonCancellation(
+    block: () -> T,
+    onFailure: (Exception) -> T,
+): T = try {
+    block()
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Exception) {
+    onFailure(error)
+}
+
 /**
  * Bound for the pending purchase-event queues, matching expo-iap's
  * ExpoIapHelper.MAX_BUFFERED_EVENTS. Oldest entries are dropped on overflow.
@@ -773,50 +784,50 @@ class HybridRnIap : HybridRnIapSpec() {
                 mapOf("subscriptionIds" to (subscriptionIds?.toList() ?: "all"))
             )
 
-            try {
-                // Use OpenIapModule's native getActiveSubscriptions method
-                RnIapLog.payload("getActiveSubscriptions.native", mapOf("type" to "subs"))
-                val activeSubscriptions = openIap.getActiveSubscriptions(subscriptionIds?.toList())
+            catchNonCancellation(
+                block = {
+                    RnIapLog.payload("getActiveSubscriptions.native", mapOf("type" to "subs"))
+                    val activeSubscriptions = openIap.getActiveSubscriptions(subscriptionIds?.toList())
 
-                val nitroSubscriptions = activeSubscriptions.map { sub ->
-                    NitroActiveSubscription(
-                        productId = sub.productId,
-                        isActive = sub.isActive,
-                        transactionId = sub.transactionId,
-                        purchaseToken = sub.purchaseToken.wrapVariant(),
-                        transactionDate = sub.transactionDate,
-                        // Android specific fields
-                        autoRenewingAndroid = sub.autoRenewingAndroid.wrapVariant(),
-                        basePlanIdAndroid = sub.basePlanIdAndroid.wrapVariant(),
-                        currentPlanId = sub.currentPlanId.wrapVariant(),
-                        purchaseTokenAndroid = sub.purchaseTokenAndroid.wrapVariant(),
-                        // iOS specific fields (null on Android)
-                        expirationDateIOS = null,
-                        environmentIOS = null,
-                        daysUntilExpirationIOS = null,
-                        renewalInfoIOS = null
+                    val nitroSubscriptions = activeSubscriptions.map { sub ->
+                        NitroActiveSubscription(
+                            productId = sub.productId,
+                            isActive = sub.isActive,
+                            transactionId = sub.transactionId,
+                            purchaseToken = sub.purchaseToken.wrapVariant(),
+                            transactionDate = sub.transactionDate,
+                            // Android specific fields
+                            autoRenewingAndroid = sub.autoRenewingAndroid.wrapVariant(),
+                            basePlanIdAndroid = sub.basePlanIdAndroid.wrapVariant(),
+                            currentPlanId = sub.currentPlanId.wrapVariant(),
+                            purchaseTokenAndroid = sub.purchaseTokenAndroid.wrapVariant(),
+                            // iOS specific fields (null on Android)
+                            expirationDateIOS = null,
+                            environmentIOS = null,
+                            daysUntilExpirationIOS = null,
+                            renewalInfoIOS = null
+                        )
+                    }
+
+                    RnIapLog.result(
+                        "getActiveSubscriptions",
+                        nitroSubscriptions.map { mapOf("productId" to it.productId, "isActive" to it.isActive) }
                     )
-                }
 
-                RnIapLog.result(
-                    "getActiveSubscriptions",
-                    nitroSubscriptions.map { mapOf("productId" to it.productId, "isActive" to it.isActive) }
-                )
-
-                nitroSubscriptions.toTypedArray()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                RnIapLog.failure("getActiveSubscriptions", e)
-                val error = OpenIapError.ServiceUnavailable()
-                throw OpenIapException(
-                    toErrorJson(
-                        error = error,
-                        debugMessage = e.message,
-                        messageOverride = "Failed to get active subscriptions: ${e.message}"
+                    nitroSubscriptions.toTypedArray()
+                },
+                onFailure = { e ->
+                    RnIapLog.failure("getActiveSubscriptions", e)
+                    val error = OpenIapError.ServiceUnavailable()
+                    throw OpenIapException(
+                        toErrorJson(
+                            error = error,
+                            debugMessage = e.message,
+                            messageOverride = "Failed to get active subscriptions: ${e.message}"
+                        )
                     )
-                )
-            }
+                },
+            )
         }
     }
 
@@ -1876,14 +1887,16 @@ class HybridRnIap : HybridRnIapSpec() {
 
     override fun enableBillingProgramAndroid(program: BillingProgramAndroid) {
         RnIapLog.payload("enableBillingProgramAndroid", mapOf("program" to program.name))
-        try {
-            val openIapProgram = mapBillingProgram(program)
-            openIapStore.enableBillingProgram(openIapProgram)
-            RnIapLog.result("enableBillingProgramAndroid", true)
-        } catch (err: Exception) {
-            RnIapLog.failure("enableBillingProgramAndroid", err)
-            // enableBillingProgram is void, so we just log the error
-        }
+        catchNonCancellation(
+            block = {
+                val openIapProgram = mapBillingProgram(program)
+                openIapStore.enableBillingProgram(openIapProgram)
+                RnIapLog.result("enableBillingProgramAndroid", true)
+            },
+            onFailure = { err ->
+                RnIapLog.failure("enableBillingProgramAndroid", err)
+            },
+        )
     }
 
     override fun isBillingProgramAvailableAndroid(program: BillingProgramAndroid): Promise<NitroBillingProgramAvailabilityResultAndroid> {

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -236,7 +236,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 }
             } catch (err: CancellationException) {
                 throw err
-            } catch (err: Throwable) {
+            } catch (err: Exception) {
                 val error = OpenIapError.InitConnection
                 val errorMessage = err.message ?: err.javaClass.name
                 RnIapLog.failure("initConnection.setActivity", err)
@@ -337,7 +337,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 }
             } catch (err: CancellationException) {
                 throw err
-            } catch (err: Throwable) {
+            } catch (err: Exception) {
                 listenersAttached = false
                 val error = OpenIapError.InitConnection
                 val errorMessage = err.message ?: err.javaClass.name
@@ -374,7 +374,7 @@ class HybridRnIap : HybridRnIapSpec() {
                     }
                 } catch (err: CancellationException) {
                     throw err
-                } catch (err: Throwable) {
+                } catch (err: Exception) {
                     val error = OpenIapError.InitConnection
                     RnIapLog.failure("initConnection.native", err)
                     throw OpenIapException(
@@ -804,6 +804,8 @@ class HybridRnIap : HybridRnIapSpec() {
                 )
 
                 nitroSubscriptions.toTypedArray()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 RnIapLog.failure("getActiveSubscriptions", e)
                 val error = OpenIapError.ServiceUnavailable()
@@ -831,6 +833,8 @@ class HybridRnIap : HybridRnIapSpec() {
                 val hasActive = openIap.hasActiveSubscriptions(subscriptionIds?.toList())
                 RnIapLog.result("hasActiveSubscriptions", hasActive)
                 hasActive
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 RnIapLog.failure("hasActiveSubscriptions", e)
                 val error = OpenIapError.ServiceUnavailable()
@@ -883,6 +887,8 @@ class HybridRnIap : HybridRnIapSpec() {
             // Ensure connection; if it fails, return an error result instead of throwing
             try {
                 ensureConnection()
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val err = OpenIapError.InitConnection
                 return@async Variant_Boolean_NitroPurchaseResult.Second(
@@ -923,6 +929,8 @@ class HybridRnIap : HybridRnIapSpec() {
                 )
                 RnIapLog.result("finishTransaction", mapOf("success" to true))
                 result
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val err = OpenIapError.BillingError()
                 RnIapLog.failure("finishTransaction", e)
@@ -957,6 +965,8 @@ class HybridRnIap : HybridRnIapSpec() {
                 }
                 RnIapLog.result("getStorefront", value)
                 value
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: OpenIapException) {
                 RnIapLog.failure("getStorefront", e)
                 throw e
@@ -1571,6 +1581,8 @@ class HybridRnIap : HybridRnIapSpec() {
 
                 Variant_NitroPurchaseVerificationResultIOS_NitroPurchaseVerificationResultAndroid_NitroPurchaseVerificationResultHorizon.Second(result)
 
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: OpenIapException) {
                 RnIapLog.failure("verifyPurchase", e)
                 throw e
@@ -1676,6 +1688,8 @@ class HybridRnIap : HybridRnIapSpec() {
                     errors = nitroErrors?.let { Variant_NullType_Array_NitroVerifyPurchaseWithProviderError_.Second(it) },
                     provider = mapPurchaseVerificationProvider(result.provider.rawValue)
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 RnIapLog.failure("verifyPurchaseWithProvider", e)
                 val error = OpenIapError.VerificationFailed
@@ -1866,7 +1880,7 @@ class HybridRnIap : HybridRnIapSpec() {
             val openIapProgram = mapBillingProgram(program)
             openIapStore.enableBillingProgram(openIapProgram)
             RnIapLog.result("enableBillingProgramAndroid", true)
-        } catch (err: Throwable) {
+        } catch (err: Exception) {
             RnIapLog.failure("enableBillingProgramAndroid", err)
             // enableBillingProgram is void, so we just log the error
         }
@@ -1887,7 +1901,9 @@ class HybridRnIap : HybridRnIapSpec() {
                 )
                 RnIapLog.result("isBillingProgramAvailableAndroid", mapOf("isAvailable" to result.isAvailable))
                 nitroResult
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("isBillingProgramAvailableAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message), err)
@@ -1917,7 +1933,9 @@ class HybridRnIap : HybridRnIapSpec() {
                 )
                 RnIapLog.result("getBillingChoiceInfoAndroid", mapOf("hasImageUrl" to result.playBillingChoiceImageUrl.isNotBlank()))
                 nitroResult
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("getBillingChoiceInfoAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message), err)
@@ -1947,7 +1965,9 @@ class HybridRnIap : HybridRnIapSpec() {
                 )
                 RnIapLog.result("createBillingProgramReportingDetailsAndroid", mapOf("hasToken" to true))
                 nitroResult
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("createBillingProgramReportingDetailsAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message), err)
@@ -1980,7 +2000,9 @@ class HybridRnIap : HybridRnIapSpec() {
                     debugMessage = result.debugMessage.wrapVariant(),
                     subResponseCode = mapSubResponseCode(result.subResponseCode)
                 )
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("showBillingProgramInformationDialogAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message), err)
@@ -2015,7 +2037,9 @@ class HybridRnIap : HybridRnIapSpec() {
                     responseCode = mapInAppMessageResponseCode(result.responseCode),
                     purchaseToken = result.purchaseToken.wrapVariant()
                 )
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("showInAppMessagesAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message), err)
@@ -2051,7 +2075,9 @@ class HybridRnIap : HybridRnIapSpec() {
                 }
                 RnIapLog.result("launchExternalLinkAndroid", result)
                 result
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("launchExternalLinkAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message))
@@ -2071,7 +2097,9 @@ class HybridRnIap : HybridRnIapSpec() {
                 val result = handler()
                 RnIapLog.result("openRedeemOfferCodeAndroid", result)
                 result
-            } catch (err: Throwable) {
+            } catch (err: CancellationException) {
+                throw err
+            } catch (err: Exception) {
                 RnIapLog.failure("openRedeemOfferCodeAndroid", err)
                 val errorType = parseOpenIapError(err)
                 throw OpenIapException(toErrorJson(errorType, debugMessage = err.message), err)

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/CancellationPreservationTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/CancellationPreservationTest.kt
@@ -1,0 +1,42 @@
+package com.margelo.nitro.iap
+
+import kotlin.coroutines.cancellation.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.fail
+import org.junit.Test
+
+class CancellationPreservationTest {
+    @Test
+    fun `non-cancellation failures are translated`() {
+        val source = IllegalStateException("billing failed")
+
+        val result = catchNonCancellation(
+            block = { throw source },
+            onFailure = { "translated: ${it.message}" },
+        )
+
+        assertEquals("translated: billing failed", result)
+    }
+
+    @Test
+    fun `cancellation bypasses formerly broad failure handling`() {
+        val cancellation = CancellationException("cancelled")
+        var handled = false
+
+        try {
+            catchNonCancellation(
+                block = { throw cancellation },
+                onFailure = {
+                    handled = true
+                },
+            )
+            fail("Expected cancellation")
+        } catch (error: CancellationException) {
+            assertSame(cancellation, error)
+        }
+
+        assertFalse(handled)
+    }
+}


### PR DESCRIPTION
## Summary

- Rethrow `CancellationException` before Android store/error translation in fourteen async boundaries.
- Cover subscription queries, transaction finishing, storefront/verification, Billing Program methods, and offer-code redemption.
- Match the existing purchase/connection cancellation behavior and preserve structured concurrency during teardown.
- Restrict expected-failure translation to `Exception` so VM/linkage `Error` failures are not swallowed or rewritten.

## Breaking changes

None. Cancelled work and fatal runtime failures no longer emit fabricated store errors or normal result values.

## Verification

- Full Android debug unit suite passed.
- Android Kotlin compilation and `git diff --check` passed.

## Preview

Not applicable; this is non-visual coroutine/error lifecycle behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling during in-app purchase operations.
  * Cancellation requests now propagate correctly instead of being incorrectly treated as regular errors.
  * Regular failures continue to be handled and reported as expected.

* **Tests**
  * Added coverage to verify correct handling of both cancellation and non-cancellation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->