### PR TITLE
fix(react-native-iap): harden store connection lifecycle

### DIFF
--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-08-30T12:03:34.849Z
+> Last updated: 2026-08-30T14:55:50.344Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -2727,9 +2727,11 @@ raw imports outside `packages/docs`.
 
 Fenced `CodeBlock` examples under active documentation must not reintroduce
 known cross-language mistakes such as Kotlin syntax in C#, obsolete Flutter
-listener names, legacy purchase request shapes, top-level Godot SKUs, or
-obsolete Kotlin/KMP named arguments. Historical release notes are excluded
-because they describe APIs as shipped at that time.
+listener names, legacy purchase request shapes, top-level Godot SKUs, obsolete
+Kotlin/KMP named arguments, unchecked connection results, or asynchronous
+listener callbacks whose returned promise, future, or task is not observed.
+Historical release notes are excluded because they describe APIs as shipped at
+that time.
 
 Keep R11 focused. Every new pattern needs a failing fixture and a valid nearby
 shape so formatting, comments, or unrelated prose cannot trigger it.

--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-08-27T15:05:38.524Z
+> Last updated: 2026-08-30T12:03:34.849Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -2803,6 +2803,14 @@ maintaining a second list. While Horizon's `success` compatibility property
 exists, its table must also mark that property as a deprecated alias for
 `isValid`.
 
+### R15 — Subscription query failures stay observable
+
+React Native and Expo subscription-query helpers reject when the store query
+fails. The React Native hook calls `onError` before rethrowing; it must not map
+the failure to `false`. Godot's compatibility boolean helper is the only
+documented false fallback. Active docs must preserve this distinction so
+callers keep the required rejection handling.
+
 ## Pre-commit checklist
 
 Run before every `git push` on docs / SDK changes:
@@ -2842,6 +2850,7 @@ parses every `/docs/apis/*.tsx` and `/docs/types/*.tsx` page, extracts:
 - focused recurring phantom shapes from active fenced code examples
 - canonical offer semantics, generated enum snippets, and search entries
 - shared purchase-verification fields and the Horizon compatibility alias
+- subscription-query rejection semantics and the Godot compatibility fallback
 
 Field mentions are cross-referenced against generated TypeScript shapes.
 Canonical offer snippets are compared with the generated TypeScript, Swift,

--- a/knowledge/internal/07-docs-consistency.md
+++ b/knowledge/internal/07-docs-consistency.md
@@ -315,6 +315,14 @@ maintaining a second list. While Horizon's `success` compatibility property
 exists, its table must also mark that property as a deprecated alias for
 `isValid`.
 
+### R15 — Subscription query failures stay observable
+
+React Native and Expo subscription-query helpers reject when the store query
+fails. The React Native hook calls `onError` before rethrowing; it must not map
+the failure to `false`. Godot's compatibility boolean helper is the only
+documented false fallback. Active docs must preserve this distinction so
+callers keep the required rejection handling.
+
 ## Pre-commit checklist
 
 Run before every `git push` on docs / SDK changes:
@@ -354,6 +362,7 @@ parses every `/docs/apis/*.tsx` and `/docs/types/*.tsx` page, extracts:
 - focused recurring phantom shapes from active fenced code examples
 - canonical offer semantics, generated enum snippets, and search entries
 - shared purchase-verification fields and the Horizon compatibility alias
+- subscription-query rejection semantics and the Godot compatibility fallback
 
 Field mentions are cross-referenced against generated TypeScript shapes.
 Canonical offer snippets are compared with the generated TypeScript, Swift,

--- a/knowledge/internal/07-docs-consistency.md
+++ b/knowledge/internal/07-docs-consistency.md
@@ -239,9 +239,11 @@ raw imports outside `packages/docs`.
 
 Fenced `CodeBlock` examples under active documentation must not reintroduce
 known cross-language mistakes such as Kotlin syntax in C#, obsolete Flutter
-listener names, legacy purchase request shapes, top-level Godot SKUs, or
-obsolete Kotlin/KMP named arguments. Historical release notes are excluded
-because they describe APIs as shipped at that time.
+listener names, legacy purchase request shapes, top-level Godot SKUs, obsolete
+Kotlin/KMP named arguments, unchecked connection results, or asynchronous
+listener callbacks whose returned promise, future, or task is not observed.
+Historical release notes are excluded because they describe APIs as shipped at
+that time.
 
 Keep R11 focused. Every new pattern needs a failing fixture and a valid nearby
 shape so formatting, comments, or unrelated prose cannot trigger it.

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -776,50 +776,52 @@ class HybridRnIap : HybridRnIapSpec() {
                 mapOf("subscriptionIds" to (subscriptionIds?.toList() ?: "all"))
             )
 
-            catchNonCancellation(
-                block = {
-                    RnIapLog.payload("getActiveSubscriptions.native", mapOf("type" to "subs"))
-                    val activeSubscriptions = openIap.getActiveSubscriptions(subscriptionIds?.toList())
+            try {
+                RnIapLog.payload("getActiveSubscriptions.native", mapOf("type" to "subs"))
+                val activeSubscriptions = openIap.getActiveSubscriptions(subscriptionIds?.toList())
 
-                    val nitroSubscriptions = activeSubscriptions.map { sub ->
-                        NitroActiveSubscription(
-                            productId = sub.productId,
-                            isActive = sub.isActive,
-                            transactionId = sub.transactionId,
-                            purchaseToken = sub.purchaseToken.wrapVariant(),
-                            transactionDate = sub.transactionDate,
-                            // Android specific fields
-                            autoRenewingAndroid = sub.autoRenewingAndroid.wrapVariant(),
-                            basePlanIdAndroid = sub.basePlanIdAndroid.wrapVariant(),
-                            currentPlanId = sub.currentPlanId.wrapVariant(),
-                            purchaseTokenAndroid = sub.purchaseTokenAndroid.wrapVariant(),
-                            // iOS specific fields (null on Android)
-                            expirationDateIOS = null,
-                            environmentIOS = null,
-                            daysUntilExpirationIOS = null,
-                            renewalInfoIOS = null
-                        )
-                    }
-
-                    RnIapLog.result(
-                        "getActiveSubscriptions",
-                        nitroSubscriptions.map { mapOf("productId" to it.productId, "isActive" to it.isActive) }
+                val nitroSubscriptions = activeSubscriptions.map { sub ->
+                    NitroActiveSubscription(
+                        productId = sub.productId,
+                        isActive = sub.isActive,
+                        transactionId = sub.transactionId,
+                        purchaseToken = sub.purchaseToken.wrapVariant(),
+                        transactionDate = sub.transactionDate,
+                        // Android specific fields
+                        autoRenewingAndroid = sub.autoRenewingAndroid.wrapVariant(),
+                        basePlanIdAndroid = sub.basePlanIdAndroid.wrapVariant(),
+                        currentPlanId = sub.currentPlanId.wrapVariant(),
+                        purchaseTokenAndroid = sub.purchaseTokenAndroid.wrapVariant(),
+                        // iOS specific fields (null on Android)
+                        expirationDateIOS = null,
+                        environmentIOS = null,
+                        daysUntilExpirationIOS = null,
+                        renewalInfoIOS = null
                     )
+                }
 
-                    nitroSubscriptions.toTypedArray()
-                },
-                onFailure = { e ->
-                    RnIapLog.failure("getActiveSubscriptions", e)
-                    val error = OpenIapError.ServiceUnavailable()
-                    throw OpenIapException(
-                        toErrorJson(
-                            error = error,
-                            debugMessage = e.message,
-                            messageOverride = "Failed to get active subscriptions: ${e.message}"
-                        )
+                RnIapLog.result(
+                    "getActiveSubscriptions",
+                    nitroSubscriptions.map { mapOf("productId" to it.productId, "isActive" to it.isActive) }
+                )
+
+                nitroSubscriptions.toTypedArray()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: OpenIapError) {
+                RnIapLog.failure("getActiveSubscriptions", e)
+                throw OpenIapException(toErrorJson(e))
+            } catch (e: Exception) {
+                RnIapLog.failure("getActiveSubscriptions", e)
+                val error = OpenIapError.ServiceUnavailable()
+                throw OpenIapException(
+                    toErrorJson(
+                        error = error,
+                        debugMessage = e.message,
+                        messageOverride = "Failed to get active subscriptions: ${e.message}"
                     )
-                },
-            )
+                )
+            }
         }
     }
 
@@ -837,6 +839,9 @@ class HybridRnIap : HybridRnIapSpec() {
                 hasActive
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: OpenIapError) {
+                RnIapLog.failure("hasActiveSubscriptions", e)
+                throw OpenIapException(toErrorJson(e))
             } catch (e: Exception) {
                 RnIapLog.failure("hasActiveSubscriptions", e)
                 val error = OpenIapError.ServiceUnavailable()
@@ -910,6 +915,22 @@ class HybridRnIap : HybridRnIapSpec() {
                 result
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: OpenIapError) {
+                RnIapLog.failure("finishTransaction", e)
+                Variant_Boolean_NitroPurchaseResult.Second(
+                    NitroPurchaseResult(
+                        responseCode = -1.0,
+                        debugMessage = e.message,
+                        code = OpenIapError.toCode(e),
+                        message = e.message,
+                        purchaseToken = purchaseToken,
+                        productId = null,
+                        productIds = null,
+                        productType = null,
+                        isEmptyProductList = null,
+                        subResponseCodeAndroid = null
+                    )
+                )
             } catch (e: Exception) {
                 val err = OpenIapError.BillingError()
                 RnIapLog.failure("finishTransaction", e)

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -82,6 +82,11 @@ internal fun parseOpenIapError(err: Throwable): OpenIapError {
     var cause: Throwable? = err
     while (cause != null) {
         if (cause is OpenIapError) return cause
+        cause = cause.cause
+    }
+
+    cause = err
+    while (cause != null) {
         val message = cause.message ?: ""
         when {
             message.contains("not prepared", ignoreCase = true) ||
@@ -96,6 +101,13 @@ internal fun parseOpenIapError(err: Throwable): OpenIapError {
     }
     return OpenIapError.ServiceUnavailable()
 }
+
+internal fun normalizeAvailablePurchasesType(type: NitroAvailablePurchasesAndroidType?): String? =
+    when (type) {
+        NitroAvailablePurchasesAndroidType.IN_APP -> "in-app"
+        NitroAvailablePurchasesAndroidType.SUBS -> "subs"
+        null -> null
+    }
 
 internal fun rejectDisconnectedPurchase(
     isInitialized: Boolean,
@@ -779,11 +791,7 @@ class HybridRnIap : HybridRnIapSpec() {
                     mapOf("type" to androidOptions?.type?.name, "includeSuspended" to includeSuspended)
                 )
 
-                val typeName = androidOptions?.type?.name?.lowercase(java.util.Locale.ROOT)
-                val normalizedType = when (typeName) {
-                    "in-app", "subs" -> typeName
-                    else -> null
-                }
+                val normalizedType = normalizeAvailablePurchasesType(androidOptions?.type)
 
                 // Create PurchaseOptions with includeSuspendedAndroid
                 val purchaseOptions = dev.hyo.openiap.PurchaseOptions(

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -109,10 +109,10 @@ internal fun rejectDisconnectedPurchase(
 internal suspend fun endRnConnectionWithCleanup(
     endConnection: suspend () -> Boolean,
     cleanup: () -> Unit,
-): Boolean = try {
-    endConnection()
-} finally {
+): Boolean {
+    val result = endConnection()
     cleanup()
+    return result
 }
 
 /**

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -250,7 +250,6 @@ class HybridRnIap : HybridRnIapSpec() {
         val configValue = (config as? Variant_NullType_InitConnectionConfig.Second)?.value
         val performInit: suspend () -> Boolean = initOperation@{
             RnIapLog.payload("initConnection", configValue)
-            if (isInitialized) return@initOperation true
 
             // CRITICAL: Set Activity BEFORE calling initConnection
             // Horizon SDK needs Activity to initialize OVRPlatform with proper returnComponent

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -78,6 +78,25 @@ class OpenIapException(private val errorJson: String, cause: Throwable? = null) 
     }
 }
 
+internal fun parseOpenIapError(err: Throwable): OpenIapError {
+    var cause: Throwable? = err
+    while (cause != null) {
+        if (cause is OpenIapError) return cause
+        val message = cause.message ?: ""
+        when {
+            message.contains("not prepared", ignoreCase = true) ||
+                message.contains("not initialized", ignoreCase = true) -> return OpenIapError.NotPrepared
+            message.contains("developer error", ignoreCase = true) ||
+                message.contains("activity not available", ignoreCase = true) -> return OpenIapError.DeveloperError()
+            message.contains("network", ignoreCase = true) -> return OpenIapError.NetworkError
+            message.contains("service unavailable", ignoreCase = true) ||
+                message.contains("billing unavailable", ignoreCase = true) -> return OpenIapError.ServiceUnavailable()
+        }
+        cause = cause.cause
+    }
+    return OpenIapError.ServiceUnavailable()
+}
+
 internal suspend fun endRnConnectionWithCleanup(
     endConnection: suspend () -> Boolean,
     cleanup: () -> Unit,
@@ -579,12 +598,14 @@ class HybridRnIap : HybridRnIapSpec() {
                     val missingSkus = androidRequest.skus.filterNot { productTypeBySku.containsKey(it) }
                     missingSkus.forEach { sku ->
                         RnIapLog.warn("requestPurchase missing type hint for $sku; attempting fetch")
-                        val fetched = runCatching {
+                        val fetched = try {
                             openIap.fetchProducts(
                                 ProductRequest(listOf(sku), ProductQueryType.All)
                             ).productsOrEmpty()
-                        }.getOrElse { error ->
-                            RnIapLog.failure("requestPurchase.fetchMissing", error)
+                        } catch (e: OpenIapError) {
+                            throw e
+                        } catch (e: Exception) {
+                            RnIapLog.failure("requestPurchase.fetchMissing", e)
                             emptyList()
                         }
                         fetched.firstOrNull()?.let { productTypeBySku[it.id] = it.type.rawValue }
@@ -706,8 +727,6 @@ class HybridRnIap : HybridRnIapSpec() {
             } catch (e: CancellationException) {
                 throw e
             } catch (e: OpenIapError) {
-                // Report the store's own reason — a purchase attempted with no
-                // connection is not a purchase failure.
                 RnIapLog.failure("requestPurchase", e)
                 if (!reachedOpenIapRequest) {
                     sendPurchaseError(toErrorResult(error = e, debugMessage = e.message))
@@ -732,47 +751,52 @@ class HybridRnIap : HybridRnIapSpec() {
     // Purchase history methods (Unified)
     override fun getAvailablePurchases(options: NitroAvailablePurchasesOptions?): Promise<Array<NitroPurchase>> {
         return Promise.async {
-            val androidOptions = (options?.android as? Variant_NullType_NitroAvailablePurchasesAndroidOptions.Second)?.value
+            try {
+                val androidOptions = (options?.android as? Variant_NullType_NitroAvailablePurchasesAndroidOptions.Second)?.value
 
-            val includeSuspended = androidOptions?.includeSuspended.unwrapBool() ?: false
+                val includeSuspended = androidOptions?.includeSuspended.unwrapBool() ?: false
 
-            RnIapLog.payload(
-                "getAvailablePurchases",
-                mapOf("type" to androidOptions?.type?.name, "includeSuspended" to includeSuspended)
-            )
-
-            val typeName = androidOptions?.type?.name?.lowercase(java.util.Locale.ROOT)
-            val normalizedType = when (typeName) {
-                "in-app", "subs" -> typeName
-                else -> null
-            }
-
-            // Create PurchaseOptions with includeSuspendedAndroid
-            val purchaseOptions = dev.hyo.openiap.PurchaseOptions(
-                includeSuspendedAndroid = includeSuspended
-            )
-
-            val result: List<OpenIapPurchase> = if (normalizedType != null) {
-                val typeEnum = parseProductQueryType(normalizedType)
                 RnIapLog.payload(
-                    "getAvailablePurchases.native",
-                    mapOf("type" to typeEnum.rawValue, "includeSuspended" to includeSuspended)
+                    "getAvailablePurchases",
+                    mapOf("type" to androidOptions?.type?.name, "includeSuspended" to includeSuspended)
                 )
-                // Note: getAvailableItems doesn't accept PurchaseOptions
-                // includeSuspended only applies when fetching all types
-                openIap.getAvailableItems(typeEnum)
-            } else {
-                RnIapLog.payload("getAvailablePurchases.native", mapOf("type" to "all", "includeSuspended" to includeSuspended))
-                openIap.getAvailablePurchases(purchaseOptions)
+
+                val typeName = androidOptions?.type?.name?.lowercase(java.util.Locale.ROOT)
+                val normalizedType = when (typeName) {
+                    "in-app", "subs" -> typeName
+                    else -> null
+                }
+
+                // Create PurchaseOptions with includeSuspendedAndroid
+                val purchaseOptions = dev.hyo.openiap.PurchaseOptions(
+                    includeSuspendedAndroid = includeSuspended
+                )
+
+                val result: List<OpenIapPurchase> = if (normalizedType != null) {
+                    val typeEnum = parseProductQueryType(normalizedType)
+                    RnIapLog.payload(
+                        "getAvailablePurchases.native",
+                        mapOf("type" to typeEnum.rawValue, "includeSuspended" to includeSuspended)
+                    )
+                    // Note: getAvailableItems doesn't accept PurchaseOptions
+                    // includeSuspended only applies when fetching all types
+                    openIap.getAvailableItems(typeEnum)
+                } else {
+                    RnIapLog.payload("getAvailablePurchases.native", mapOf("type" to "all", "includeSuspended" to includeSuspended))
+                    openIap.getAvailablePurchases(purchaseOptions)
+                }
+                RnIapLog.result(
+                    "getAvailablePurchases",
+                    mapOf(
+                        "purchaseCount" to result.size,
+                        "productIds" to result.map { it.productId }
+                    )
+                )
+                result.map { convertToNitroPurchase(it) }.toTypedArray()
+            } catch (e: OpenIapError) {
+                RnIapLog.failure("getAvailablePurchases", e)
+                throw OpenIapException(toErrorJson(e), e)
             }
-            RnIapLog.result(
-                "getAvailablePurchases",
-                mapOf(
-                    "purchaseCount" to result.size,
-                    "productIds" to result.map { it.productId }
-                )
-            )
-            result.map { convertToNitroPurchase(it) }.toTypedArray()
         }
     }
 
@@ -2255,30 +2279,6 @@ class HybridRnIap : HybridRnIapSpec() {
         return Promise.async {
             throw OpenIapException(toErrorJson(OpenIapError.FeatureNotSupported()))
         }
-    }
-
-    // ---------------------------------------------------------------------
-    // OpenIAP error helpers: unify error codes/messages from library
-    // ---------------------------------------------------------------------
-    private fun parseOpenIapError(err: Throwable): OpenIapError {
-        // Try to extract OpenIapError from the exception chain
-        var cause: Throwable? = err
-        while (cause != null) {
-            val message = cause.message ?: ""
-            // Check if message contains OpenIAP error patterns
-            when {
-                message.contains("not prepared", ignoreCase = true) ||
-                message.contains("not initialized", ignoreCase = true) -> return OpenIapError.NotPrepared
-                message.contains("developer error", ignoreCase = true) ||
-                message.contains("activity not available", ignoreCase = true) -> return OpenIapError.DeveloperError()
-                message.contains("network", ignoreCase = true) -> return OpenIapError.NetworkError
-                message.contains("service unavailable", ignoreCase = true) ||
-                message.contains("billing unavailable", ignoreCase = true) -> return OpenIapError.ServiceUnavailable()
-            }
-            cause = cause.cause
-        }
-        // Default to ServiceUnavailable if we can't determine the error type
-        return OpenIapError.ServiceUnavailable()
     }
 
     private fun toErrorJson(

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -705,6 +705,14 @@ class HybridRnIap : HybridRnIapSpec() {
                 defaultResult
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: OpenIapError) {
+                // Report the store's own reason — a purchase attempted with no
+                // connection is not a purchase failure.
+                RnIapLog.failure("requestPurchase", e)
+                if (!reachedOpenIapRequest) {
+                    sendPurchaseError(toErrorResult(error = e, debugMessage = e.message))
+                }
+                defaultResult
             } catch (e: Exception) {
                 RnIapLog.failure("requestPurchase", e)
                 if (!reachedOpenIapRequest) {

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -615,16 +615,18 @@ class HybridRnIap : HybridRnIapSpec() {
                     val missingSkus = androidRequest.skus.filterNot { productTypeBySku.containsKey(it) }
                     missingSkus.forEach { sku ->
                         RnIapLog.warn("requestPurchase missing type hint for $sku; attempting fetch")
-                        val fetched = try {
-                            openIap.fetchProducts(
-                                ProductRequest(listOf(sku), ProductQueryType.All)
-                            ).productsOrEmpty()
-                        } catch (e: OpenIapError) {
-                            throw e
-                        } catch (e: Exception) {
-                            RnIapLog.failure("requestPurchase.fetchMissing", e)
-                            emptyList()
-                        }
+                        val fetched = catchNonCancellation(
+                            block = {
+                                openIap.fetchProducts(
+                                    ProductRequest(listOf(sku), ProductQueryType.All)
+                                ).productsOrEmpty()
+                            },
+                            onFailure = { error ->
+                                if (error is OpenIapError) throw error
+                                RnIapLog.failure("requestPurchase.fetchMissing", error)
+                                emptyList()
+                            },
+                        )
                         fetched.firstOrNull()?.let { productTypeBySku[it.id] = it.type.rawValue }
                         if (!productTypeBySku.containsKey(sku)) {
                             sendPurchaseError(toErrorResult(OpenIapError.SkuNotFound(sku)))

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -217,10 +217,6 @@ class HybridRnIap : HybridRnIapSpec() {
     private fun Variant_NullType_Double?.unwrapDouble(): Double? = (this as? Variant_NullType_Double.Second)?.value
     private fun Variant_NullType_Boolean?.unwrapBool(): Boolean? = (this as? Variant_NullType_Boolean.Second)?.value
 
-    private suspend fun ensureConnection() {
-        initConnection(null as Variant_NullType_InitConnectionConfig?).await()
-    }
-
     override fun initConnection(config: Variant_NullType_InitConnectionConfig?): Promise<Boolean> {
         val configValue = (config as? Variant_NullType_InitConnectionConfig.Second)?.value
         val performInit: suspend () -> Boolean = initOperation@{
@@ -481,7 +477,6 @@ class HybridRnIap : HybridRnIapSpec() {
                 throw OpenIapException(toErrorJson(OpenIapError.EmptySkuList))
             }
 
-            ensureConnection()
 
             val queryType = parseProductQueryType(type)
             val skusList = skus.toList()
@@ -558,7 +553,6 @@ class HybridRnIap : HybridRnIapSpec() {
 
             var reachedOpenIapRequest = false
             try {
-                ensureConnection()
 
                 // Ensure Activity is available for purchase flow
                 val activity = withContext(Dispatchers.Main) {
@@ -731,7 +725,6 @@ class HybridRnIap : HybridRnIapSpec() {
     override fun getAvailablePurchases(options: NitroAvailablePurchasesOptions?): Promise<Array<NitroPurchase>> {
         return Promise.async {
             val androidOptions = (options?.android as? Variant_NullType_NitroAvailablePurchasesAndroidOptions.Second)?.value
-            ensureConnection()
 
             val includeSuspended = androidOptions?.includeSuspended.unwrapBool() ?: false
 
@@ -777,7 +770,6 @@ class HybridRnIap : HybridRnIapSpec() {
 
     override fun getActiveSubscriptions(subscriptionIds: Array<String>?): Promise<Array<NitroActiveSubscription>> {
         return Promise.async {
-            ensureConnection()
 
             RnIapLog.payload(
                 "getActiveSubscriptions",
@@ -833,7 +825,6 @@ class HybridRnIap : HybridRnIapSpec() {
 
     override fun hasActiveSubscriptions(subscriptionIds: Array<String>?): Promise<Boolean> {
         return Promise.async {
-            ensureConnection()
 
             RnIapLog.payload(
                 "hasActiveSubscriptions",
@@ -895,29 +886,6 @@ class HybridRnIap : HybridRnIapSpec() {
                 )
             }
 
-            // Ensure connection; if it fails, return an error result instead of throwing
-            try {
-                ensureConnection()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                val err = OpenIapError.InitConnection
-                return@async Variant_Boolean_NitroPurchaseResult.Second(
-                    NitroPurchaseResult(
-                        responseCode = -1.0,
-                        debugMessage = e.message,
-                        code = OpenIapError.toCode(err),
-                        message = e.message?.takeIf { it.isNotBlank() } ?: err.message,
-                        purchaseToken = purchaseToken,
-                        productId = null,
-                        productIds = null,
-                        productType = null,
-                        isEmptyProductList = null,
-                        subResponseCodeAndroid = null
-                    )
-                )
-            }
-
             try {
                 if (isConsumable) {
                     openIap.consumePurchaseAndroid(purchaseToken)
@@ -966,7 +934,6 @@ class HybridRnIap : HybridRnIapSpec() {
     override fun getStorefront(): Promise<String> {
         return Promise.async {
             try {
-                ensureConnection()
                 RnIapLog.payload("getStorefront", null)
                 val value = openIap.getStorefront()
                 if (value.isBlank()) {
@@ -1424,7 +1391,6 @@ class HybridRnIap : HybridRnIapSpec() {
     override fun deepLinkToSubscriptionsAndroid(options: NitroDeepLinkOptionsAndroid): Promise<Unit> {
         return Promise.async {
             try {
-                ensureConnection()
                 OpenIapDeepLinkOptions(
                     skuAndroid = options.skuAndroid.unwrapString(),
                     packageNameAndroid = options.packageNameAndroid.unwrapString()
@@ -1903,7 +1869,6 @@ class HybridRnIap : HybridRnIapSpec() {
         return Promise.async {
             RnIapLog.payload("isBillingProgramAvailableAndroid", mapOf("program" to program.name))
             try {
-                ensureConnection()
                 val openIapProgram = mapBillingProgram(program)
                 val result = openIapStore.isBillingProgramAvailable(openIapProgram)
                 val nitroResult = NitroBillingProgramAvailabilityResultAndroid(
@@ -1932,7 +1897,6 @@ class HybridRnIap : HybridRnIapSpec() {
                 "userLocale" to params.userLocale.unwrapString()
             ))
             try {
-                ensureConnection()
                 val result = openIapStore.getBillingChoiceInfo(
                     OpenIapGetBillingChoiceInfoParams(
                         billingProgram = mapBillingProgram(params.billingProgram),
@@ -1966,7 +1930,6 @@ class HybridRnIap : HybridRnIapSpec() {
                 mapOf("program" to program.name, "developerBillingType" to developerBillingType?.name)
             )
             try {
-                ensureConnection()
                 val openIapProgram = mapBillingProgram(program)
                 val result = openIapStore.createBillingProgramReportingDetails(
                     openIapProgram,
@@ -1994,7 +1957,6 @@ class HybridRnIap : HybridRnIapSpec() {
         return Promise.async {
             RnIapLog.payload("showBillingProgramInformationDialogAndroid", mapOf("program" to params.billingProgram.name))
             try {
-                ensureConnection()
                 val activity = withContext(Dispatchers.Main) {
                     runCatching { context.currentActivity }.getOrNull()
                 } ?: throw OpenIapException(toErrorJson(OpenIapError.DeveloperError(), debugMessage = "Activity not available"))
@@ -2031,7 +1993,6 @@ class HybridRnIap : HybridRnIapSpec() {
             val categories = messageParams?.categories?.asSecondOrNull()
             RnIapLog.payload("showInAppMessagesAndroid", mapOf("categories" to categories?.map { it.name }))
             try {
-                ensureConnection()
                 val activity = withContext(Dispatchers.Main) {
                     runCatching { context.currentActivity }.getOrNull()
                 } ?: throw OpenIapException(toErrorJson(OpenIapError.DeveloperError(), debugMessage = "Activity not available"))
@@ -2069,7 +2030,6 @@ class HybridRnIap : HybridRnIapSpec() {
                 "linkUri" to params.linkUri
             ))
             try {
-                ensureConnection()
 
                 val activity = withContext(Dispatchers.Main) {
                     runCatching { context.currentActivity }.getOrNull()

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -97,6 +97,15 @@ internal fun parseOpenIapError(err: Throwable): OpenIapError {
     return OpenIapError.ServiceUnavailable()
 }
 
+internal fun rejectDisconnectedPurchase(
+    isInitialized: Boolean,
+    sendError: (OpenIapError) -> Unit,
+): Boolean {
+    if (isInitialized) return false
+    sendError(OpenIapError.NotPrepared)
+    return true
+}
+
 internal suspend fun endRnConnectionWithCleanup(
     endConnection: suspend () -> Boolean,
     cleanup: () -> Unit,
@@ -213,6 +222,7 @@ class HybridRnIap : HybridRnIapSpec() {
     private val developerProvidedBillingListenersAndroid = mutableListOf<(DeveloperProvidedBillingDetailsAndroid) -> Unit>()
     private val subscriptionBillingIssueListeners = mutableListOf<(NitroPurchase) -> Unit>()
     private var listenersAttached = false
+    @Volatile
     private var isInitialized = false
     private val connectionLifecycleQueue = ConnectionLifecycleQueue()
     
@@ -567,6 +577,13 @@ class HybridRnIap : HybridRnIapSpec() {
             if (androidRequest.skus.isEmpty()) {
                 RnIapLog.warn("requestPurchase received empty SKU list")
                 sendPurchaseError(toErrorResult(OpenIapError.EmptySkuList))
+                return@async defaultResult
+            }
+
+            if (rejectDisconnectedPurchase(isInitialized) { error ->
+                RnIapLog.warn("requestPurchase called before initConnection")
+                sendPurchaseError(toErrorResult(error))
+            }) {
                 return@async defaultResult
             }
 

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/AvailablePurchasesTypeTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/AvailablePurchasesTypeTest.kt
@@ -1,0 +1,20 @@
+package com.margelo.nitro.iap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AvailablePurchasesTypeTest {
+    @Test
+    fun `maps generated purchase types to native query values`() {
+        assertEquals(
+            "in-app",
+            normalizeAvailablePurchasesType(NitroAvailablePurchasesAndroidType.IN_APP),
+        )
+        assertEquals(
+            "subs",
+            normalizeAvailablePurchasesType(NitroAvailablePurchasesAndroidType.SUBS),
+        )
+        assertNull(normalizeAvailablePurchasesType(null))
+    }
+}

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/CancellationPreservationTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/CancellationPreservationTest.kt
@@ -39,4 +39,25 @@ class CancellationPreservationTest {
 
         assertFalse(handled)
     }
+
+    @Test
+    fun `product lookup fallback cannot replace cancellation with an empty result`() {
+        val cancellation = CancellationException("cancelled")
+        var usedFallback = false
+
+        try {
+            catchNonCancellation<List<String>>(
+                block = { throw cancellation },
+                onFailure = {
+                    usedFallback = true
+                    emptyList()
+                },
+            )
+            fail("Expected cancellation")
+        } catch (error: CancellationException) {
+            assertSame(cancellation, error)
+        }
+
+        assertFalse(usedFallback)
+    }
 }

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/ConnectionLifecycleQueueTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/ConnectionLifecycleQueueTest.kt
@@ -25,6 +25,22 @@ class ConnectionLifecycleQueueTest {
     }
 
     @Test(timeout = 5_000)
+    fun `end failure preserves connection state`() = runBlocking {
+        val failure = IllegalStateException("teardown failed")
+        val cleanedUp = AtomicBoolean(false)
+
+        val result = runCatching {
+            endRnConnectionWithCleanup(
+                endConnection = { throw failure },
+                cleanup = { cleanedUp.set(true) },
+            )
+        }
+
+        assertEquals(failure, result.exceptionOrNull())
+        assertFalse(cleanedUp.get())
+    }
+
+    @Test(timeout = 5_000)
     fun `later end invalidates a pending init even when end awaits first`() =
         runBlocking {
             val queue = ConnectionLifecycleQueue()

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/ConnectionLifecycleQueueTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/ConnectionLifecycleQueueTest.kt
@@ -123,6 +123,34 @@ class ConnectionLifecycleQueueTest {
         }
 
     @Test(timeout = 5_000)
+    fun `a later reconnect runs a fresh init operation`() =
+        runBlocking {
+            val queue = ConnectionLifecycleQueue()
+            val calls = AtomicInteger()
+            val operation: suspend () -> Boolean = {
+                calls.incrementAndGet()
+                true
+            }
+
+            val first =
+                queue.enqueueInit(
+                    operation = operation,
+                    onCommitted = {},
+                    onFailed = {},
+                )
+            assertTrue(first.await())
+
+            val reconnect =
+                queue.enqueueInit(
+                    operation = operation,
+                    onCommitted = {},
+                    onFailed = {},
+                )
+            assertTrue(reconnect.await())
+            assertEquals(2, calls.get())
+        }
+
+    @Test(timeout = 5_000)
     fun `end during native init prevents commit and runs after native returns`() =
         runBlocking {
             val queue = ConnectionLifecycleQueue()

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/OpenIapErrorMappingTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/OpenIapErrorMappingTest.kt
@@ -1,7 +1,10 @@
 package com.margelo.nitro.iap
 
 import dev.hyo.openiap.OpenIapError
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class OpenIapErrorMappingTest {
@@ -15,5 +18,17 @@ class OpenIapErrorMappingTest {
         val wrapped = IllegalStateException("Billing client not ready", OpenIapError.NotPrepared)
 
         assertSame(OpenIapError.NotPrepared, parseOpenIapError(wrapped))
+    }
+
+    @Test
+    fun `reports not prepared before purchase delegation`() {
+        var emitted: OpenIapError? = null
+
+        assertTrue(rejectDisconnectedPurchase(isInitialized = false) { emitted = it })
+        assertSame(OpenIapError.NotPrepared, emitted)
+
+        emitted = null
+        assertFalse(rejectDisconnectedPurchase(isInitialized = true) { emitted = it })
+        assertNull(emitted)
     }
 }

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/OpenIapErrorMappingTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/OpenIapErrorMappingTest.kt
@@ -15,7 +15,7 @@ class OpenIapErrorMappingTest {
 
     @Test
     fun `preserves an OpenIapError in the cause chain`() {
-        val wrapped = IllegalStateException("Billing client not ready", OpenIapError.NotPrepared)
+        val wrapped = IllegalStateException("Service unavailable", OpenIapError.NotPrepared)
 
         assertSame(OpenIapError.NotPrepared, parseOpenIapError(wrapped))
     }

--- a/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/OpenIapErrorMappingTest.kt
+++ b/libraries/react-native-iap/android/src/test/java/com/margelo/nitro/iap/OpenIapErrorMappingTest.kt
@@ -1,0 +1,19 @@
+package com.margelo.nitro.iap
+
+import dev.hyo.openiap.OpenIapError
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class OpenIapErrorMappingTest {
+    @Test
+    fun `preserves a direct OpenIapError`() {
+        assertSame(OpenIapError.NotPrepared, parseOpenIapError(OpenIapError.NotPrepared))
+    }
+
+    @Test
+    fun `preserves an OpenIapError in the cause chain`() {
+        val wrapped = IllegalStateException("Billing client not ready", OpenIapError.NotPrepared)
+
+        assertSame(OpenIapError.NotPrepared, parseOpenIapError(wrapped))
+    }
+}

--- a/libraries/react-native-iap/example/ios/example.xcodeproj/project.pbxproj
+++ b/libraries/react-native-iap/example/ios/example.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0C80B921A6F3F58F76C31292 /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-example.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2C45A4A7038ED639A0DA8047 /* SubscriptionBillingIssueReconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F63961E1E4779D0D0CC89E /* SubscriptionBillingIssueReconnectTests.swift */; };
+		9A1C0DE1000000000000C0DE /* ConnectOnDemandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1C0DE0000000000000C0DE /* ConnectOnDemandTests.swift */; };
 		39B415FD9B823A99DF82885B /* libPods-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A1B53C93D4444C448EAF564 /* libPods-exampleTests.a */; };
 		6CA9F570183E5756970ADA69 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
@@ -34,6 +35,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = example/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = example/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		15F63961E1E4779D0D0CC89E /* SubscriptionBillingIssueReconnectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = exampleTests/SubscriptionBillingIssueReconnectTests.swift; sourceTree = "<group>"; };
+		9A1C0DE0000000000000C0DE /* ConnectOnDemandTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = exampleTests/ConnectOnDemandTests.swift; sourceTree = "<group>"; };
 		192B71D5D16C43463188CE4C /* exampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = exampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A1B53C93D4444C448EAF564 /* libPods-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				15F63961E1E4779D0D0CC89E /* SubscriptionBillingIssueReconnectTests.swift */,
+				9A1C0DE0000000000000C0DE /* ConnectOnDemandTests.swift */,
 			);
 			name = exampleTests;
 			sourceTree = SOURCE_ROOT;
@@ -358,6 +361,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C45A4A7038ED639A0DA8047 /* SubscriptionBillingIssueReconnectTests.swift in Sources */,
+				9A1C0DE1000000000000C0DE /* ConnectOnDemandTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -2,16 +2,7 @@ import XCTest
 import OpenIAP
 @testable import NitroIap
 
-/// A store call made without `initConnection()` must still arrive with the
-/// bridge's listeners attached.
-///
-/// StoreKit has no connection to open, so the bridge connects on demand rather
-/// than refusing. That is only safe if the on-demand path is the same one
-/// `initConnection()` uses — otherwise a purchase would run with no subscription
-/// observing it, and the app would never call `finishTransaction`.
-///
-/// Reflection note: matches SubscriptionBillingIssueReconnectTests — the state is
-/// `private` in HybridRnIap, and `Mirror` reads it without widening the API.
+/// Verifies on-demand StoreKit operations use the bridge lifecycle and listeners.
 @available(iOS 15.0, macOS 14.0, tvOS 15.0, watchOS 8.0, *)
 final class ConnectOnDemandTests: XCTestCase {
 
@@ -57,6 +48,25 @@ final class ConnectOnDemandTests: XCTestCase {
         )
 
         _ = try await hybrid.endConnection().await()
+    }
+
+    func testEndFailureDoesNotRunConnectionCleanup() async {
+        enum TeardownFailure: Error {
+            case failed
+        }
+        var cleanedUp = false
+
+        do {
+            _ = try await endConnectionThenCleanup(
+                endConnection: { throw TeardownFailure.failed },
+                cleanup: { cleanedUp = true }
+            )
+            XCTFail("expected teardown failure")
+        } catch TeardownFailure.failed {
+            XCTAssertFalse(cleanedUp)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
     }
 
     func testQueuedTeardownPreventsLateStoreDelegation() async throws {

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -50,25 +50,6 @@ final class ConnectOnDemandTests: XCTestCase {
         _ = try await hybrid.endConnection().await()
     }
 
-    func testEndFailureDoesNotRunConnectionCleanup() async {
-        enum TeardownFailure: Error {
-            case failed
-        }
-        var cleanedUp = false
-
-        do {
-            _ = try await endConnectionThenCleanup(
-                endConnection: { throw TeardownFailure.failed },
-                cleanup: { cleanedUp = true }
-            )
-            XCTFail("expected teardown failure")
-        } catch TeardownFailure.failed {
-            XCTAssertFalse(cleanedUp)
-        } catch {
-            XCTFail("unexpected error: \(error)")
-        }
-    }
-
     func testQueuedTeardownPreventsLateStoreDelegation() async throws {
         let hybrid = HybridRnIap()
         let connected = try await hybrid.initConnection(config: nil).await()
@@ -120,6 +101,156 @@ final class ConnectOnDemandTests: XCTestCase {
         XCTAssertEqual(probe.events, ["delivery", "end"])
     }
 
+    func testFailedTeardownPreservesListenerDeliveryAcrossReconnect() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in probe.record(purchase.id) },
+            options: nil
+        )
+        let connected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(connected)
+        let subscriptionBeforeFailure = try XCTUnwrap(inspectPurchaseUpdatedSub(hybrid))
+        let teardownFailure = NSError(domain: "ConnectOnDemandTests", code: 1)
+
+        let failedEnd = hybrid.enqueueEndOperation { throw teardownFailure }
+        do {
+            _ = try await failedEnd.value
+            XCTFail("the injected teardown failure must be preserved")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, teardownFailure.domain)
+            XCTAssertEqual((error as NSError).code, teardownFailure.code)
+        }
+
+        XCTAssertTrue(inspectInitialized(hybrid))
+        XCTAssertEqual(inspectPurchaseUpdatedListeners(hybrid).count, 1)
+        let reconnected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(reconnected)
+        let subscriptionAfterReconnect = try XCTUnwrap(inspectPurchaseUpdatedSub(hybrid))
+        XCTAssertEqual(
+            ObjectIdentifier(subscriptionAfterReconnect as AnyObject),
+            ObjectIdentifier(subscriptionBeforeFailure as AnyObject)
+        )
+
+        let purchase = RnIapHelper.convertPurchaseDictionary([
+            "id": "preserved-transaction",
+            "transactionId": "preserved-transaction",
+            "productId": "premium",
+            "transactionDate": 1,
+            "store": "apple",
+            "quantity": 1,
+            "purchaseState": "purchased",
+            "isAutoRenewing": false
+        ])
+        inspectPurchaseUpdatedListeners(hybrid).first?(purchase)
+        XCTAssertEqual(probe.events, ["preserved-transaction"])
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    func testReturnedPurchaseReachesNonDedupingListenerBeforeTeardown() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in probe.record(purchase.id) },
+            options: PurchaseUpdatedListenerOptions(
+                dedupeTransactionIOS: .second(false)
+            )
+        )
+        let connected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(connected)
+        let purchase = try makePurchase(id: "returned-transaction")
+
+        _ = try await hybrid.runRequestPurchaseOperation {
+            .purchase(purchase)
+        }
+        XCTAssertEqual(probe.events, ["returned-transaction"])
+
+        let epoch = hybrid.currentConnectionEpoch()
+        let originalCallback = hybrid.enqueuePurchaseUpdateDelivery(
+            purchase,
+            expectedEpoch: epoch,
+            includeDuplicateListeners: true
+        )
+        _ = try await originalCallback.value
+        XCTAssertEqual(
+            probe.events,
+            ["returned-transaction"],
+            "the asynchronous callback for the returned purchase must be suppressed once"
+        )
+        let replay = hybrid.enqueuePurchaseUpdateDelivery(
+            purchase,
+            expectedEpoch: epoch,
+            includeDuplicateListeners: true
+        )
+        _ = try await replay.value
+        XCTAssertEqual(
+            probe.events,
+            ["returned-transaction", "returned-transaction"],
+            "later StoreKit replays must still reach non-deduping listeners"
+        )
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    func testNativeCallbackQueuedDuringRequestDoesNotDuplicateFallback() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in probe.record(purchase.id) },
+            options: nil
+        )
+        let connected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(connected)
+        let purchase = try makePurchase(id: "native-winner")
+        let epoch = hybrid.currentConnectionEpoch()
+        let holder = DeliveryTaskHolder()
+
+        _ = try await hybrid.runRequestPurchaseOperation {
+            let delivery = hybrid.enqueuePurchaseUpdateDelivery(
+                purchase,
+                expectedEpoch: epoch,
+                includeDuplicateListeners: false
+            )
+            await holder.set(delivery)
+            return .purchase(purchase)
+        }
+        let heldTask = await holder.task
+        let queuedDelivery = try XCTUnwrap(heldTask)
+        _ = try await queuedDelivery.value
+        let endPromise = try hybrid.endConnection()
+        _ = try await endPromise.await()
+        probe.record("end")
+        XCTAssertEqual(probe.events, ["native-winner", "end"])
+    }
+
+    func testPurchaseErrorReachesListenerBeforeTeardown() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        try hybrid.addPurchaseErrorListener { error in
+            probe.record(error.code)
+        }
+        let connected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(connected)
+        let purchaseError = PurchaseError.make(
+            code: .userCancelled,
+            productId: "premium",
+            message: "cancelled"
+        )
+
+        do {
+            _ = try await hybrid.runRequestPurchaseOperation {
+                throw purchaseError
+            }
+            XCTFail("the injected purchase error must be preserved")
+        } catch let error as PurchaseError {
+            XCTAssertEqual(error.code, .userCancelled)
+        }
+
+        _ = try await hybrid.endConnection().await()
+        XCTAssertEqual(probe.events, [ErrorCode.userCancelled.rawValue])
+    }
+
     func testConnectionRequiringCallsUseBridgeOwnedOperations() throws {
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -130,7 +261,6 @@ final class ConnectOnDemandTests: XCTestCase {
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
         let guardedMethods = [
             "fetchProducts",
-            "requestPurchase",
             "getAvailablePurchases",
             "getActiveSubscriptions",
             "hasActiveSubscriptions",
@@ -172,24 +302,33 @@ final class ConnectOnDemandTests: XCTestCase {
             )
         }
 
-        let requestPurchaseBody = String(try methodBody("requestPurchase", in: source))
-        let operationBody = try closureBody(
-            after: "runConnectedOperation",
-            in: requestPurchaseBody
+        let requestPurchaseBody = try methodBody("requestPurchase", in: source)
+        XCTAssertTrue(requestPurchaseBody.contains("runRequestPurchaseOperation"))
+        let requestOperationBody = try methodBody(
+            "runRequestPurchaseOperation",
+            in: source
         )
-        let nativeRequest = try XCTUnwrap(
-            operationBody.range(of: "OpenIapModule.shared.requestPurchase")
+        XCTAssertTrue(requestOperationBody.contains("runConnectedOperation"))
+        let nativeResult = try XCTUnwrap(
+            requestOperationBody.range(of: "let result = try await operation()")
         )
         let delivery = try XCTUnwrap(
-            operationBody.range(
+            requestOperationBody.range(
                 of: "deliverRequestPurchaseResultIfNeeded",
-                range: nativeRequest.upperBound..<operationBody.endIndex
+                range: nativeResult.upperBound..<requestOperationBody.endIndex
             )
         )
         XCTAssertLessThan(
-            operationBody.distance(from: operationBody.startIndex, to: nativeRequest.lowerBound),
-            operationBody.distance(from: operationBody.startIndex, to: delivery.lowerBound)
+            requestOperationBody.distance(
+                from: requestOperationBody.startIndex,
+                to: nativeResult.lowerBound
+            ),
+            requestOperationBody.distance(
+                from: requestOperationBody.startIndex,
+                to: delivery.lowerBound
+            )
         )
+        XCTAssertTrue(requestOperationBody.contains("deliverRequestPurchaseError"))
     }
 
     // MARK: - Private reflection helpers
@@ -210,11 +349,51 @@ final class ConnectOnDemandTests: XCTestCase {
         childValue(hybrid, label: "isInitialized") as? Bool ?? false
     }
 
+    private func inspectPurchaseUpdatedSub(_ hybrid: HybridRnIap) -> Any? {
+        guard let child = childValue(hybrid, label: "purchaseUpdatedSub") else {
+            XCTFail("HybridRnIap no longer exposes purchaseUpdatedSub — test needs update")
+            return nil
+        }
+        let mirror = Mirror(reflecting: child)
+        if mirror.displayStyle == .optional {
+            return mirror.children.first?.value
+        }
+        return child
+    }
+
+    private func inspectPurchaseUpdatedListeners(
+        _ hybrid: HybridRnIap
+    ) -> [(NitroPurchase) -> Void] {
+        guard let registrations = childValue(
+            hybrid,
+            label: "purchaseUpdatedListeners"
+        ) as? [(token: Double, listener: (NitroPurchase) -> Void)] else {
+            XCTFail("HybridRnIap no longer exposes purchaseUpdatedListeners — test needs update")
+            return []
+        }
+        return registrations.map { $0.listener }
+    }
+
     private func childValue(_ object: Any, label: String) -> Any? {
         Mirror(reflecting: object)
             .children
             .first { $0.label == label }?
             .value
+    }
+
+    private func makePurchase(id: String) throws -> OpenIAP.Purchase {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "id": id,
+            "isAutoRenewing": false,
+            "productId": "premium",
+            "purchaseState": "purchased",
+            "quantity": 1,
+            "store": "apple",
+            "transactionDate": 1,
+            "transactionId": id
+        ])
+        let purchase = try JSONDecoder().decode(OpenIAP.PurchaseIOS.self, from: data)
+        return .purchaseIos(purchase)
     }
 
     private func methodBody(_ name: String, in source: String) throws -> Substring {
@@ -274,6 +453,14 @@ final class ConnectOnDemandTests: XCTestCase {
         func release() {
             continuation?.resume()
             continuation = nil
+        }
+    }
+
+    private actor DeliveryTaskHolder {
+        private(set) var task: Task<Void, Error>?
+
+        func set(_ task: Task<Void, Error>) {
+            self.task = task
         }
     }
 

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -40,18 +40,20 @@ final class ConnectOnDemandTests: XCTestCase {
         _ = try await hybrid.endConnection().await()
     }
 
-    func testOnDemandConnectIsNotRepeatedOnEveryCall() async throws {
+    func testOnDemandConnectReusesAttachedListeners() async throws {
         let hybrid = HybridRnIap()
 
+        try hybrid.addSubscriptionBillingIssueListener { _ in }
         _ = try await hybrid.getAvailablePurchases(options: nil).await()
-        let epochAfterFirst = inspectEpoch(hybrid)
+        let subAfterFirst = try XCTUnwrap(inspectSub(hybrid))
 
         _ = try await hybrid.getAvailablePurchases(options: nil).await()
+        let subAfterSecond = try XCTUnwrap(inspectSub(hybrid))
 
         XCTAssertEqual(
-            inspectEpoch(hybrid),
-            epochAfterFirst,
-            "the second call must reuse the open connection, not reconnect"
+            ObjectIdentifier(subAfterSecond as AnyObject),
+            ObjectIdentifier(subAfterFirst as AnyObject),
+            "the second call must reuse the attached listener"
         )
 
         _ = try await hybrid.endConnection().await()
@@ -73,10 +75,6 @@ final class ConnectOnDemandTests: XCTestCase {
 
     private func inspectInitialized(_ hybrid: HybridRnIap) -> Bool {
         childValue(hybrid, label: "isInitialized") as? Bool ?? false
-    }
-
-    private func inspectEpoch(_ hybrid: HybridRnIap) -> UInt64 {
-        childValue(hybrid, label: "connectionEpoch") as? UInt64 ?? .max
     }
 
     private func childValue(_ object: Any, label: String) -> Any? {

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -59,6 +59,82 @@ final class ConnectOnDemandTests: XCTestCase {
         _ = try await hybrid.endConnection().await()
     }
 
+    func testQueuedTeardownPreventsLateStoreDelegation() async throws {
+        let hybrid = HybridRnIap()
+        let connected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(connected)
+
+        let endPromise = try hybrid.endConnection()
+        let probe = DelegationProbe()
+        let operation = hybrid.enqueueConnectedOperation {
+            probe.markDelegated()
+            return true
+        }
+
+        _ = try await endPromise.await()
+        do {
+            _ = try await operation.value
+            XCTFail("a store operation queued after teardown must not run")
+        } catch let error as OpenIapException {
+            XCTAssertEqual(error.domain, OpenIapException.domain)
+            XCTAssertTrue(error.localizedDescription.contains(ErrorCode.initConnection.rawValue))
+        }
+        XCTAssertFalse(probe.wasDelegated)
+    }
+
+    func testConnectionRequiringCallsUseBridgeOwnedOperations() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = packageRoot.appendingPathComponent("ios/HybridRnIap.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let guardedMethods = [
+            "fetchProducts",
+            "requestPurchase",
+            "getAvailablePurchases",
+            "getActiveSubscriptions",
+            "hasActiveSubscriptions",
+            "finishTransaction",
+            "verifyPurchase",
+            "verifyPurchaseWithProvider",
+            "getStorefront",
+            "getAppTransactionIOS",
+            "getPromotedProductIOS",
+            "presentCodeRedemptionSheetIOS",
+            "clearTransactionIOS",
+            "subscriptionStatusIOS",
+            "currentEntitlementIOS",
+            "latestTransactionIOS",
+            "getPendingTransactionsIOS",
+            "getAllTransactionsIOS",
+            "syncIOS",
+            "showManageSubscriptionsIOS",
+            "deepLinkToSubscriptionsIOS",
+            "isEligibleForIntroOfferIOS",
+            "getReceiptDataIOS",
+            "requestReceiptRefreshIOS",
+            "isTransactionVerifiedIOS",
+            "getTransactionJwsIOS",
+            "beginRefundRequestIOS",
+            "canPresentExternalPurchaseNoticeIOS",
+            "presentExternalPurchaseNoticeSheetIOS",
+            "presentExternalPurchaseLinkIOS",
+            "isEligibleForExternalPurchaseCustomLinkIOS",
+            "getExternalPurchaseCustomLinkTokenIOS",
+            "showExternalPurchaseCustomLinkNoticeIOS"
+        ]
+
+        for method in guardedMethods {
+            let body = try methodBody(method, in: source)
+            XCTAssertTrue(
+                body.contains("runConnectedOperation"),
+                "\(method) must not delegate around the bridge lifecycle queue"
+            )
+        }
+    }
+
     // MARK: - Private reflection helpers
 
     private func inspectSub(_ hybrid: HybridRnIap) -> Any? {
@@ -82,5 +158,46 @@ final class ConnectOnDemandTests: XCTestCase {
             .children
             .first { $0.label == label }?
             .value
+    }
+
+    private func methodBody(_ name: String, in source: String) throws -> Substring {
+        let start = try XCTUnwrap(source.range(of: "    func \(name)"))
+        let openingBrace = try XCTUnwrap(
+            source.range(of: "{", range: start.upperBound..<source.endIndex)
+        )
+        var depth = 0
+        var index = openingBrace.lowerBound
+        while index < source.endIndex {
+            switch source[index] {
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return source[start.lowerBound...index]
+                }
+            default:
+                break
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "ConnectOnDemandTests", code: 1)
+    }
+
+    private final class DelegationProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var delegated = false
+
+        var wasDelegated: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return delegated
+        }
+
+        func markDelegated() {
+            lock.lock()
+            delegated = true
+            lock.unlock()
+        }
     }
 }

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -82,6 +82,34 @@ final class ConnectOnDemandTests: XCTestCase {
         XCTAssertFalse(probe.wasDelegated)
     }
 
+    func testTeardownWaitsForConnectedOperationDelivery() async throws {
+        let hybrid = HybridRnIap()
+        let connected = try await hybrid.initConnection(config: nil).await()
+        XCTAssertTrue(connected)
+        let gate = DeliveryGate()
+        let probe = EventProbe()
+
+        let operation = hybrid.enqueueConnectedOperation {
+            await gate.waitUntilReleased()
+            probe.record("delivery")
+            return true
+        }
+        while !(await gate.hasStarted) {
+            await Task.yield()
+        }
+
+        let endPromise = try hybrid.endConnection()
+        let endTask = Task {
+            _ = try await endPromise.await()
+            probe.record("end")
+        }
+        await gate.release()
+
+        _ = try await operation.value
+        try await endTask.value
+        XCTAssertEqual(probe.events, ["delivery", "end"])
+    }
+
     func testConnectionRequiringCallsUseBridgeOwnedOperations() throws {
         let packageRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -133,6 +161,25 @@ final class ConnectOnDemandTests: XCTestCase {
                 "\(method) must not delegate around the bridge lifecycle queue"
             )
         }
+
+        let requestPurchaseBody = String(try methodBody("requestPurchase", in: source))
+        let operationBody = try closureBody(
+            after: "runConnectedOperation",
+            in: requestPurchaseBody
+        )
+        let nativeRequest = try XCTUnwrap(
+            operationBody.range(of: "OpenIapModule.shared.requestPurchase")
+        )
+        let delivery = try XCTUnwrap(
+            operationBody.range(
+                of: "deliverRequestPurchaseResultIfNeeded",
+                range: nativeRequest.upperBound..<operationBody.endIndex
+            )
+        )
+        XCTAssertLessThan(
+            operationBody.distance(from: operationBody.startIndex, to: nativeRequest.lowerBound),
+            operationBody.distance(from: operationBody.startIndex, to: delivery.lowerBound)
+        )
     }
 
     // MARK: - Private reflection helpers
@@ -161,9 +208,13 @@ final class ConnectOnDemandTests: XCTestCase {
     }
 
     private func methodBody(_ name: String, in source: String) throws -> Substring {
-        let start = try XCTUnwrap(source.range(of: "    func \(name)"))
+        try closureBody(after: "    func \(name)", in: source)
+    }
+
+    private func closureBody(after marker: String, in source: String) throws -> Substring {
+        let markerRange = try XCTUnwrap(source.range(of: marker))
         let openingBrace = try XCTUnwrap(
-            source.range(of: "{", range: start.upperBound..<source.endIndex)
+            source.range(of: "{", range: markerRange.upperBound..<source.endIndex)
         )
         var depth = 0
         var index = openingBrace.lowerBound
@@ -174,14 +225,14 @@ final class ConnectOnDemandTests: XCTestCase {
             case "}":
                 depth -= 1
                 if depth == 0 {
-                    return source[start.lowerBound...index]
+                    return source[openingBrace.lowerBound...index]
                 }
             default:
                 break
             }
             index = source.index(after: index)
         }
-        throw NSError(domain: "ConnectOnDemandTests", code: 1)
+        throw NSError(domain: "ConnectOnDemandTests", code: 2)
     }
 
     private final class DelegationProbe: @unchecked Sendable {
@@ -197,6 +248,38 @@ final class ConnectOnDemandTests: XCTestCase {
         func markDelegated() {
             lock.lock()
             delegated = true
+            lock.unlock()
+        }
+    }
+
+    private actor DeliveryGate {
+        private(set) var hasStarted = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func waitUntilReleased() async {
+            hasStarted = true
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func release() {
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    private final class EventProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var recordedEvents: [String] = []
+
+        var events: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedEvents
+        }
+
+        func record(_ event: String) {
+            lock.lock()
+            recordedEvents.append(event)
             lock.unlock()
         }
     }

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -50,6 +50,75 @@ final class ConnectOnDemandTests: XCTestCase {
         _ = try await hybrid.endConnection().await()
     }
 
+    func testPurchaseCallbackDuringInitIsDeliveredAfterConnectionSucceeds() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in probe.record(purchase.id) },
+            options: nil
+        )
+        let purchase = try makePurchase(id: "during-init")
+        let holder = DeliveryTaskHolder()
+
+        let connection = hybrid.enqueueConnectOperation {
+            XCTAssertNotNil(
+                self.inspectPurchaseUpdatedSub(hybrid),
+                "the bridge listener must be attached before StoreKit initialization"
+            )
+            let delivery = hybrid.enqueuePurchaseUpdateDelivery(
+                purchase,
+                expectedEpoch: hybrid.currentConnectionEpoch(),
+                includeDuplicateListeners: false
+            )
+            await holder.set(delivery)
+            return true
+        }
+
+        let connected = try await connection.value
+        XCTAssertTrue(connected)
+        let heldDelivery = await holder.task
+        let delivery = try XCTUnwrap(heldDelivery)
+        _ = try await delivery.value
+        XCTAssertEqual(probe.events, ["during-init"])
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    func testPurchaseErrorCallbackDuringFailedInitIsDelivered() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        try hybrid.addPurchaseErrorListener { error in
+            probe.record(error.code)
+        }
+        let purchaseError = PurchaseError.make(
+            code: .iapNotAvailable,
+            message: "Store unavailable"
+        )
+        let holder = DeliveryTaskHolder()
+
+        let connection = hybrid.enqueueConnectOperation {
+            XCTAssertNotNil(
+                self.inspectPurchaseErrorSub(hybrid),
+                "the error listener must be attached before StoreKit initialization"
+            )
+            let delivery = hybrid.enqueuePurchaseErrorDelivery(
+                purchaseError,
+                expectedEpoch: hybrid.currentConnectionEpoch()
+            )
+            await holder.set(delivery)
+            return false
+        }
+
+        let connected = try await connection.value
+        XCTAssertFalse(connected)
+        let heldDelivery = await holder.task
+        let delivery = try XCTUnwrap(heldDelivery)
+        _ = try await delivery.value
+        XCTAssertEqual(probe.events, [ErrorCode.iapNotAvailable.rawValue])
+
+        _ = try await hybrid.endConnection().await()
+    }
+
     func testQueuedTeardownPreventsLateStoreDelegation() async throws {
         let hybrid = HybridRnIap()
         let connected = try await hybrid.initConnection(config: nil).await()
@@ -389,6 +458,18 @@ final class ConnectOnDemandTests: XCTestCase {
     private func inspectPurchaseUpdatedSub(_ hybrid: HybridRnIap) -> Any? {
         guard let child = childValue(hybrid, label: "purchaseUpdatedSub") else {
             XCTFail("HybridRnIap no longer exposes purchaseUpdatedSub — test needs update")
+            return nil
+        }
+        let mirror = Mirror(reflecting: child)
+        if mirror.displayStyle == .optional {
+            return mirror.children.first?.value
+        }
+        return child
+    }
+
+    private func inspectPurchaseErrorSub(_ hybrid: HybridRnIap) -> Any? {
+        guard let child = childValue(hybrid, label: "purchaseErrorSub") else {
+            XCTFail("HybridRnIap no longer exposes purchaseErrorSub — test needs update")
             return nil
         }
         let mirror = Mirror(reflecting: child)

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -53,10 +53,6 @@ final class ConnectOnDemandTests: XCTestCase {
     func testPurchaseCallbackDuringInitIsDeliveredAfterConnectionSucceeds() async throws {
         let hybrid = HybridRnIap()
         let probe = EventProbe()
-        _ = try hybrid.addPurchaseUpdatedListener(
-            listener: { purchase in probe.record(purchase.id) },
-            options: nil
-        )
         let purchase = try makePurchase(id: "during-init")
         let holder = DeliveryTaskHolder()
 
@@ -79,6 +75,13 @@ final class ConnectOnDemandTests: XCTestCase {
         let heldDelivery = await holder.task
         let delivery = try XCTUnwrap(heldDelivery)
         _ = try await delivery.value
+        XCTAssertTrue(probe.events.isEmpty)
+
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in probe.record(purchase.id) },
+            options: nil
+        )
+        _ = try await hybrid.enqueueLifecycleBarrier().value
         XCTAssertEqual(probe.events, ["during-init"])
 
         _ = try await hybrid.endConnection().await()
@@ -87,9 +90,6 @@ final class ConnectOnDemandTests: XCTestCase {
     func testPurchaseErrorCallbackDuringFailedInitIsDelivered() async throws {
         let hybrid = HybridRnIap()
         let probe = EventProbe()
-        try hybrid.addPurchaseErrorListener { error in
-            probe.record(error.code)
-        }
         let purchaseError = PurchaseError.make(
             code: .iapNotAvailable,
             message: "Store unavailable"
@@ -114,7 +114,154 @@ final class ConnectOnDemandTests: XCTestCase {
         let heldDelivery = await holder.task
         let delivery = try XCTUnwrap(heldDelivery)
         _ = try await delivery.value
+        XCTAssertTrue(probe.events.isEmpty)
+
+        try hybrid.addPurchaseErrorListener { error in
+            probe.record(error.code)
+        }
+        _ = try await hybrid.enqueueLifecycleBarrier().value
         XCTAssertEqual(probe.events, [ErrorCode.iapNotAvailable.rawValue])
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    func testOnDemandInitErrorIsOwnedByTheCallingOperation() async throws {
+        let hybrid = HybridRnIap()
+        let probe = EventProbe()
+        try hybrid.addPurchaseErrorListener { error in
+            probe.record(error.code)
+        }
+        let purchaseError = PurchaseError.make(
+            code: .iapNotAvailable,
+            message: "Store unavailable"
+        )
+
+        let connection = hybrid.enqueueOnDemandConnectOperation { false }
+
+        let connected = try await connection.value
+        XCTAssertFalse(connected)
+        let delivery = hybrid.enqueuePurchaseErrorDelivery(
+            purchaseError,
+            expectedEpoch: hybrid.currentConnectionEpoch()
+        )
+        _ = try await delivery.value
+        XCTAssertTrue(
+            probe.events.isEmpty,
+            "on-demand initialization failures belong to the calling operation"
+        )
+
+        _ = try await hybrid.enqueueEndOperation { true }.value
+    }
+
+    func testPendingPurchaseUpdatesAreBoundedAndFlushInOrder() async throws {
+        let hybrid = HybridRnIap()
+        let connected = try await hybrid.enqueueConnectOperation { true }.value
+        XCTAssertTrue(connected)
+        let epoch = hybrid.currentConnectionEpoch()
+
+        for index in 0...200 {
+            let purchase = try makePurchase(id: "buffered-\(index)")
+            _ = try await hybrid.enqueuePurchaseUpdateDelivery(
+                purchase,
+                expectedEpoch: epoch,
+                includeDuplicateListeners: false
+            ).value
+        }
+
+        let probe = EventProbe()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in probe.record(purchase.id) },
+            options: nil
+        )
+        _ = try await hybrid.enqueueLifecycleBarrier().value
+        XCTAssertEqual(probe.events.count, 200)
+        XCTAssertEqual(probe.events.first, "buffered-1")
+        XCTAssertEqual(probe.events.last, "buffered-200")
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    func testBufferedReplayFinishesBeforeCallbackTriggeredTeardown() async throws {
+        let hybrid = HybridRnIap()
+        let connected = try await hybrid.enqueueConnectOperation { true }.value
+        XCTAssertTrue(connected)
+        let epoch = hybrid.currentConnectionEpoch()
+
+        for id in ["replay-first", "replay-second"] {
+            _ = try await hybrid.enqueuePurchaseUpdateDelivery(
+                try makePurchase(id: id),
+                expectedEpoch: epoch,
+                includeDuplicateListeners: false
+            ).value
+        }
+
+        let probe = EventProbe()
+        let endHolder = EndTaskHolder()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in
+                probe.record(purchase.id)
+                if purchase.id == "replay-first" {
+                    endHolder.set(hybrid.enqueueEndOperation { true })
+                }
+            },
+            options: nil
+        )
+        _ = try await hybrid.enqueueLifecycleBarrier().value
+        let endTask = try XCTUnwrap(endHolder.task)
+        _ = try await endTask.value
+        probe.record("end")
+
+        XCTAssertEqual(probe.events, ["replay-first", "replay-second", "end"])
+    }
+
+    func testListenerRegisteredDuringReplayOnlyReceivesLaterEvents() async throws {
+        let hybrid = HybridRnIap()
+        let connected = try await hybrid.enqueueConnectOperation { true }.value
+        XCTAssertTrue(connected)
+        let epoch = hybrid.currentConnectionEpoch()
+        let livePurchase = try makePurchase(id: "live")
+
+        for id in ["buffered-first", "buffered-second"] {
+            _ = try await hybrid.enqueuePurchaseUpdateDelivery(
+                try makePurchase(id: id),
+                expectedEpoch: epoch,
+                includeDuplicateListeners: false
+            ).value
+        }
+
+        let firstProbe = EventProbe()
+        let reentrantProbe = EventProbe()
+        let liveDeliveryHolder = VoidTaskHolder()
+        _ = try hybrid.addPurchaseUpdatedListener(
+            listener: { purchase in
+                firstProbe.record(purchase.id)
+                if purchase.id == "buffered-first" {
+                    do {
+                        _ = try hybrid.addPurchaseUpdatedListener(
+                            listener: { laterPurchase in
+                                reentrantProbe.record(laterPurchase.id)
+                            },
+                            options: nil
+                        )
+                    } catch {
+                        reentrantProbe.record("listener-registration-failed")
+                    }
+                    liveDeliveryHolder.set(
+                        hybrid.enqueuePurchaseUpdateDelivery(
+                            livePurchase,
+                            expectedEpoch: epoch,
+                            includeDuplicateListeners: false
+                        )
+                    )
+                }
+            },
+            options: nil
+        )
+        _ = try await hybrid.enqueueLifecycleBarrier().value
+        let liveDelivery = try XCTUnwrap(liveDeliveryHolder.task)
+        _ = try await liveDelivery.value
+        XCTAssertEqual(firstProbe.events, ["buffered-first", "buffered-second", "live"])
+        XCTAssertEqual(reentrantProbe.events, ["live"])
 
         _ = try await hybrid.endConnection().await()
     }
@@ -579,6 +726,40 @@ final class ConnectOnDemandTests: XCTestCase {
 
         func set(_ task: Task<Void, Error>) {
             self.task = task
+        }
+    }
+
+    private final class EndTaskHolder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedTask: Task<Bool, Error>?
+
+        var task: Task<Bool, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedTask
+        }
+
+        func set(_ task: Task<Bool, Error>) {
+            lock.lock()
+            storedTask = task
+            lock.unlock()
+        }
+    }
+
+    private final class VoidTaskHolder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedTask: Task<Void, Error>?
+
+        var task: Task<Void, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedTask
+        }
+
+        func set(_ task: Task<Void, Error>) {
+            lock.lock()
+            storedTask = task
+            lock.unlock()
         }
     }
 

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import OpenIAP
+@testable import NitroIap
+
+/// A store call made without `initConnection()` must still arrive with the
+/// bridge's listeners attached.
+///
+/// StoreKit has no connection to open, so the bridge connects on demand rather
+/// than refusing. That is only safe if the on-demand path is the same one
+/// `initConnection()` uses — otherwise a purchase would run with no subscription
+/// observing it, and the app would never call `finishTransaction`.
+///
+/// Reflection note: matches SubscriptionBillingIssueReconnectTests — the state is
+/// `private` in HybridRnIap, and `Mirror` reads it without widening the API.
+@available(iOS 15.0, macOS 14.0, tvOS 15.0, watchOS 8.0, *)
+final class ConnectOnDemandTests: XCTestCase {
+
+    func testStoreCallWithoutInitConnectionConnectsAndAttachesListeners() async throws {
+        let hybrid = HybridRnIap()
+
+        try hybrid.addSubscriptionBillingIssueListener { _ in }
+        XCTAssertFalse(inspectInitialized(hybrid))
+        XCTAssertNil(
+            inspectSub(hybrid),
+            "precondition: nothing is attached before a connection exists"
+        )
+
+        // No initConnection() — this is the call an app makes on mount.
+        _ = try await hybrid.getAvailablePurchases(options: nil).await()
+
+        XCTAssertTrue(
+            inspectInitialized(hybrid),
+            "a guarded store call must open the connection instead of refusing"
+        )
+        XCTAssertNotNil(
+            inspectSub(hybrid),
+            "the on-demand connect must attach listeners, or purchase events are lost"
+        )
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    func testOnDemandConnectIsNotRepeatedOnEveryCall() async throws {
+        let hybrid = HybridRnIap()
+
+        _ = try await hybrid.getAvailablePurchases(options: nil).await()
+        let epochAfterFirst = inspectEpoch(hybrid)
+
+        _ = try await hybrid.getAvailablePurchases(options: nil).await()
+
+        XCTAssertEqual(
+            inspectEpoch(hybrid),
+            epochAfterFirst,
+            "the second call must reuse the open connection, not reconnect"
+        )
+
+        _ = try await hybrid.endConnection().await()
+    }
+
+    // MARK: - Private reflection helpers
+
+    private func inspectSub(_ hybrid: HybridRnIap) -> Any? {
+        guard let child = childValue(hybrid, label: "subscriptionBillingIssueSub") else {
+            XCTFail("HybridRnIap no longer exposes subscriptionBillingIssueSub — test needs update")
+            return nil
+        }
+        let mirror = Mirror(reflecting: child)
+        if mirror.displayStyle == .optional {
+            return mirror.children.first?.value
+        }
+        return child
+    }
+
+    private func inspectInitialized(_ hybrid: HybridRnIap) -> Bool {
+        childValue(hybrid, label: "isInitialized") as? Bool ?? false
+    }
+
+    private func inspectEpoch(_ hybrid: HybridRnIap) -> UInt64 {
+        childValue(hybrid, label: "connectionEpoch") as? UInt64 ?? .max
+    }
+
+    private func childValue(_ object: Any, label: String) -> Any? {
+        Mirror(reflecting: object)
+            .children
+            .first { $0.label == label }?
+            .value
+    }
+}

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -164,19 +164,28 @@ final class ConnectOnDemandTests: XCTestCase {
         _ = try await hybrid.runRequestPurchaseOperation {
             .purchase(purchase)
         }
-        XCTAssertEqual(probe.events, ["returned-transaction"])
+        _ = try await hybrid.runRequestPurchaseOperation {
+            .purchase(purchase)
+        }
+        XCTAssertEqual(probe.events, ["returned-transaction", "returned-transaction"])
 
         let epoch = hybrid.currentConnectionEpoch()
-        let originalCallback = hybrid.enqueuePurchaseUpdateDelivery(
+        let firstCallback = hybrid.enqueuePurchaseUpdateDelivery(
             purchase,
             expectedEpoch: epoch,
             includeDuplicateListeners: true
         )
-        _ = try await originalCallback.value
+        let secondCallback = hybrid.enqueuePurchaseUpdateDelivery(
+            purchase,
+            expectedEpoch: epoch,
+            includeDuplicateListeners: true
+        )
+        _ = try await firstCallback.value
+        _ = try await secondCallback.value
         XCTAssertEqual(
             probe.events,
-            ["returned-transaction"],
-            "the asynchronous callback for the returned purchase must be suppressed once"
+            ["returned-transaction", "returned-transaction"],
+            "each direct delivery must suppress its matching asynchronous callback"
         )
         let replay = hybrid.enqueuePurchaseUpdateDelivery(
             purchase,
@@ -186,7 +195,7 @@ final class ConnectOnDemandTests: XCTestCase {
         _ = try await replay.value
         XCTAssertEqual(
             probe.events,
-            ["returned-transaction", "returned-transaction"],
+            ["returned-transaction", "returned-transaction", "returned-transaction"],
             "later StoreKit replays must still reach non-deduping listeners"
         )
 
@@ -224,7 +233,7 @@ final class ConnectOnDemandTests: XCTestCase {
         XCTAssertEqual(probe.events, ["native-winner", "end"])
     }
 
-    func testPurchaseErrorReachesListenerBeforeTeardown() async throws {
+    func testDelayedPurchaseErrorCallbacksAreSuppressedBeforeTeardown() async throws {
         let hybrid = HybridRnIap()
         let probe = EventProbe()
         try hybrid.addPurchaseErrorListener { error in
@@ -237,18 +246,37 @@ final class ConnectOnDemandTests: XCTestCase {
             productId: "premium",
             message: "cancelled"
         )
+        let epoch = hybrid.currentConnectionEpoch()
 
-        do {
-            _ = try await hybrid.runRequestPurchaseOperation {
-                throw purchaseError
+        for _ in 0..<2 {
+            do {
+                _ = try await hybrid.runRequestPurchaseOperation {
+                    throw purchaseError
+                }
+                XCTFail("the injected purchase error must be preserved")
+            } catch let error as PurchaseError {
+                XCTAssertEqual(error.code, .userCancelled)
             }
-            XCTFail("the injected purchase error must be preserved")
-        } catch let error as PurchaseError {
-            XCTAssertEqual(error.code, .userCancelled)
         }
 
+        _ = hybrid.enqueueConnectedOperation {
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        let firstNativeDelivery = hybrid.enqueuePurchaseErrorDelivery(
+            purchaseError,
+            expectedEpoch: epoch
+        )
+        let secondNativeDelivery = hybrid.enqueuePurchaseErrorDelivery(
+            purchaseError,
+            expectedEpoch: epoch
+        )
+        _ = try await firstNativeDelivery.value
+        _ = try await secondNativeDelivery.value
         _ = try await hybrid.endConnection().await()
-        XCTAssertEqual(probe.events, [ErrorCode.userCancelled.rawValue])
+        XCTAssertEqual(
+            probe.events,
+            [ErrorCode.userCancelled.rawValue, ErrorCode.userCancelled.rawValue]
+        )
     }
 
     func testConnectionRequiringCallsUseBridgeOwnedOperations() throws {

--- a/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
+++ b/libraries/react-native-iap/example/ios/exampleTests/ConnectOnDemandTests.swift
@@ -357,6 +357,15 @@ final class ConnectOnDemandTests: XCTestCase {
             )
         )
         XCTAssertTrue(requestOperationBody.contains("deliverRequestPurchaseError"))
+
+        let enqueueConnectBody = try closureBody(
+            after: "    private func enqueueConnect",
+            in: source
+        )
+        XCTAssertTrue(
+            enqueueConnectBody.contains("if isCurrent, !reuseExistingConnection"),
+            "on-demand connection failure must be reported only by the calling operation"
+        )
     }
 
     // MARK: - Private reflection helpers

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -2,6 +2,15 @@ import Foundation
 import NitroModules
 import OpenIAP
 
+func endConnectionThenCleanup(
+    endConnection: () async throws -> Bool,
+    cleanup: () async -> Void
+) async rethrows -> Bool {
+    let result = try await endConnection()
+    await cleanup()
+    return result
+}
+
 @available(iOS 15.0, macOS 14.0, tvOS 15.0, watchOS 8.0, *)
 class HybridRnIap: HybridRnIapSpec {
     private enum PurchaseUpdatedListenerBucket {
@@ -60,15 +69,11 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async { try await operation.value }
     }
 
-    // StoreKit has no connection to open: initConnection allocates the product
-    // cache and registers observers. A caller that skipped it gets that work
-    // done here instead of an error, and it runs through the same path so the
-    // bridge's purchase listeners attach — otherwise events would be lost.
+    // StoreKit initialization still owns caches and observers despite having no persistent connection.
     private func ensureConnection() async throws {
         if isConnectionInitialized() { return }
         _ = try await enqueueConnect(nil, reuseExistingConnection: true).value
-        // Still refuse if the connect did not take: the listeners attach on the
-        // same path, so proceeding here would run a purchase nothing observes.
+        // Never run a store operation without listeners installed by the same lifecycle path.
         guard isConnectionInitialized() else {
             throw OpenIapException.make(code: .initConnection, message: "Connection not initialized. Call initConnection() first.")
         }
@@ -119,14 +124,20 @@ class HybridRnIap: HybridRnIapSpec {
 
     func endConnection() throws -> Promise<Bool> {
         let operation = enqueueLifecycleOperation {
-            let subscriptions = self.detachConnectionState()
-            self.removeSubscriptions(subscriptions)
-            await MainActor.run {
-                self.productTypeBySku.removeAll()
-                self.purchasePayloadById.removeAll()
-            }
             RnIapLog.payload("endConnection", nil)
-            let result = try await OpenIapModule.shared.endConnection()
+            let result = try await endConnectionThenCleanup(
+                endConnection: {
+                    try await OpenIapModule.shared.endConnection()
+                },
+                cleanup: {
+                    let subscriptions = self.detachConnectionState()
+                    self.removeSubscriptions(subscriptions)
+                    await MainActor.run {
+                        self.productTypeBySku.removeAll()
+                        self.purchasePayloadById.removeAll()
+                    }
+                }
+            )
             RnIapLog.result("endConnection", result)
             return result
         }

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -65,7 +65,7 @@ class HybridRnIap: HybridRnIapSpec {
     // bridge's purchase listeners attach — otherwise events would be lost.
     private func ensureConnection() async throws {
         if isConnectionInitialized() { return }
-        _ = try await enqueueConnect(nil).value
+        _ = try await enqueueConnect(nil, reuseExistingConnection: true).value
         // Still refuse if the connect did not take: the listeners attach on the
         // same path, so proceeding here would run a purchase nothing observes.
         guard isConnectionInitialized() else {
@@ -73,8 +73,12 @@ class HybridRnIap: HybridRnIapSpec {
         }
     }
 
-    private func enqueueConnect(_ configValue: InitConnectionConfig?) -> Task<Bool, Error> {
+    private func enqueueConnect(
+        _ configValue: InitConnectionConfig?,
+        reuseExistingConnection: Bool = false
+    ) -> Task<Bool, Error> {
         enqueueLifecycleOperation {
+            if reuseExistingConnection, self.isConnectionInitialized() { return true }
             RnIapLog.payload("initConnection", configValue)
             let epoch = self.listenerLock.withLock { self.connectionEpoch }
 
@@ -661,6 +665,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func presentCodeRedemptionSheetIOS() throws -> Promise<Variant_NullType_NitroPurchase> {
         return Promise.async {
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("presentCodeRedemptionSheetIOS", nil)
                 guard let purchase = try await OpenIapModule.shared.presentCodeRedemptionSheetIOS() else {

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -51,11 +51,30 @@ class HybridRnIap: HybridRnIapSpec {
     
     
     func initConnection(config: Variant_NullType_InitConnectionConfig?) throws -> Promise<Bool> {
-        let operation = enqueueLifecycleOperation {
-            let configValue: InitConnectionConfig? = {
-                if case .second(let c) = config { return c }
-                return nil
-            }()
+        let configValue: InitConnectionConfig? = {
+            if case .second(let c) = config { return c }
+            return nil
+        }()
+        let operation = enqueueConnect(configValue)
+        return Promise.async { try await operation.value }
+    }
+
+    // StoreKit has no connection to open: initConnection allocates the product
+    // cache and registers observers. A caller that skipped it gets that work
+    // done here instead of an error, and it runs through the same path so the
+    // bridge's purchase listeners attach — otherwise events would be lost.
+    private func ensureConnection() async throws {
+        if isConnectionInitialized() { return }
+        _ = try await enqueueConnect(nil).value
+        // Still refuse if the connect did not take: the listeners attach on the
+        // same path, so proceeding here would run a purchase nothing observes.
+        guard isConnectionInitialized() else {
+            throw OpenIapException.make(code: .initConnection, message: "Connection not initialized. Call initConnection() first.")
+        }
+    }
+
+    private func enqueueConnect(_ configValue: InitConnectionConfig?) -> Task<Bool, Error> {
+        enqueueLifecycleOperation {
             RnIapLog.payload("initConnection", configValue)
             let epoch = self.listenerLock.withLock { self.connectionEpoch }
 
@@ -91,9 +110,8 @@ class HybridRnIap: HybridRnIapSpec {
                 return false
             }
         }
-        return Promise.async { try await operation.value }
     }
-    
+
     func endConnection() throws -> Promise<Bool> {
         let operation = enqueueLifecycleOperation {
             let subscriptions = self.detachConnectionState()
@@ -112,7 +130,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func fetchProducts(skus: [String], type: String) throws -> Promise<[NitroProduct]> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             RnIapLog.payload("fetchProducts", [
                 "skus": skus,
                 "type": type
@@ -200,7 +218,9 @@ class HybridRnIap: HybridRnIapSpec {
                 return defaultResult
             }
 
-            guard self.isConnectionInitialized() else {
+            do {
+                try await self.ensureConnection()
+            } catch {
                 let err = RnIapHelper.makePurchaseErrorResult(
                     code: .initConnection,
                     message: "IAP store connection not initialized",
@@ -291,7 +311,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getAvailablePurchases(options: NitroAvailablePurchasesOptions?) throws -> Promise<[NitroPurchase]> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 // Unwrap Variant ios options
                 let iosOpts: NitroAvailablePurchasesIosOptions?
@@ -331,7 +351,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func getActiveSubscriptions(subscriptionIds: [String]?) throws -> Promise<[NitroActiveSubscription]> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getActiveSubscriptions", subscriptionIds ?? [])
                 // Call OpenIAP's native getActiveSubscriptions - includes renewalInfoIOS!
@@ -353,7 +373,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func hasActiveSubscriptions(subscriptionIds: [String]?) throws -> Promise<Bool> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("hasActiveSubscriptions", subscriptionIds ?? [])
                 let hasActive = try await OpenIapModule.shared.hasActiveSubscriptions(subscriptionIds)
@@ -372,7 +392,7 @@ class HybridRnIap: HybridRnIapSpec {
     func finishTransaction(params: NitroFinishTransactionParams) throws -> Promise<Variant_Bool_NitroPurchaseResult> {
         return Promise.async {
             guard case .second(let iosParams) = params.ios else { return .first(true) }
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload(
                     "finishTransaction", ["transactionId": iosParams.transactionId]
@@ -619,7 +639,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getPromotedProductIOS() throws -> Promise<Variant_NullType_NitroProduct> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getPromotedProductIOS", nil)
                 guard let product = try await OpenIapModule.shared.getPromotedProductIOS() else {
@@ -678,7 +698,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func subscriptionStatusIOS(sku: String) throws -> Promise<Variant_NullType__NitroSubscriptionStatus_> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("subscriptionStatusIOS", ["sku": sku])
                 let statuses = try await OpenIapModule.shared.subscriptionStatusIOS(sku: sku)
@@ -717,7 +737,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func currentEntitlementIOS(sku: String) throws -> Promise<Variant_NullType_NitroPurchase> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("currentEntitlementIOS", ["sku": sku])
                 let purchase = try await OpenIapModule.shared.currentEntitlementIOS(sku: sku)
@@ -746,7 +766,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func latestTransactionIOS(sku: String) throws -> Promise<Variant_NullType_NitroPurchase> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("latestTransactionIOS", ["sku": sku])
                 let purchase = try await OpenIapModule.shared.latestTransactionIOS(sku: sku)
@@ -855,7 +875,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func showManageSubscriptionsIOS() throws -> Promise<[NitroPurchase]> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("showManageSubscriptionsIOS", nil)
                 let changedPurchases = try await OpenIapModule.shared.showManageSubscriptionsIOS()
@@ -875,7 +895,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func deepLinkToSubscriptionsIOS() throws -> Promise<Bool> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("deepLinkToSubscriptionsIOS", nil)
                 try await OpenIapModule.shared.deepLinkToSubscriptions(nil)
@@ -902,7 +922,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getReceiptDataIOS() throws -> Promise<String> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getReceiptDataIOS", nil)
                 let receipt = try await RnIapHelper.loadReceiptData(refresh: false)
@@ -920,7 +940,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func requestReceiptRefreshIOS() throws -> Promise<String> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("requestReceiptRefreshIOS", nil)
                 let receipt = try await RnIapHelper.loadReceiptData(refresh: true)
@@ -938,7 +958,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     func isTransactionVerifiedIOS(sku: String) throws -> Promise<Bool> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             RnIapLog.payload("isTransactionVerifiedIOS", ["sku": sku])
             let value = try await OpenIapModule.shared.isTransactionVerifiedIOS(sku: sku)
             RnIapLog.result("isTransactionVerifiedIOS", value)
@@ -948,7 +968,7 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getTransactionJwsIOS(sku: String) throws -> Promise<Variant_NullType_String> {
         return Promise.async {
-            try self.ensureConnection()
+            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getTransactionJwsIOS", ["sku": sku])
                 let jws = try await OpenIapModule.shared.getTransactionJwsIOS(sku: sku)
@@ -1312,12 +1332,6 @@ class HybridRnIap: HybridRnIapSpec {
         }
     }
 
-    private func ensureConnection() throws {
-        guard isConnectionInitialized() else {
-            throw OpenIapException.make(code: .initConnection, message: "Connection not initialized. Call initConnection() first.")
-        }
-    }
-
     private func isConnectionInitialized() -> Bool {
         listenerLock.withLock { isInitialized }
     }
@@ -1512,7 +1526,7 @@ class HybridRnIap: HybridRnIapSpec {
             RnIapLog.payload("canPresentExternalPurchaseNoticeIOS", nil)
 
             if #available(iOS 16.0, *) {
-                try self.ensureConnection()
+                try await self.ensureConnection()
                 do {
                     let canPresent = try await OpenIapModule.shared.canPresentExternalPurchaseNoticeIOS()
                     RnIapLog.result("canPresentExternalPurchaseNoticeIOS", canPresent)
@@ -1537,7 +1551,7 @@ class HybridRnIap: HybridRnIapSpec {
             RnIapLog.payload("presentExternalPurchaseNoticeSheetIOS", nil)
 
             if #available(iOS 16.0, *) {
-                try self.ensureConnection()
+                try await self.ensureConnection()
                 do {
                     let result = try await OpenIapModule.shared.presentExternalPurchaseNoticeSheetIOS()
 
@@ -1578,7 +1592,7 @@ class HybridRnIap: HybridRnIapSpec {
             RnIapLog.payload("presentExternalPurchaseLinkIOS", ["url": url])
 
             if #available(iOS 16.0, *) {
-                try self.ensureConnection()
+                try await self.ensureConnection()
                 do {
                     let result = try await OpenIapModule.shared.presentExternalPurchaseLinkIOS(url)
                     let nitroResult = ExternalPurchaseLinkResultIOS(

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -35,6 +35,7 @@ class HybridRnIap: HybridRnIapSpec {
     private var lastPurchaseErrorKey: String? = nil
     private var lastPurchaseErrorTimestamp: TimeInterval = 0
     private var purchasePayloadById: [String: [String: Any]] = [:]
+    private var deliveredPurchaseUpdateIds = Set<String>()
     // Thread safety lock for listener arrays and error dedup state
     private let listenerLock = NSLock()
     private let lifecycleLock = NSLock()
@@ -280,7 +281,15 @@ class HybridRnIap: HybridRnIapSpec {
                 )
 
                 let result = try await self.runConnectedOperation {
-                    try await OpenIapModule.shared.requestPurchase(props)
+                    let epoch = self.currentConnectionEpoch()
+                    let result = try await OpenIapModule.shared.requestPurchase(props)
+                    // OpenIAP posts listener callbacks asynchronously. Deliver the
+                    // returned purchase before teardown can detach this bridge.
+                    await self.deliverRequestPurchaseResultIfNeeded(
+                        result,
+                        expectedEpoch: epoch
+                    )
+                    return result
                 }
                 if result != nil {
                     RnIapLog.result("requestPurchase", "delegated to OpenIAP")
@@ -1303,6 +1312,50 @@ class HybridRnIap: HybridRnIapSpec {
         return try await enqueueConnectedOperation(operation).value
     }
 
+    private func currentConnectionEpoch() -> UInt64 {
+        listenerLock.withLock { connectionEpoch }
+    }
+
+    private func claimPurchaseUpdateDelivery(
+        transactionId: String,
+        expectedEpoch: UInt64
+    ) -> Bool {
+        listenerLock.withLock {
+            guard isInitialized, connectionEpoch == expectedEpoch else { return false }
+            return deliveredPurchaseUpdateIds.insert(transactionId).inserted
+        }
+    }
+
+    private func deliverRequestPurchaseResultIfNeeded(
+        _ result: OpenIAP.RequestPurchaseResult?,
+        expectedEpoch: UInt64
+    ) async {
+        guard let result else { return }
+        let purchases: [OpenIAP.Purchase]
+        switch result {
+        case .purchase(let purchase):
+            purchases = purchase.map { [$0] } ?? []
+        case .purchases(let values):
+            purchases = values ?? []
+        }
+
+        for purchase in purchases {
+            let rawPayload = OpenIapSerialization.purchase(purchase)
+            guard let transactionId = rawPayload["id"] as? String,
+                  claimPurchaseUpdateDelivery(
+                      transactionId: transactionId,
+                      expectedEpoch: expectedEpoch
+                  ) else { continue }
+            let payload = RnIapHelper.sanitizeDictionary(rawPayload)
+            let nitro = RnIapHelper.convertPurchaseDictionary(payload)
+            await MainActor.run {
+                guard self.isCurrentConnection(expectedEpoch) else { return }
+                self.purchasePayloadById[transactionId] = rawPayload
+                self.sendPurchaseUpdate(nitro, includeDuplicateListeners: false)
+            }
+        }
+    }
+
     private func attachListenersIfNeeded(epoch: UInt64) {
         attachPurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
         attachDuplicatePurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
@@ -1398,6 +1451,13 @@ class HybridRnIap: HybridRnIapSpec {
                 Task { @MainActor in
                     guard self.isCurrentConnection(expectedEpoch) else { return }
                     let rawPayload = OpenIapSerialization.purchase(openIapPurchase)
+                    if let transactionId = rawPayload["id"] as? String,
+                       !self.claimPurchaseUpdateDelivery(
+                           transactionId: transactionId,
+                           expectedEpoch: expectedEpoch
+                       ) {
+                        return
+                    }
                     let payload = RnIapHelper.sanitizeDictionary(rawPayload)
                     RnIapLog.result("purchaseUpdatedListener", payload)
                     if let identifier = rawPayload["id"] as? String {
@@ -1573,6 +1633,7 @@ class HybridRnIap: HybridRnIapSpec {
             subscriptionBillingIssueListeners.removeAll()
             lastPurchaseErrorKey = nil
             lastPurchaseErrorTimestamp = 0
+            deliveredPurchaseUpdateIds.removeAll()
             return subscriptions
         }
     }

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -2,15 +2,6 @@ import Foundation
 import NitroModules
 import OpenIAP
 
-func endConnectionThenCleanup(
-    endConnection: () async throws -> Bool,
-    cleanup: () async -> Void
-) async rethrows -> Bool {
-    let result = try await endConnection()
-    await cleanup()
-    return result
-}
-
 @available(iOS 15.0, macOS 14.0, tvOS 15.0, watchOS 8.0, *)
 class HybridRnIap: HybridRnIapSpec {
     private enum PurchaseUpdatedListenerBucket {
@@ -45,6 +36,7 @@ class HybridRnIap: HybridRnIapSpec {
     private var lastPurchaseErrorTimestamp: TimeInterval = 0
     private var purchasePayloadById: [String: [String: Any]] = [:]
     private var deliveredPurchaseUpdateIds = Set<String>()
+    private var pendingDuplicatePurchaseUpdateSuppressions = Set<String>()
     // Thread safety lock for listener arrays and error dedup state
     private let listenerLock = NSLock()
     private let lifecycleLock = NSLock()
@@ -123,25 +115,28 @@ class HybridRnIap: HybridRnIapSpec {
     }
 
     func endConnection() throws -> Promise<Bool> {
+        let operation = enqueueEndOperation {
+            try await OpenIapModule.shared.endConnection()
+        }
+        return Promise.async { try await operation.value }
+    }
+
+    func enqueueEndOperation(
+        _ endConnection: @escaping () async throws -> Bool
+    ) -> Task<Bool, Error> {
         let operation = enqueueLifecycleOperation {
             RnIapLog.payload("endConnection", nil)
-            let result = try await endConnectionThenCleanup(
-                endConnection: {
-                    try await OpenIapModule.shared.endConnection()
-                },
-                cleanup: {
-                    let subscriptions = self.detachConnectionState()
-                    self.removeSubscriptions(subscriptions)
-                    await MainActor.run {
-                        self.productTypeBySku.removeAll()
-                        self.purchasePayloadById.removeAll()
-                    }
-                }
-            )
+            let result = try await endConnection()
+            let subscriptions = self.detachConnectionState()
+            self.removeSubscriptions(subscriptions)
+            await MainActor.run {
+                self.productTypeBySku.removeAll()
+                self.purchasePayloadById.removeAll()
+            }
             RnIapLog.result("endConnection", result)
             return result
         }
-        return Promise.async { try await operation.value }
+        return operation
     }
     
     func fetchProducts(skus: [String], type: String) throws -> Promise<[NitroProduct]> {
@@ -291,16 +286,8 @@ class HybridRnIap: HybridRnIapSpec {
                     "requestPurchase.native", iosPayload
                 )
 
-                let result = try await self.runConnectedOperation {
-                    let epoch = self.currentConnectionEpoch()
-                    let result = try await OpenIapModule.shared.requestPurchase(props)
-                    // OpenIAP posts listener callbacks asynchronously. Deliver the
-                    // returned purchase before teardown can detach this bridge.
-                    await self.deliverRequestPurchaseResultIfNeeded(
-                        result,
-                        expectedEpoch: epoch
-                    )
-                    return result
+                let result = try await self.runRequestPurchaseOperation {
+                    try await OpenIapModule.shared.requestPurchase(props)
                 }
                 if result != nil {
                     RnIapLog.result("requestPurchase", "delegated to OpenIAP")
@@ -311,8 +298,6 @@ class HybridRnIap: HybridRnIapSpec {
                 return defaultResult
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("requestPurchase", error: purchaseError)
-                // OpenIAP already publishes purchaseError events for PurchaseError instances.
-                // Avoid emitting a duplicate event back to JS; simply return.
                 return defaultResult
             } catch let connectionError as OpenIapException {
                 RnIapLog.failure("requestPurchase", error: connectionError)
@@ -1323,8 +1308,27 @@ class HybridRnIap: HybridRnIapSpec {
         return try await enqueueConnectedOperation(operation).value
     }
 
-    private func currentConnectionEpoch() -> UInt64 {
+    func currentConnectionEpoch() -> UInt64 {
         listenerLock.withLock { connectionEpoch }
+    }
+
+    func runRequestPurchaseOperation(
+        _ operation: @escaping () async throws -> OpenIAP.RequestPurchaseResult?
+    ) async throws -> OpenIAP.RequestPurchaseResult? {
+        try await runConnectedOperation {
+            let epoch = self.currentConnectionEpoch()
+            do {
+                let result = try await operation()
+                await self.deliverRequestPurchaseResultIfNeeded(
+                    result,
+                    expectedEpoch: epoch
+                )
+                return result
+            } catch let purchaseError as PurchaseError {
+                self.deliverRequestPurchaseError(purchaseError)
+                throw purchaseError
+            }
+        }
     }
 
     private func claimPurchaseUpdateDelivery(
@@ -1334,6 +1338,36 @@ class HybridRnIap: HybridRnIapSpec {
         listenerLock.withLock {
             guard isInitialized, connectionEpoch == expectedEpoch else { return false }
             return deliveredPurchaseUpdateIds.insert(transactionId).inserted
+        }
+    }
+
+    private func claimRequestPurchaseDelivery(
+        transactionId: String,
+        expectedEpoch: UInt64
+    ) -> (deduping: Bool, nonDeduping: Bool) {
+        listenerLock.withLock {
+            guard isInitialized, connectionEpoch == expectedEpoch else {
+                return (false, false)
+            }
+            let deduping = deliveredPurchaseUpdateIds.insert(transactionId).inserted
+            let nonDeduping = !purchaseUpdatedDuplicateListeners.isEmpty
+            if nonDeduping {
+                pendingDuplicatePurchaseUpdateSuppressions.insert(transactionId)
+            }
+            return (deduping, nonDeduping)
+        }
+    }
+
+    private func claimDuplicatePurchaseUpdateDelivery(
+        transactionId: String,
+        expectedEpoch: UInt64
+    ) -> Bool {
+        listenerLock.withLock {
+            guard isInitialized, connectionEpoch == expectedEpoch else { return false }
+            if pendingDuplicatePurchaseUpdateSuppressions.remove(transactionId) != nil {
+                return false
+            }
+            return true
         }
     }
 
@@ -1352,19 +1386,103 @@ class HybridRnIap: HybridRnIapSpec {
 
         for purchase in purchases {
             let rawPayload = OpenIapSerialization.purchase(purchase)
-            guard let transactionId = rawPayload["id"] as? String,
-                  claimPurchaseUpdateDelivery(
-                      transactionId: transactionId,
-                      expectedEpoch: expectedEpoch
-                  ) else { continue }
+            guard let transactionId = rawPayload["id"] as? String else { continue }
+            let delivery = claimRequestPurchaseDelivery(
+                transactionId: transactionId,
+                expectedEpoch: expectedEpoch
+            )
+            guard delivery.deduping || delivery.nonDeduping else { continue }
             let payload = RnIapHelper.sanitizeDictionary(rawPayload)
             let nitro = RnIapHelper.convertPurchaseDictionary(payload)
             await MainActor.run {
                 guard self.isCurrentConnection(expectedEpoch) else { return }
                 self.purchasePayloadById[transactionId] = rawPayload
-                self.sendPurchaseUpdate(nitro, includeDuplicateListeners: false)
+                if delivery.deduping {
+                    self.sendPurchaseUpdate(nitro, includeDuplicateListeners: false)
+                }
+                if delivery.nonDeduping {
+                    self.sendPurchaseUpdate(nitro, includeDuplicateListeners: true)
+                }
             }
         }
+    }
+
+    private func deliverPurchaseUpdateIfNeeded(
+        _ purchase: OpenIAP.Purchase,
+        expectedEpoch: UInt64
+    ) async {
+        let rawPayload = OpenIapSerialization.purchase(purchase)
+        if let transactionId = rawPayload["id"] as? String,
+           !claimPurchaseUpdateDelivery(
+               transactionId: transactionId,
+               expectedEpoch: expectedEpoch
+           ) {
+            return
+        }
+        let payload = RnIapHelper.sanitizeDictionary(rawPayload)
+        let nitro = RnIapHelper.convertPurchaseDictionary(payload)
+        await MainActor.run {
+            guard self.isCurrentConnection(expectedEpoch) else { return }
+            RnIapLog.result("purchaseUpdatedListener", payload)
+            if let transactionId = rawPayload["id"] as? String {
+                self.purchasePayloadById[transactionId] = rawPayload
+            }
+            self.sendPurchaseUpdate(nitro, includeDuplicateListeners: false)
+        }
+    }
+
+    private func deliverDuplicatePurchaseUpdateIfNeeded(
+        _ purchase: OpenIAP.Purchase,
+        expectedEpoch: UInt64
+    ) async {
+        let rawPayload = OpenIapSerialization.purchase(purchase)
+        if let transactionId = rawPayload["id"] as? String,
+           !claimDuplicatePurchaseUpdateDelivery(
+               transactionId: transactionId,
+               expectedEpoch: expectedEpoch
+           ) {
+            return
+        }
+        let payload = RnIapHelper.sanitizeDictionary(rawPayload)
+        let nitro = RnIapHelper.convertPurchaseDictionary(payload)
+        await MainActor.run {
+            guard self.isCurrentConnection(expectedEpoch) else { return }
+            RnIapLog.result("purchaseUpdatedListener.duplicates", payload)
+            if let transactionId = rawPayload["id"] as? String {
+                self.purchasePayloadById[transactionId] = rawPayload
+            }
+            self.sendPurchaseUpdate(nitro, includeDuplicateListeners: true)
+        }
+    }
+
+    func enqueuePurchaseUpdateDelivery(
+        _ purchase: OpenIAP.Purchase,
+        expectedEpoch: UInt64,
+        includeDuplicateListeners: Bool
+    ) -> Task<Void, Error> {
+        enqueueConnectedOperation {
+            if includeDuplicateListeners {
+                await self.deliverDuplicatePurchaseUpdateIfNeeded(
+                    purchase,
+                    expectedEpoch: expectedEpoch
+                )
+            } else {
+                await self.deliverPurchaseUpdateIfNeeded(
+                    purchase,
+                    expectedEpoch: expectedEpoch
+                )
+            }
+        }
+    }
+
+    private func deliverRequestPurchaseError(_ error: PurchaseError) {
+        let result = RnIapHelper.makePurchaseErrorResult(
+            code: error.code,
+            message: error.message,
+            error.productId,
+            debugMessage: error.debugMessage
+        )
+        sendPurchaseError(result, productId: error.productId)
     }
 
     private func attachListenersIfNeeded(epoch: UInt64) {
@@ -1386,17 +1504,23 @@ class HybridRnIap: HybridRnIapSpec {
                     RnIapLog.warn("purchaseErrorListener: HybridRnIap deallocated, error event dropped")
                     return
                 }
-                Task { @MainActor in
+                let operation = self.enqueueConnectedOperation {
                     guard self.isCurrentConnection(expectedEpoch) else { return }
                     let payload = RnIapHelper.sanitizeDictionary(OpenIapSerialization.encode(error))
-                    RnIapLog.result("purchaseErrorListener", payload)
                     let nitroError = RnIapHelper.makePurchaseErrorResult(
                         code: error.code,
                         message: error.message,
                         error.productId,
                         debugMessage: error.debugMessage
                     )
-                    self.sendPurchaseError(nitroError, productId: error.productId)
+                    await MainActor.run {
+                        guard self.isCurrentConnection(expectedEpoch) else { return }
+                        RnIapLog.result("purchaseErrorListener", payload)
+                        self.sendPurchaseError(nitroError, productId: error.productId)
+                    }
+                }
+                Task {
+                    _ = try? await operation.value
                 }
             }
             RnIapLog.result("purchaseErrorListener.register", "attached")
@@ -1459,23 +1583,13 @@ class HybridRnIap: HybridRnIapSpec {
                     RnIapLog.warn("purchaseUpdatedListener: HybridRnIap deallocated, purchase event dropped")
                     return
                 }
-                Task { @MainActor in
-                    guard self.isCurrentConnection(expectedEpoch) else { return }
-                    let rawPayload = OpenIapSerialization.purchase(openIapPurchase)
-                    if let transactionId = rawPayload["id"] as? String,
-                       !self.claimPurchaseUpdateDelivery(
-                           transactionId: transactionId,
-                           expectedEpoch: expectedEpoch
-                       ) {
-                        return
-                    }
-                    let payload = RnIapHelper.sanitizeDictionary(rawPayload)
-                    RnIapLog.result("purchaseUpdatedListener", payload)
-                    if let identifier = rawPayload["id"] as? String {
-                        self.purchasePayloadById[identifier] = rawPayload
-                    }
-                    let nitro = RnIapHelper.convertPurchaseDictionary(payload)
-                    self.sendPurchaseUpdate(nitro, includeDuplicateListeners: false)
+                let operation = self.enqueuePurchaseUpdateDelivery(
+                    openIapPurchase,
+                    expectedEpoch: expectedEpoch,
+                    includeDuplicateListeners: false
+                )
+                Task {
+                    _ = try? await operation.value
                 }
             }
             RnIapLog.result("purchaseUpdatedListener.register", "attached")
@@ -1497,16 +1611,13 @@ class HybridRnIap: HybridRnIapSpec {
                     RnIapLog.warn("purchaseUpdatedListener: HybridRnIap deallocated, non-deduping purchase event dropped")
                     return
                 }
-                Task { @MainActor in
-                    guard self.isCurrentConnection(expectedEpoch) else { return }
-                    let rawPayload = OpenIapSerialization.purchase(openIapPurchase)
-                    let payload = RnIapHelper.sanitizeDictionary(rawPayload)
-                    RnIapLog.result("purchaseUpdatedListener.duplicates", payload)
-                    if let identifier = rawPayload["id"] as? String {
-                        self.purchasePayloadById[identifier] = rawPayload
-                    }
-                    let nitro = RnIapHelper.convertPurchaseDictionary(payload)
-                    self.sendPurchaseUpdate(nitro, includeDuplicateListeners: true)
+                let operation = self.enqueuePurchaseUpdateDelivery(
+                    openIapPurchase,
+                    expectedEpoch: expectedEpoch,
+                    includeDuplicateListeners: true
+                )
+                Task {
+                    _ = try? await operation.value
                 }
             }, options: options)
             RnIapLog.result("purchaseUpdatedListener.register.duplicates", "attached")
@@ -1569,17 +1680,17 @@ class HybridRnIap: HybridRnIapSpec {
         let currentKey = RnIapHelper.makeErrorDedupKey(code: error.code, productId: dedupIdentifier)
 
         // Protect error dedup state since sendPurchaseError is called from multiple threads
-        let shouldSkip: Bool = listenerLock.withLock {
+        let snapshot: [(NitroPurchaseResult) -> Void]? = listenerLock.withLock {
             let now = Date().timeIntervalSince1970
             let withinWindow = (now - lastPurchaseErrorTimestamp) < 0.15
             if currentKey == lastPurchaseErrorKey && withinWindow {
-                return true
+                return nil
             }
             lastPurchaseErrorKey = currentKey
             lastPurchaseErrorTimestamp = now
-            return false
+            return Array(purchaseErrorListeners)
         }
-        if shouldSkip { return }
+        guard let snapshot else { return }
 
         // Ensure we never leak SKU via purchaseToken
         let sanitized: NitroPurchaseResult
@@ -1599,7 +1710,6 @@ class HybridRnIap: HybridRnIapSpec {
         } else {
             sanitized = error
         }
-        let snapshot = listenerLock.withLock { Array(purchaseErrorListeners) }
         for listener in snapshot {
             listener(sanitized)
         }
@@ -1645,6 +1755,7 @@ class HybridRnIap: HybridRnIapSpec {
             lastPurchaseErrorKey = nil
             lastPurchaseErrorTimestamp = 0
             deliveredPurchaseUpdateIds.removeAll()
+            pendingDuplicatePurchaseUpdateSuppressions.removeAll()
             return subscriptions
         }
     }

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -134,7 +134,6 @@ class HybridRnIap: HybridRnIapSpec {
     
     func fetchProducts(skus: [String], type: String) throws -> Promise<[NitroProduct]> {
         return Promise.async {
-            try await self.ensureConnection()
             RnIapLog.payload("fetchProducts", [
                 "skus": skus,
                 "type": type
@@ -144,7 +143,6 @@ class HybridRnIap: HybridRnIapSpec {
                 throw OpenIapException.make(code: .emptySkuList)
             }
 
-            var productsById: [String: NitroProduct] = [:]
             let normalizedType = type.lowercased()
             let queryTypes: [ProductQueryType]
             if normalizedType == "all" {
@@ -153,21 +151,27 @@ class HybridRnIap: HybridRnIapSpec {
                 queryTypes = [RnIapHelper.parseProductQueryType(type)]
             }
 
-            for queryType in queryTypes {
-                let request = try OpenIapSerialization.productRequest(skus: skus, type: queryType)
-                RnIapLog.payload(
-                    "fetchProducts.native", [
-                        "skus": skus,
-                        "type": queryType.rawValue
-                    ]
-                )
-                let result = try await OpenIapModule.shared.fetchProducts(request)
-                let payloads = RnIapHelper.sanitizeArray(OpenIapSerialization.products(result))
-                RnIapLog.result("fetchProducts.native", payloads)
-                for payload in payloads {
-                    let nitroProduct = RnIapHelper.convertProductDictionary(payload)
-                    productsById[nitroProduct.id] = nitroProduct
+            let productsById = try await self.runConnectedOperation {
+                var fetched: [String: NitroProduct] = [:]
+                for queryType in queryTypes {
+                    let request = try OpenIapSerialization.productRequest(skus: skus, type: queryType)
+                    RnIapLog.payload(
+                        "fetchProducts.native", [
+                            "skus": skus,
+                            "type": queryType.rawValue
+                        ]
+                    )
+                    let result = try await OpenIapModule.shared.fetchProducts(request)
+                    let payloads = RnIapHelper.sanitizeArray(
+                        OpenIapSerialization.products(result)
+                    )
+                    RnIapLog.result("fetchProducts.native", payloads)
+                    for payload in payloads {
+                        let product = RnIapHelper.convertProductDictionary(payload)
+                        fetched[product.id] = product
+                    }
                 }
+                return fetched
             }
 
             var products: [NitroProduct] = []
@@ -219,18 +223,6 @@ class HybridRnIap: HybridRnIapSpec {
                     message: "No iOS request provided"
                 )
                 self.sendPurchaseError(error, productId: nil)
-                return defaultResult
-            }
-
-            do {
-                try await self.ensureConnection()
-            } catch {
-                let err = RnIapHelper.makePurchaseErrorResult(
-                    code: .initConnection,
-                    message: "IAP store connection not initialized",
-                    iosRequest.sku
-                )
-                self.sendPurchaseError(err, productId: iosRequest.sku)
                 return defaultResult
             }
 
@@ -287,7 +279,9 @@ class HybridRnIap: HybridRnIapSpec {
                     "requestPurchase.native", iosPayload
                 )
 
-                let result = try await OpenIapModule.shared.requestPurchase(props)
+                let result = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.requestPurchase(props)
+                }
                 if result != nil {
                     RnIapLog.result("requestPurchase", "delegated to OpenIAP")
                 } else {
@@ -299,6 +293,15 @@ class HybridRnIap: HybridRnIapSpec {
                 RnIapLog.failure("requestPurchase", error: purchaseError)
                 // OpenIAP already publishes purchaseError events for PurchaseError instances.
                 // Avoid emitting a duplicate event back to JS; simply return.
+                return defaultResult
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("requestPurchase", error: connectionError)
+                let err = RnIapHelper.makePurchaseErrorResult(
+                    code: .initConnection,
+                    message: "IAP store connection ended before the purchase started",
+                    iosRequest.sku
+                )
+                self.sendPurchaseError(err, productId: iosRequest.sku)
                 return defaultResult
             } catch {
                 RnIapLog.failure("requestPurchase", error: error)
@@ -315,7 +318,6 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getAvailablePurchases(options: NitroAvailablePurchasesOptions?) throws -> Promise<[NitroPurchase]> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 // Unwrap Variant ios options
                 let iosOpts: NitroAvailablePurchasesIosOptions?
@@ -339,13 +341,18 @@ class HybridRnIap: HybridRnIapSpec {
                 ]
                 let purchaseOptions = try OpenIapSerialization.purchaseOptions(from: optionsDictionary)
                 RnIapLog.payload("getAvailablePurchases", optionsDictionary)
-                let purchases = try await OpenIapModule.shared.getAvailablePurchases(purchaseOptions)
+                let purchases = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getAvailablePurchases(purchaseOptions)
+                }
                 let payloads = RnIapHelper.sanitizeArray(try RnIapHelper.purchasesRequired(purchases))
                 RnIapLog.result("getAvailablePurchases", payloads)
                 return payloads.map { RnIapHelper.convertPurchaseDictionary($0) }
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getAvailablePurchases", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getAvailablePurchases", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getAvailablePurchases", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -355,11 +362,12 @@ class HybridRnIap: HybridRnIapSpec {
 
     func getActiveSubscriptions(subscriptionIds: [String]?) throws -> Promise<[NitroActiveSubscription]> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getActiveSubscriptions", subscriptionIds ?? [])
                 // Call OpenIAP's native getActiveSubscriptions - includes renewalInfoIOS!
-                let subscriptions = try await OpenIapModule.shared.getActiveSubscriptions(subscriptionIds)
+                let subscriptions = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getActiveSubscriptions(subscriptionIds)
+                }
                 let payloads = RnIapHelper.sanitizeArray(
                     try subscriptions.map { try RnIapHelper.encodeRequired($0) }
                 )
@@ -368,6 +376,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getActiveSubscriptions", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getActiveSubscriptions", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getActiveSubscriptions", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -377,15 +388,19 @@ class HybridRnIap: HybridRnIapSpec {
 
     func hasActiveSubscriptions(subscriptionIds: [String]?) throws -> Promise<Bool> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("hasActiveSubscriptions", subscriptionIds ?? [])
-                let hasActive = try await OpenIapModule.shared.hasActiveSubscriptions(subscriptionIds)
+                let hasActive = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.hasActiveSubscriptions(subscriptionIds)
+                }
                 RnIapLog.result("hasActiveSubscriptions", hasActive)
                 return hasActive
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("hasActiveSubscriptions", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("hasActiveSubscriptions", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("hasActiveSubscriptions", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -396,7 +411,6 @@ class HybridRnIap: HybridRnIapSpec {
     func finishTransaction(params: NitroFinishTransactionParams) throws -> Promise<Variant_Bool_NitroPurchaseResult> {
         return Promise.async {
             guard case .second(let iosParams) = params.ios else { return .first(true) }
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload(
                     "finishTransaction", ["transactionId": iosParams.transactionId]
@@ -414,7 +428,12 @@ class HybridRnIap: HybridRnIapSpec {
                 let sanitizedPayload = RnIapHelper.sanitizeDictionary(purchasePayload)
                 RnIapLog.payload("finishTransaction.nativePayload", sanitizedPayload)
                 let purchaseInput = try OpenIapSerialization.purchaseInput(from: purchasePayload)
-                _ = try await OpenIapModule.shared.finishTransaction(purchase: purchaseInput, isConsumable: nil)
+                _ = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.finishTransaction(
+                        purchase: purchaseInput,
+                        isConsumable: nil
+                    )
+                }
                 RnIapLog.result("finishTransaction", true)
                 _ = await MainActor.run {
                     self.purchasePayloadById.removeValue(forKey: iosParams.transactionId)
@@ -444,7 +463,9 @@ class HybridRnIap: HybridRnIapSpec {
 
                 RnIapLog.payload("verifyPurchase", ["sku": sku])
                 let props = try OpenIapSerialization.verifyPurchaseProps(from: ["apple": ["sku": sku]])
-                let verifyResult = try await OpenIapModule.shared.verifyPurchase(props)
+                let verifyResult = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.verifyPurchase(props)
+                }
                 guard case let .verifyPurchaseResultIos(result) = verifyResult else {
                     throw OpenIapException.make(code: .featureNotSupported, message: "Expected iOS validation result")
                 }
@@ -471,6 +492,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("verifyPurchase", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("verifyPurchase", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("verifyPurchase", error: error)
                 throw OpenIapException.make(code: .purchaseVerificationFailed, message: error.localizedDescription)
@@ -525,7 +549,9 @@ class HybridRnIap: HybridRnIapSpec {
                 // Use JSONSerialization + JSONDecoder like expo-iap does
                 let jsonData = try JSONSerialization.data(withJSONObject: propsDict)
                 let props = try JSONDecoder().decode(VerifyPurchaseWithProviderProps.self, from: jsonData)
-                let result = try await OpenIapModule.shared.verifyPurchaseWithProvider(props)
+                let result = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.verifyPurchaseWithProvider(props)
+                }
                 RnIapLog.result("verifyPurchaseWithProvider", ["provider": result.provider, "hasIapkit": result.iapkit != nil])
                 // Convert result to Nitro types
                 var nitroIapkitResult: NitroVerifyPurchaseWithIapkitResult? = nil
@@ -571,6 +597,9 @@ class HybridRnIap: HybridRnIapSpec {
                 // Convert PurchaseError to OpenIapException to preserve message through Nitro bridge
                 RnIapLog.failure("verifyPurchaseWithProvider", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("verifyPurchaseWithProvider", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("verifyPurchaseWithProvider", error: error)
                 throw OpenIapException.make(code: .purchaseVerificationFailed, message: error.localizedDescription)
@@ -582,12 +611,17 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async {
             do {
                 RnIapLog.payload("getStorefront", nil)
-                let storefront = try await OpenIapModule.shared.getStorefront()
+                let storefront = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getStorefront()
+                }
                 RnIapLog.result("getStorefront", storefront)
                 return storefront
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getStorefront", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getStorefront", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getStorefront", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -601,7 +635,10 @@ class HybridRnIap: HybridRnIapSpec {
             do {
                 RnIapLog.payload("getAppTransactionIOS", nil)
                 if #available(iOS 16.0, *) {
-                    if let appTx = try await OpenIapModule.shared.getAppTransactionIOS() {
+                    let appTx = try await self.runConnectedOperation {
+                        try await OpenIapModule.shared.getAppTransactionIOS()
+                    }
+                    if let appTx {
                         var result: [String: Any?] = [
                             "bundleId": appTx.bundleId,
                             "appVersion": appTx.appVersion,
@@ -634,6 +671,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getAppTransactionIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getAppTransactionIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getAppTransactionIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -643,10 +683,12 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getPromotedProductIOS() throws -> Promise<Variant_NullType_NitroProduct> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getPromotedProductIOS", nil)
-                guard let product = try await OpenIapModule.shared.getPromotedProductIOS() else {
+                let product = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getPromotedProductIOS()
+                }
+                guard let product else {
                     RnIapLog.result("getPromotedProductIOS", nil)
                     return .first(.null)
                 }
@@ -656,6 +698,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getPromotedProductIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getPromotedProductIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getPromotedProductIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -665,10 +710,12 @@ class HybridRnIap: HybridRnIapSpec {
 
     func presentCodeRedemptionSheetIOS() throws -> Promise<Variant_NullType_NitroPurchase> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("presentCodeRedemptionSheetIOS", nil)
-                guard let purchase = try await OpenIapModule.shared.presentCodeRedemptionSheetIOS() else {
+                let purchase = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.presentCodeRedemptionSheetIOS()
+                }
+                guard let purchase else {
                     RnIapLog.result("presentCodeRedemptionSheetIOS", nil)
                     return .first(.null)
                 }
@@ -681,6 +728,9 @@ class HybridRnIap: HybridRnIapSpec {
                     }
                 }
                 return .second(RnIapHelper.convertPurchaseDictionary(payload))
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("presentCodeRedemptionSheetIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("presentCodeRedemptionSheetIOS", error: error)
                 throw OpenIapException.make(
@@ -694,7 +744,9 @@ class HybridRnIap: HybridRnIapSpec {
     func clearTransactionIOS() throws -> Promise<Void> {
         return Promise.async {
             RnIapLog.payload("clearTransactionIOS", nil)
-            let ok = try await OpenIapModule.shared.clearTransactionIOS()
+            let ok = try await self.runConnectedOperation {
+                try await OpenIapModule.shared.clearTransactionIOS()
+            }
             RnIapLog.result("clearTransactionIOS", ok)
         }
     }
@@ -703,10 +755,11 @@ class HybridRnIap: HybridRnIapSpec {
     
     func subscriptionStatusIOS(sku: String) throws -> Promise<Variant_NullType__NitroSubscriptionStatus_> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("subscriptionStatusIOS", ["sku": sku])
-                let statuses = try await OpenIapModule.shared.subscriptionStatusIOS(sku: sku)
+                let statuses = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.subscriptionStatusIOS(sku: sku)
+                }
                 let payloads = statuses.map { RnIapHelper.sanitizeDictionary(OpenIapSerialization.encode($0)) }
                 RnIapLog.result("subscriptionStatusIOS", payloads)
                 let result: [NitroSubscriptionStatus] = payloads.map { payload in
@@ -733,6 +786,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("subscriptionStatusIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("subscriptionStatusIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("subscriptionStatusIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -742,10 +798,11 @@ class HybridRnIap: HybridRnIapSpec {
     
     func currentEntitlementIOS(sku: String) throws -> Promise<Variant_NullType_NitroPurchase> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("currentEntitlementIOS", ["sku": sku])
-                let purchase = try await OpenIapModule.shared.currentEntitlementIOS(sku: sku)
+                let purchase = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.currentEntitlementIOS(sku: sku)
+                }
                 if let purchase {
                     let raw = OpenIapSerialization.encode(purchase)
                     let payload = RnIapHelper.sanitizeDictionary(raw)
@@ -762,6 +819,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("currentEntitlementIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("currentEntitlementIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("currentEntitlementIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -771,10 +831,11 @@ class HybridRnIap: HybridRnIapSpec {
 
     func latestTransactionIOS(sku: String) throws -> Promise<Variant_NullType_NitroPurchase> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("latestTransactionIOS", ["sku": sku])
-                let purchase = try await OpenIapModule.shared.latestTransactionIOS(sku: sku)
+                let purchase = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.latestTransactionIOS(sku: sku)
+                }
                 if let purchase {
                     let raw = OpenIapSerialization.encode(purchase)
                     let payload = RnIapHelper.sanitizeDictionary(raw)
@@ -791,6 +852,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("latestTransactionIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("latestTransactionIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("latestTransactionIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -802,7 +866,9 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async {
             do {
                 RnIapLog.payload("getPendingTransactionsIOS", nil)
-                let pending = try await OpenIapModule.shared.getPendingTransactionsIOS()
+                let pending = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getPendingTransactionsIOS()
+                }
                 var unionPurchases: [OpenIAP.Purchase] = []
                 for purchase in pending {
                     let union = OpenIAP.Purchase.purchaseIos(purchase)
@@ -820,6 +886,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getPendingTransactionsIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getPendingTransactionsIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getPendingTransactionsIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -831,7 +900,9 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async {
             do {
                 RnIapLog.payload("getAllTransactionsIOS", nil)
-                let all = try await OpenIapModule.shared.getAllTransactionsIOS()
+                let all = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getAllTransactionsIOS()
+                }
                 var unionPurchases: [OpenIAP.Purchase] = []
                 var payloadUpdates: [String: [String: Any]] = [:]
                 for purchase in all {
@@ -854,6 +925,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getAllTransactionsIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getAllTransactionsIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getAllTransactionsIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -865,12 +939,17 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async {
             do {
                 RnIapLog.payload("syncIOS", nil)
-                let ok = try await OpenIapModule.shared.syncIOS()
+                let ok = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.syncIOS()
+                }
                 RnIapLog.result("syncIOS", ok)
                 return ok
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("syncIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("syncIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("syncIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -880,10 +959,11 @@ class HybridRnIap: HybridRnIapSpec {
 
     func showManageSubscriptionsIOS() throws -> Promise<[NitroPurchase]> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("showManageSubscriptionsIOS", nil)
-                let changedPurchases = try await OpenIapModule.shared.showManageSubscriptionsIOS()
+                let changedPurchases = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.showManageSubscriptionsIOS()
+                }
                 let unionPurchases = changedPurchases.map { OpenIAP.Purchase.purchaseIos($0) }
                 let payloads = RnIapHelper.sanitizeArray(try RnIapHelper.purchasesRequired(unionPurchases))
                 RnIapLog.result("showManageSubscriptionsIOS", payloads)
@@ -891,6 +971,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("showManageSubscriptionsIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("showManageSubscriptionsIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("showManageSubscriptionsIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -900,15 +983,19 @@ class HybridRnIap: HybridRnIapSpec {
 
     func deepLinkToSubscriptionsIOS() throws -> Promise<Bool> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("deepLinkToSubscriptionsIOS", nil)
-                try await OpenIapModule.shared.deepLinkToSubscriptions(nil)
+                try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.deepLinkToSubscriptions(nil)
+                }
                 RnIapLog.result("deepLinkToSubscriptionsIOS", true)
                 return true
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("deepLinkToSubscriptionsIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("deepLinkToSubscriptionsIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("deepLinkToSubscriptionsIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -919,7 +1006,9 @@ class HybridRnIap: HybridRnIapSpec {
     func isEligibleForIntroOfferIOS(groupID: String) throws -> Promise<Bool> {
         return Promise.async {
             RnIapLog.payload("isEligibleForIntroOfferIOS", ["groupID": groupID])
-            let value = try await OpenIapModule.shared.isEligibleForIntroOfferIOS(groupID: groupID)
+            let value = try await self.runConnectedOperation {
+                try await OpenIapModule.shared.isEligibleForIntroOfferIOS(groupID: groupID)
+            }
             RnIapLog.result("isEligibleForIntroOfferIOS", value)
             return value
         }
@@ -927,15 +1016,19 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getReceiptDataIOS() throws -> Promise<String> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getReceiptDataIOS", nil)
-                let receipt = try await RnIapHelper.loadReceiptData(refresh: false)
+                let receipt = try await self.runConnectedOperation {
+                    try await RnIapHelper.loadReceiptData(refresh: false)
+                }
                 RnIapLog.result("getReceiptDataIOS", "<receipt>")
                 return receipt
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getReceiptDataIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getReceiptDataIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getReceiptDataIOS", error: error)
                 throw OpenIapException.make(code: .purchaseVerificationFailed, message: error.localizedDescription)
@@ -945,15 +1038,19 @@ class HybridRnIap: HybridRnIapSpec {
 
     func requestReceiptRefreshIOS() throws -> Promise<String> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("requestReceiptRefreshIOS", nil)
-                let receipt = try await RnIapHelper.loadReceiptData(refresh: true)
+                let receipt = try await self.runConnectedOperation {
+                    try await RnIapHelper.loadReceiptData(refresh: true)
+                }
                 RnIapLog.result("requestReceiptRefreshIOS", "<receipt>")
                 return receipt
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("requestReceiptRefreshIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("requestReceiptRefreshIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("requestReceiptRefreshIOS", error: error)
                 throw OpenIapException.make(code: .purchaseVerificationFailed, message: error.localizedDescription)
@@ -963,9 +1060,10 @@ class HybridRnIap: HybridRnIapSpec {
 
     func isTransactionVerifiedIOS(sku: String) throws -> Promise<Bool> {
         return Promise.async {
-            try await self.ensureConnection()
             RnIapLog.payload("isTransactionVerifiedIOS", ["sku": sku])
-            let value = try await OpenIapModule.shared.isTransactionVerifiedIOS(sku: sku)
+            let value = try await self.runConnectedOperation {
+                try await OpenIapModule.shared.isTransactionVerifiedIOS(sku: sku)
+            }
             RnIapLog.result("isTransactionVerifiedIOS", value)
             return value
         }
@@ -973,10 +1071,11 @@ class HybridRnIap: HybridRnIapSpec {
     
     func getTransactionJwsIOS(sku: String) throws -> Promise<Variant_NullType_String> {
         return Promise.async {
-            try await self.ensureConnection()
             do {
                 RnIapLog.payload("getTransactionJwsIOS", ["sku": sku])
-                let jws = try await OpenIapModule.shared.getTransactionJwsIOS(sku: sku)
+                let jws = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getTransactionJwsIOS(sku: sku)
+                }
                 let maskedJws: Any? = (jws == nil) ? nil : "<jws>"
                 RnIapLog.result("getTransactionJwsIOS", maskedJws)
                 if let jws {
@@ -986,6 +1085,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getTransactionJwsIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getTransactionJwsIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getTransactionJwsIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -997,7 +1099,9 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async {
             do {
                 RnIapLog.payload("beginRefundRequestIOS", ["sku": sku])
-                let result = try await OpenIapModule.shared.beginRefundRequestIOS(sku: sku)
+                let result = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.beginRefundRequestIOS(sku: sku)
+                }
                 RnIapLog.result("beginRefundRequestIOS", result)
                 if let result {
                     return .second(result)
@@ -1006,6 +1110,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("beginRefundRequestIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("beginRefundRequestIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("beginRefundRequestIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -1025,7 +1132,9 @@ class HybridRnIap: HybridRnIapSpec {
         Task {
             guard self.isCurrentConnection(epoch) else { return }
             RnIapLog.payload("promotedProductListenerIOS.fetch", nil)
-            if let product = try? await OpenIapModule.shared.getPromotedProductIOS() {
+            if let product = try? await self.enqueueConnectedOperation({
+                try await OpenIapModule.shared.getPromotedProductIOS()
+            }).value {
                 guard self.isCurrentConnection(epoch) else { return }
                 let payload = RnIapHelper.sanitizeDictionary(OpenIapSerialization.encode(product))
                 RnIapLog.result("promotedProductListenerIOS.fetch", payload)
@@ -1173,6 +1282,27 @@ class HybridRnIap: HybridRnIapSpec {
         }
     }
 
+    func enqueueConnectedOperation<T>(
+        _ operation: @escaping () async throws -> T
+    ) -> Task<T, Error> {
+        enqueueLifecycleOperation {
+            guard self.isConnectionInitialized() else {
+                throw OpenIapException.make(
+                    code: .initConnection,
+                    message: "Connection ended before the store operation started."
+                )
+            }
+            return try await operation()
+        }
+    }
+
+    private func runConnectedOperation<T>(
+        _ operation: @escaping () async throws -> T
+    ) async throws -> T {
+        try await ensureConnection()
+        return try await enqueueConnectedOperation(operation).value
+    }
+
     private func attachListenersIfNeeded(epoch: UInt64) {
         attachPurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
         attachDuplicatePurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
@@ -1225,7 +1355,9 @@ class HybridRnIap: HybridRnIapSpec {
                     RnIapLog.payload("promotedProductListenerIOS", ["productId": productId])
                     do {
                         let request = try OpenIapSerialization.productRequest(skus: [productId], type: .all)
-                        let result = try await OpenIapModule.shared.fetchProducts(request)
+                        let result = try await self.enqueueConnectedOperation {
+                            try await OpenIapModule.shared.fetchProducts(request)
+                        }.value
                         let payloads = RnIapHelper.sanitizeArray(OpenIapSerialization.products(result))
                         RnIapLog.result("fetchProducts", payloads)
                         if let payload = payloads.first {
@@ -1531,14 +1663,18 @@ class HybridRnIap: HybridRnIapSpec {
             RnIapLog.payload("canPresentExternalPurchaseNoticeIOS", nil)
 
             if #available(iOS 16.0, *) {
-                try await self.ensureConnection()
                 do {
-                    let canPresent = try await OpenIapModule.shared.canPresentExternalPurchaseNoticeIOS()
+                    let canPresent = try await self.runConnectedOperation {
+                        try await OpenIapModule.shared.canPresentExternalPurchaseNoticeIOS()
+                    }
                     RnIapLog.result("canPresentExternalPurchaseNoticeIOS", canPresent)
                     return canPresent
                 } catch let purchaseError as PurchaseError {
                     RnIapLog.failure("canPresentExternalPurchaseNoticeIOS", error: purchaseError)
                     throw OpenIapException.from(purchaseError)
+                } catch let connectionError as OpenIapException {
+                    RnIapLog.failure("canPresentExternalPurchaseNoticeIOS", error: connectionError)
+                    throw connectionError
                 } catch {
                     RnIapLog.failure("canPresentExternalPurchaseNoticeIOS", error: error)
                     throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -1556,9 +1692,10 @@ class HybridRnIap: HybridRnIapSpec {
             RnIapLog.payload("presentExternalPurchaseNoticeSheetIOS", nil)
 
             if #available(iOS 16.0, *) {
-                try await self.ensureConnection()
                 do {
-                    let result = try await OpenIapModule.shared.presentExternalPurchaseNoticeSheetIOS()
+                    let result = try await self.runConnectedOperation {
+                        try await OpenIapModule.shared.presentExternalPurchaseNoticeSheetIOS()
+                    }
 
                     // Convert OpenIAP action to Nitro action via raw value
                     let actionString = result.result.rawValue
@@ -1580,6 +1717,9 @@ class HybridRnIap: HybridRnIapSpec {
                 } catch let purchaseError as PurchaseError {
                     RnIapLog.failure("presentExternalPurchaseNoticeSheetIOS", error: purchaseError)
                     throw OpenIapException.from(purchaseError)
+                } catch let connectionError as OpenIapException {
+                    RnIapLog.failure("presentExternalPurchaseNoticeSheetIOS", error: connectionError)
+                    throw connectionError
                 } catch {
                     RnIapLog.failure("presentExternalPurchaseNoticeSheetIOS", error: error)
                     throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -1597,9 +1737,10 @@ class HybridRnIap: HybridRnIapSpec {
             RnIapLog.payload("presentExternalPurchaseLinkIOS", ["url": url])
 
             if #available(iOS 16.0, *) {
-                try await self.ensureConnection()
                 do {
-                    let result = try await OpenIapModule.shared.presentExternalPurchaseLinkIOS(url)
+                    let result = try await self.runConnectedOperation {
+                        try await OpenIapModule.shared.presentExternalPurchaseLinkIOS(url)
+                    }
                     let nitroResult = ExternalPurchaseLinkResultIOS(
                         error: RnIapHelper.wrapString(result.error),
                         success: result.success
@@ -1609,6 +1750,9 @@ class HybridRnIap: HybridRnIapSpec {
                 } catch let purchaseError as PurchaseError {
                     RnIapLog.failure("presentExternalPurchaseLinkIOS", error: purchaseError)
                     throw OpenIapException.from(purchaseError)
+                } catch let connectionError as OpenIapException {
+                    RnIapLog.failure("presentExternalPurchaseLinkIOS", error: connectionError)
+                    throw connectionError
                 } catch {
                     RnIapLog.failure("presentExternalPurchaseLinkIOS", error: error)
                     throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -1627,12 +1771,17 @@ class HybridRnIap: HybridRnIapSpec {
         return Promise.async {
             RnIapLog.payload("isEligibleForExternalPurchaseCustomLinkIOS", nil)
             do {
-                let isEligible = try await OpenIapModule.shared.isEligibleForExternalPurchaseCustomLinkIOS()
+                let isEligible = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.isEligibleForExternalPurchaseCustomLinkIOS()
+                }
                 RnIapLog.result("isEligibleForExternalPurchaseCustomLinkIOS", isEligible)
                 return isEligible
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("isEligibleForExternalPurchaseCustomLinkIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("isEligibleForExternalPurchaseCustomLinkIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("isEligibleForExternalPurchaseCustomLinkIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -1648,7 +1797,9 @@ class HybridRnIap: HybridRnIapSpec {
                 guard let openIapTokenType = OpenIAP.ExternalPurchaseCustomLinkTokenTypeIOS(rawValue: tokenType.stringValue) else {
                     throw OpenIapException.make(code: .developerError, message: "Invalid token type: \(tokenType.stringValue). Must be 'acquisition' or 'services'")
                 }
-                let result = try await OpenIapModule.shared.getExternalPurchaseCustomLinkTokenIOS(openIapTokenType)
+                let result = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.getExternalPurchaseCustomLinkTokenIOS(openIapTokenType)
+                }
                 let nitroResult = ExternalPurchaseCustomLinkTokenResultIOS(
                     error: RnIapHelper.wrapString(result.error),
                     token: RnIapHelper.wrapString(result.token)
@@ -1662,6 +1813,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("getExternalPurchaseCustomLinkTokenIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("getExternalPurchaseCustomLinkTokenIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("getExternalPurchaseCustomLinkTokenIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)
@@ -1684,7 +1838,9 @@ class HybridRnIap: HybridRnIapSpec {
                 } else {
                     throw OpenIapException.make(code: .developerError, message: "Invalid notice type: \(noticeType.stringValue). Must be 'browser'")
                 }
-                let result = try await OpenIapModule.shared.showExternalPurchaseCustomLinkNoticeIOS(openIapNoticeType)
+                let result = try await self.runConnectedOperation {
+                    try await OpenIapModule.shared.showExternalPurchaseCustomLinkNoticeIOS(openIapNoticeType)
+                }
                 let nitroResult = ExternalPurchaseCustomLinkNoticeResultIOS(
                     continued: result.continued,
                     error: RnIapHelper.wrapString(result.error)
@@ -1694,6 +1850,9 @@ class HybridRnIap: HybridRnIapSpec {
             } catch let purchaseError as PurchaseError {
                 RnIapLog.failure("showExternalPurchaseCustomLinkNoticeIOS", error: purchaseError)
                 throw OpenIapException.from(purchaseError)
+            } catch let connectionError as OpenIapException {
+                RnIapLog.failure("showExternalPurchaseCustomLinkNoticeIOS", error: connectionError)
+                throw connectionError
             } catch {
                 RnIapLog.failure("showExternalPurchaseCustomLinkNoticeIOS", error: error)
                 throw OpenIapException.make(code: .serviceError, message: error.localizedDescription)

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -74,7 +74,8 @@ class HybridRnIap: HybridRnIapSpec {
 
     private func enqueueConnect(
         _ configValue: InitConnectionConfig?,
-        reuseExistingConnection: Bool = false
+        reuseExistingConnection: Bool = false,
+        connect: (() async throws -> Bool)? = nil
     ) -> Task<Bool, Error> {
         enqueueLifecycleOperation {
             if reuseExistingConnection, self.isConnectionInitialized() { return true }
@@ -84,7 +85,13 @@ class HybridRnIap: HybridRnIapSpec {
             do {
                 // Note: iOS doesn't support alternative billing config parameter
                 // Config is ignored on iOS platform
-                let ok = try await OpenIapModule.shared.initConnection()
+                self.attachCoreListenersIfNeeded(epoch: epoch)
+                let ok: Bool
+                if let connect {
+                    ok = try await connect()
+                } else {
+                    ok = try await OpenIapModule.shared.initConnection()
+                }
                 RnIapLog.result("initConnection", ok)
                 let isCurrent = self.listenerLock.withLock {
                     guard self.connectionEpoch == epoch else { return false }
@@ -113,6 +120,12 @@ class HybridRnIap: HybridRnIapSpec {
                 return false
             }
         }
+    }
+
+    func enqueueConnectOperation(
+        _ connect: @escaping () async throws -> Bool
+    ) -> Task<Bool, Error> {
+        enqueueConnect(nil, connect: connect)
     }
 
     func endConnection() throws -> Promise<Bool> {
@@ -1520,8 +1533,8 @@ class HybridRnIap: HybridRnIapSpec {
         _ error: PurchaseError,
         expectedEpoch: UInt64
     ) -> Task<Void, Error> {
-        enqueueConnectedOperation {
-            guard self.isCurrentConnection(expectedEpoch),
+        enqueueLifecycleOperation {
+            guard self.isCurrentEpoch(expectedEpoch),
                   !self.consumeRequestPurchaseErrorSuppression(error) else {
                 return
             }
@@ -1533,25 +1546,28 @@ class HybridRnIap: HybridRnIapSpec {
                 debugMessage: error.debugMessage
             )
             await MainActor.run {
-                guard self.isCurrentConnection(expectedEpoch) else { return }
+                guard self.isCurrentEpoch(expectedEpoch) else { return }
                 RnIapLog.result("purchaseErrorListener", payload)
                 self.sendPurchaseError(nitroError, productId: error.productId)
             }
         }
     }
 
-    private func attachListenersIfNeeded(epoch: UInt64) {
+    private func attachCoreListenersIfNeeded(epoch: UInt64) {
         attachPurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
         attachDuplicatePurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
         attachPurchaseErrorSubIfNeeded(expectedEpoch: epoch)
+    }
+
+    private func attachListenersIfNeeded(epoch: UInt64) {
+        attachCoreListenersIfNeeded(epoch: epoch)
         attachPromotedProductSubIfNeeded(expectedEpoch: epoch)
         attachSubscriptionBillingIssueSubIfNeeded(expectedEpoch: epoch)
     }
 
     private func attachPurchaseErrorSubIfNeeded(expectedEpoch: UInt64) {
         listenerLock.withLock {
-            guard isInitialized,
-                  connectionEpoch == expectedEpoch,
+            guard connectionEpoch == expectedEpoch,
                   purchaseErrorSub == nil else { return }
             RnIapLog.payload("purchaseErrorListener.register", nil)
             purchaseErrorSub = OpenIapModule.shared.purchaseErrorListener { [weak self] error in
@@ -1618,8 +1634,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     private func attachPurchaseUpdatedSubIfNeeded(expectedEpoch: UInt64) {
         listenerLock.withLock {
-            guard isInitialized,
-                  connectionEpoch == expectedEpoch,
+            guard connectionEpoch == expectedEpoch,
                   purchaseUpdatedSub == nil else { return }
             RnIapLog.payload("purchaseUpdatedListener.register", nil)
             purchaseUpdatedSub = OpenIapModule.shared.purchaseUpdatedListener { [weak self] openIapPurchase in
@@ -1642,8 +1657,7 @@ class HybridRnIap: HybridRnIapSpec {
 
     private func attachDuplicatePurchaseUpdatedSubIfNeeded(expectedEpoch: UInt64) {
         listenerLock.withLock {
-            guard isInitialized,
-                  connectionEpoch == expectedEpoch,
+            guard connectionEpoch == expectedEpoch,
                   purchaseUpdatedDuplicateSub == nil,
                   !purchaseUpdatedDuplicateListeners.isEmpty else { return }
             RnIapLog.payload("purchaseUpdatedListener.register.duplicates", nil)
@@ -1701,6 +1715,10 @@ class HybridRnIap: HybridRnIapSpec {
 
     private func isCurrentConnection(_ epoch: UInt64) -> Bool {
         listenerLock.withLock { isInitialized && connectionEpoch == epoch }
+    }
+
+    private func isCurrentEpoch(_ epoch: UInt64) -> Bool {
+        listenerLock.withLock { connectionEpoch == epoch }
     }
     
     private func sendPurchaseUpdate(_ purchase: NitroPurchase, includeDuplicateListeners: Bool) {

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -102,7 +102,7 @@ class HybridRnIap: HybridRnIapSpec {
                     self.isInitialized = false
                     return true
                 }
-                if isCurrent {
+                if isCurrent, !reuseExistingConnection {
                     RnIapLog.failure("initConnection", error: error)
                     let err = RnIapHelper.makePurchaseErrorResult(
                         code: .initConnection,

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -36,7 +36,8 @@ class HybridRnIap: HybridRnIapSpec {
     private var lastPurchaseErrorTimestamp: TimeInterval = 0
     private var purchasePayloadById: [String: [String: Any]] = [:]
     private var deliveredPurchaseUpdateIds = Set<String>()
-    private var pendingDuplicatePurchaseUpdateSuppressions = Set<String>()
+    private var pendingDuplicatePurchaseUpdateSuppressions: [String: Int] = [:]
+    private var pendingRequestPurchaseErrorSuppressions: [String: Int] = [:]
     // Thread safety lock for listener arrays and error dedup state
     private let listenerLock = NSLock()
     private let lifecycleLock = NSLock()
@@ -1352,7 +1353,7 @@ class HybridRnIap: HybridRnIapSpec {
             let deduping = deliveredPurchaseUpdateIds.insert(transactionId).inserted
             let nonDeduping = !purchaseUpdatedDuplicateListeners.isEmpty
             if nonDeduping {
-                pendingDuplicatePurchaseUpdateSuppressions.insert(transactionId)
+                pendingDuplicatePurchaseUpdateSuppressions[transactionId, default: 0] += 1
             }
             return (deduping, nonDeduping)
         }
@@ -1364,7 +1365,12 @@ class HybridRnIap: HybridRnIapSpec {
     ) -> Bool {
         listenerLock.withLock {
             guard isInitialized, connectionEpoch == expectedEpoch else { return false }
-            if pendingDuplicatePurchaseUpdateSuppressions.remove(transactionId) != nil {
+            if let count = pendingDuplicatePurchaseUpdateSuppressions[transactionId] {
+                if count == 1 {
+                    pendingDuplicatePurchaseUpdateSuppressions.removeValue(forKey: transactionId)
+                } else {
+                    pendingDuplicatePurchaseUpdateSuppressions[transactionId] = count - 1
+                }
                 return false
             }
             return true
@@ -1482,7 +1488,56 @@ class HybridRnIap: HybridRnIapSpec {
             error.productId,
             debugMessage: error.debugMessage
         )
-        sendPurchaseError(result, productId: error.productId)
+        let key = RnIapHelper.makeErrorDedupKey(
+            code: error.code.rawValue,
+            productId: error.productId
+        )
+        listenerLock.withLock {
+            pendingRequestPurchaseErrorSuppressions[key, default: 0] += 1
+        }
+        sendPurchaseError(result, productId: error.productId, dedupe: false)
+    }
+
+    private func consumeRequestPurchaseErrorSuppression(_ error: PurchaseError) -> Bool {
+        let key = RnIapHelper.makeErrorDedupKey(
+            code: error.code.rawValue,
+            productId: error.productId
+        )
+        return listenerLock.withLock {
+            guard let count = pendingRequestPurchaseErrorSuppressions[key] else {
+                return false
+            }
+            if count == 1 {
+                pendingRequestPurchaseErrorSuppressions.removeValue(forKey: key)
+            } else {
+                pendingRequestPurchaseErrorSuppressions[key] = count - 1
+            }
+            return true
+        }
+    }
+
+    func enqueuePurchaseErrorDelivery(
+        _ error: PurchaseError,
+        expectedEpoch: UInt64
+    ) -> Task<Void, Error> {
+        enqueueConnectedOperation {
+            guard self.isCurrentConnection(expectedEpoch),
+                  !self.consumeRequestPurchaseErrorSuppression(error) else {
+                return
+            }
+            let payload = RnIapHelper.sanitizeDictionary(OpenIapSerialization.encode(error))
+            let nitroError = RnIapHelper.makePurchaseErrorResult(
+                code: error.code,
+                message: error.message,
+                error.productId,
+                debugMessage: error.debugMessage
+            )
+            await MainActor.run {
+                guard self.isCurrentConnection(expectedEpoch) else { return }
+                RnIapLog.result("purchaseErrorListener", payload)
+                self.sendPurchaseError(nitroError, productId: error.productId)
+            }
+        }
     }
 
     private func attachListenersIfNeeded(epoch: UInt64) {
@@ -1504,21 +1559,10 @@ class HybridRnIap: HybridRnIapSpec {
                     RnIapLog.warn("purchaseErrorListener: HybridRnIap deallocated, error event dropped")
                     return
                 }
-                let operation = self.enqueueConnectedOperation {
-                    guard self.isCurrentConnection(expectedEpoch) else { return }
-                    let payload = RnIapHelper.sanitizeDictionary(OpenIapSerialization.encode(error))
-                    let nitroError = RnIapHelper.makePurchaseErrorResult(
-                        code: error.code,
-                        message: error.message,
-                        error.productId,
-                        debugMessage: error.debugMessage
-                    )
-                    await MainActor.run {
-                        guard self.isCurrentConnection(expectedEpoch) else { return }
-                        RnIapLog.result("purchaseErrorListener", payload)
-                        self.sendPurchaseError(nitroError, productId: error.productId)
-                    }
-                }
+                let operation = self.enqueuePurchaseErrorDelivery(
+                    error,
+                    expectedEpoch: expectedEpoch
+                )
                 Task {
                     _ = try? await operation.value
                 }
@@ -1673,7 +1717,11 @@ class HybridRnIap: HybridRnIapSpec {
         }
     }
 
-    private func sendPurchaseError(_ error: NitroPurchaseResult, productId: String? = nil) {
+    private func sendPurchaseError(
+        _ error: NitroPurchaseResult,
+        productId: String? = nil,
+        dedupe: Bool = true
+    ) {
         let dedupIdentifier = productId
             ?? (error.purchaseToken?.isEmpty == false ? error.purchaseToken : nil)
             ?? (error.message.isEmpty ? nil : error.message)
@@ -1681,13 +1729,15 @@ class HybridRnIap: HybridRnIapSpec {
 
         // Protect error dedup state since sendPurchaseError is called from multiple threads
         let snapshot: [(NitroPurchaseResult) -> Void]? = listenerLock.withLock {
-            let now = Date().timeIntervalSince1970
-            let withinWindow = (now - lastPurchaseErrorTimestamp) < 0.15
-            if currentKey == lastPurchaseErrorKey && withinWindow {
-                return nil
+            if dedupe {
+                let now = Date().timeIntervalSince1970
+                let withinWindow = (now - lastPurchaseErrorTimestamp) < 0.15
+                if currentKey == lastPurchaseErrorKey && withinWindow {
+                    return nil
+                }
+                lastPurchaseErrorKey = currentKey
+                lastPurchaseErrorTimestamp = now
             }
-            lastPurchaseErrorKey = currentKey
-            lastPurchaseErrorTimestamp = now
             return Array(purchaseErrorListeners)
         }
         guard let snapshot else { return }
@@ -1756,6 +1806,7 @@ class HybridRnIap: HybridRnIapSpec {
             lastPurchaseErrorTimestamp = 0
             deliveredPurchaseUpdateIds.removeAll()
             pendingDuplicatePurchaseUpdateSuppressions.removeAll()
+            pendingRequestPurchaseErrorSuppressions.removeAll()
             return subscriptions
         }
     }

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -2,8 +2,54 @@ import Foundation
 import NitroModules
 import OpenIAP
 
+private final class PendingEventBuffer<Event> {
+    private let capacity: Int
+    private let label: String
+    private var events: [Event] = []
+    private var isFlushing = false
+
+    init(capacity: Int, label: String) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+        self.label = label
+    }
+
+    func enqueueIfNeeded(hasListeners: Bool, event: Event) -> Bool {
+        guard !hasListeners || isFlushing else { return false }
+        if events.count >= capacity {
+            events.removeFirst()
+            RnIapLog.warn("\(label) overflow; dropping oldest")
+        }
+        events.append(event)
+        return true
+    }
+
+    func beginFlushIfNeeded() -> Bool {
+        guard !isFlushing, !events.isEmpty else { return false }
+        isFlushing = true
+        return true
+    }
+
+    func takeBatchOrFinish(hasListeners: Bool) -> [Event]? {
+        guard hasListeners, !events.isEmpty else {
+            isFlushing = false
+            return nil
+        }
+        let batch = events
+        events.removeAll()
+        return batch
+    }
+
+    func clear() {
+        events.removeAll()
+        isFlushing = false
+    }
+}
+
 @available(iOS 15.0, macOS 14.0, tvOS 15.0, watchOS 8.0, *)
 class HybridRnIap: HybridRnIapSpec {
+    private static let maxPendingEvents = 200
+
     private enum PurchaseUpdatedListenerBucket {
         case deduping
         case nonDeduping
@@ -38,6 +84,19 @@ class HybridRnIap: HybridRnIapSpec {
     private var deliveredPurchaseUpdateIds = Set<String>()
     private var pendingDuplicatePurchaseUpdateSuppressions: [String: Int] = [:]
     private var pendingRequestPurchaseErrorSuppressions: [String: Int] = [:]
+    private var pendingOnDemandInitErrorSuppressions: [String: Int] = [:]
+    private let pendingPurchaseUpdates = PendingEventBuffer<NitroPurchase>(
+        capacity: HybridRnIap.maxPendingEvents,
+        label: "pendingPurchaseUpdates"
+    )
+    private let pendingDuplicatePurchaseUpdates = PendingEventBuffer<NitroPurchase>(
+        capacity: HybridRnIap.maxPendingEvents,
+        label: "pendingDuplicatePurchaseUpdates"
+    )
+    private let pendingPurchaseErrors = PendingEventBuffer<NitroPurchaseResult>(
+        capacity: HybridRnIap.maxPendingEvents,
+        label: "pendingPurchaseErrors"
+    )
     // Thread safety lock for listener arrays and error dedup state
     private let listenerLock = NSLock()
     private let lifecycleLock = NSLock()
@@ -96,6 +155,12 @@ class HybridRnIap: HybridRnIapSpec {
                 let isCurrent = self.listenerLock.withLock {
                     guard self.connectionEpoch == epoch else { return false }
                     self.isInitialized = ok
+                    if reuseExistingConnection, !ok {
+                        self.pendingOnDemandInitErrorSuppressions[
+                            ErrorCode.iapNotAvailable.rawValue,
+                            default: 0
+                        ] += 1
+                    }
                     return true
                 }
                 guard isCurrent else { return false }
@@ -126,6 +191,12 @@ class HybridRnIap: HybridRnIapSpec {
         _ connect: @escaping () async throws -> Bool
     ) -> Task<Bool, Error> {
         enqueueConnect(nil, connect: connect)
+    }
+
+    func enqueueOnDemandConnectOperation(
+        _ connect: @escaping () async throws -> Bool
+    ) -> Task<Bool, Error> {
+        enqueueConnect(nil, reuseExistingConnection: true, connect: connect)
     }
 
     func endConnection() throws -> Promise<Bool> {
@@ -1175,7 +1246,7 @@ class HybridRnIap: HybridRnIapSpec {
     ) throws -> Double {
         let dedupeTransactionIOS = purchaseUpdatedDedupeTransactionIOS(from: options)
         let receiveDuplicateTransactionUpdatesIOS = !dedupeTransactionIOS
-        let (token, epoch) = listenerLock.withLock {
+        let (token, epoch, shouldFlush, flushEpoch) = listenerLock.withLock {
             let token = nextPurchaseUpdatedListenerToken
             nextPurchaseUpdatedListenerToken += 1
 
@@ -1189,9 +1260,26 @@ class HybridRnIap: HybridRnIapSpec {
                 purchaseUpdatedListeners.append((token: token, listener: listener))
             }
             purchaseUpdatedListenerRegistrations.append(registration)
-            return (token, isInitialized ? connectionEpoch : nil)
+            let shouldFlush: Bool
+            if receiveDuplicateTransactionUpdatesIOS {
+                shouldFlush = pendingDuplicatePurchaseUpdates.beginFlushIfNeeded()
+            } else {
+                shouldFlush = pendingPurchaseUpdates.beginFlushIfNeeded()
+            }
+            return (
+                token,
+                isInitialized ? connectionEpoch : nil,
+                shouldFlush,
+                connectionEpoch
+            )
         }
 
+        if shouldFlush {
+            schedulePendingPurchaseUpdateFlush(
+                includeDuplicateListeners: receiveDuplicateTransactionUpdatesIOS,
+                expectedEpoch: flushEpoch
+            )
+        }
         if let epoch {
             if receiveDuplicateTransactionUpdatesIOS {
                 attachDuplicatePurchaseUpdatedSubIfNeeded(expectedEpoch: epoch)
@@ -1213,9 +1301,13 @@ class HybridRnIap: HybridRnIapSpec {
     }
 
     func addPurchaseErrorListener(listener: @escaping (NitroPurchaseResult) -> Void) throws {
-        let epoch = listenerLock.withLock {
+        let (epoch, shouldFlush, flushEpoch) = listenerLock.withLock {
             purchaseErrorListeners.append(listener)
-            return isInitialized ? connectionEpoch : nil
+            let shouldFlush = pendingPurchaseErrors.beginFlushIfNeeded()
+            return (isInitialized ? connectionEpoch : nil, shouldFlush, connectionEpoch)
+        }
+        if shouldFlush {
+            schedulePendingPurchaseErrorFlush(expectedEpoch: flushEpoch)
         }
         if let epoch {
             attachPurchaseErrorSubIfNeeded(expectedEpoch: epoch)
@@ -1533,8 +1625,9 @@ class HybridRnIap: HybridRnIapSpec {
         _ error: PurchaseError,
         expectedEpoch: UInt64
     ) -> Task<Void, Error> {
-        enqueueLifecycleOperation {
+        return enqueueLifecycleOperation {
             guard self.isCurrentEpoch(expectedEpoch),
+                  !self.consumeOnDemandInitErrorSuppression(error),
                   !self.consumeRequestPurchaseErrorSuppression(error) else {
                 return
             }
@@ -1550,6 +1643,21 @@ class HybridRnIap: HybridRnIapSpec {
                 RnIapLog.result("purchaseErrorListener", payload)
                 self.sendPurchaseError(nitroError, productId: error.productId)
             }
+        }
+    }
+
+    private func consumeOnDemandInitErrorSuppression(_ error: PurchaseError) -> Bool {
+        listenerLock.withLock {
+            let key = error.code.rawValue
+            guard let count = pendingOnDemandInitErrorSuppressions[key] else {
+                return false
+            }
+            if count == 1 {
+                pendingOnDemandInitErrorSuppressions.removeValue(forKey: key)
+            } else {
+                pendingOnDemandInitErrorSuppressions[key] = count - 1
+            }
+            return true
         }
     }
 
@@ -1724,9 +1832,21 @@ class HybridRnIap: HybridRnIapSpec {
     private func sendPurchaseUpdate(_ purchase: NitroPurchase, includeDuplicateListeners: Bool) {
         let snapshot: [(NitroPurchase) -> Void] = listenerLock.withLock {
             if includeDuplicateListeners {
+                if pendingDuplicatePurchaseUpdates.enqueueIfNeeded(
+                    hasListeners: !purchaseUpdatedDuplicateListeners.isEmpty,
+                    event: purchase
+                ) {
+                    return []
+                }
                 return purchaseUpdatedDuplicateListeners.map(\.listener)
             }
 
+            if pendingPurchaseUpdates.enqueueIfNeeded(
+                hasListeners: !purchaseUpdatedListeners.isEmpty,
+                event: purchase
+            ) {
+                return []
+            }
             return purchaseUpdatedListeners.map(\.listener)
         }
 
@@ -1744,21 +1864,6 @@ class HybridRnIap: HybridRnIapSpec {
             ?? (error.purchaseToken?.isEmpty == false ? error.purchaseToken : nil)
             ?? (error.message.isEmpty ? nil : error.message)
         let currentKey = RnIapHelper.makeErrorDedupKey(code: error.code, productId: dedupIdentifier)
-
-        // Protect error dedup state since sendPurchaseError is called from multiple threads
-        let snapshot: [(NitroPurchaseResult) -> Void]? = listenerLock.withLock {
-            if dedupe {
-                let now = Date().timeIntervalSince1970
-                let withinWindow = (now - lastPurchaseErrorTimestamp) < 0.15
-                if currentKey == lastPurchaseErrorKey && withinWindow {
-                    return nil
-                }
-                lastPurchaseErrorKey = currentKey
-                lastPurchaseErrorTimestamp = now
-            }
-            return Array(purchaseErrorListeners)
-        }
-        guard let snapshot else { return }
 
         // Ensure we never leak SKU via purchaseToken
         let sanitized: NitroPurchaseResult
@@ -1778,9 +1883,102 @@ class HybridRnIap: HybridRnIapSpec {
         } else {
             sanitized = error
         }
+
+        // Protect error dedup state since sendPurchaseError is called from multiple threads
+        let snapshot: [(NitroPurchaseResult) -> Void]? = listenerLock.withLock {
+            if dedupe {
+                let now = Date().timeIntervalSince1970
+                let withinWindow = (now - lastPurchaseErrorTimestamp) < 0.15
+                if currentKey == lastPurchaseErrorKey && withinWindow {
+                    return nil
+                }
+                lastPurchaseErrorKey = currentKey
+                lastPurchaseErrorTimestamp = now
+            }
+            if pendingPurchaseErrors.enqueueIfNeeded(
+                hasListeners: !purchaseErrorListeners.isEmpty,
+                event: sanitized
+            ) {
+                return []
+            }
+            return Array(purchaseErrorListeners)
+        }
+        guard let snapshot else { return }
         for listener in snapshot {
             listener(sanitized)
         }
+    }
+
+    private func schedulePendingPurchaseUpdateFlush(
+        includeDuplicateListeners: Bool,
+        expectedEpoch: UInt64
+    ) {
+        let operation: Task<Void, Error> = enqueueLifecycleOperation {
+            await self.flushPendingPurchaseUpdates(
+                includeDuplicateListeners: includeDuplicateListeners,
+                expectedEpoch: expectedEpoch
+            )
+        }
+        Task { _ = try? await operation.value }
+    }
+
+    private func flushPendingPurchaseUpdates(
+        includeDuplicateListeners: Bool,
+        expectedEpoch: UInt64
+    ) async {
+        while true {
+            let delivery: (events: [NitroPurchase], listeners: [(NitroPurchase) -> Void])? = listenerLock.withLock {
+                guard connectionEpoch == expectedEpoch else { return nil }
+                let listeners = includeDuplicateListeners
+                    ? purchaseUpdatedDuplicateListeners.map(\.listener)
+                    : purchaseUpdatedListeners.map(\.listener)
+                let buffer = includeDuplicateListeners
+                    ? pendingDuplicatePurchaseUpdates
+                    : pendingPurchaseUpdates
+                guard let events = buffer.takeBatchOrFinish(
+                    hasListeners: !listeners.isEmpty
+                ) else { return nil }
+                return (events, listeners)
+            }
+            guard let delivery else { return }
+            for event in delivery.events {
+                for listener in delivery.listeners {
+                    guard isCurrentEpoch(expectedEpoch) else { return }
+                    await MainActor.run { listener(event) }
+                }
+            }
+        }
+    }
+
+    private func schedulePendingPurchaseErrorFlush(expectedEpoch: UInt64) {
+        let operation: Task<Void, Error> = enqueueLifecycleOperation {
+            await self.flushPendingPurchaseErrors(expectedEpoch: expectedEpoch)
+        }
+        Task { _ = try? await operation.value }
+    }
+
+    private func flushPendingPurchaseErrors(expectedEpoch: UInt64) async {
+        while true {
+            let delivery: (events: [NitroPurchaseResult], listeners: [(NitroPurchaseResult) -> Void])? = listenerLock.withLock {
+                guard connectionEpoch == expectedEpoch else { return nil }
+                let listeners = Array(purchaseErrorListeners)
+                guard let events = pendingPurchaseErrors.takeBatchOrFinish(
+                    hasListeners: !listeners.isEmpty
+                ) else { return nil }
+                return (events, listeners)
+            }
+            guard let delivery else { return }
+            for event in delivery.events {
+                for listener in delivery.listeners {
+                    guard isCurrentEpoch(expectedEpoch) else { return }
+                    await MainActor.run { listener(event) }
+                }
+            }
+        }
+    }
+
+    func enqueueLifecycleBarrier() -> Task<Void, Error> {
+        enqueueLifecycleOperation {}
     }
 
     private func sendPurchaseErrorDedup(_ error: NitroPurchaseResult, productId: String? = nil) {
@@ -1825,6 +2023,10 @@ class HybridRnIap: HybridRnIapSpec {
             deliveredPurchaseUpdateIds.removeAll()
             pendingDuplicatePurchaseUpdateSuppressions.removeAll()
             pendingRequestPurchaseErrorSuppressions.removeAll()
+            pendingOnDemandInitErrorSuppressions.removeAll()
+            pendingPurchaseUpdates.clear()
+            pendingDuplicatePurchaseUpdates.clear()
+            pendingPurchaseErrors.clear()
             return subscriptions
         }
     }

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -579,6 +579,34 @@ describe('hooks/useIAP (renderer)', () => {
     expect(api.products).toEqual([expect.objectContaining({id: 'product1'})]);
   });
 
+  it('surfaces the native error when fetching while disconnected', async () => {
+    // Counterpart to the test above. Android rejects with not-prepared until
+    // initConnection has run; the caller must learn that rather than get a
+    // silently empty result.
+    const notConnected = new Error('Billing client not ready');
+    jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(false as any);
+    mockFetchProducts.mockRejectedValueOnce(notConnected);
+
+    let api: any;
+    const onError = jest.fn();
+    const Harness = () => {
+      api = useIAP({onError});
+      return null;
+    };
+    await act(async () => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+    await act(async () => {});
+    expect(api.connected).toBe(false);
+
+    await act(async () => {
+      await api.fetchProducts({skus: ['product1']});
+    });
+
+    expect(onError).toHaveBeenCalledWith(notConnected);
+    expect(api.products).toEqual([]);
+  });
+
   describe('onError callback', () => {
     it('calls onError when fetchProducts fails', async () => {
       const fetchError = new Error('Network error fetching products');

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -1157,6 +1157,8 @@ describe('hooks/useIAP (renderer)', () => {
         expect(await secondReconnect!).toBe(true);
       });
       expect(api.connected).toBe(true);
+      expect(IAP.purchaseUpdatedListener).toHaveBeenCalledTimes(1);
+      expect(IAP.purchaseErrorListener).toHaveBeenCalledTimes(1);
 
       await act(async () => {
         resolveFirst?.(true);
@@ -1164,8 +1166,8 @@ describe('hooks/useIAP (renderer)', () => {
       });
 
       expect(api.connected).toBe(true);
-      expect(IAP.purchaseUpdatedListener).not.toHaveBeenCalled();
-      expect(IAP.purchaseErrorListener).not.toHaveBeenCalled();
+      expect(IAP.purchaseUpdatedListener).toHaveBeenCalledTimes(1);
+      expect(IAP.purchaseErrorListener).toHaveBeenCalledTimes(1);
     });
 
     it('reconnect re-registers listeners after successful reconnection', async () => {

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -580,9 +580,6 @@ describe('hooks/useIAP (renderer)', () => {
   });
 
   it('surfaces the native error when fetching while disconnected', async () => {
-    // Counterpart to the test above. Android rejects with not-prepared until
-    // initConnection has run; the caller must learn that rather than get a
-    // silently empty result.
     const notConnected = new Error('Billing client not ready');
     jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(false as any);
     mockFetchProducts.mockRejectedValueOnce(notConnected);

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -43,6 +43,7 @@ jest.mock('react-native', () => ({
 // Import after mocks
 import * as IAP from '../../index';
 import {useIAP} from '../../hooks/useIAP';
+import {Platform} from 'react-native';
 
 describe('hooks/useIAP (renderer)', () => {
   afterEach(() => {
@@ -580,34 +581,40 @@ describe('hooks/useIAP (renderer)', () => {
   });
 
   it('surfaces the native error when fetching while disconnected', async () => {
+    const originalPlatform = Platform.OS;
+    (Platform as any).OS = 'android';
     const notConnected = new Error('Billing client not ready');
-    jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(false as any);
-    mockFetchProducts.mockRejectedValueOnce(notConnected);
+    try {
+      jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(false as any);
+      mockFetchProducts.mockRejectedValueOnce(notConnected);
 
-    let api: any;
-    const onError = jest.fn();
-    const Harness = () => {
-      api = useIAP({onError});
-      return null;
-    };
-    await act(async () => {
-      TestRenderer.create(React.createElement(Harness));
-    });
-    await act(async () => {});
-    expect(api.connected).toBe(false);
+      let api: any;
+      const onError = jest.fn();
+      const Harness = () => {
+        api = useIAP({onError});
+        return null;
+      };
+      await act(async () => {
+        TestRenderer.create(React.createElement(Harness));
+      });
+      await act(async () => {});
+      expect(api.connected).toBe(false);
 
-    let thrown: unknown;
-    await act(async () => {
-      try {
-        await api.fetchProducts({skus: ['product1']});
-      } catch (error) {
-        thrown = error;
-      }
-    });
+      let thrown: unknown;
+      await act(async () => {
+        try {
+          await api.fetchProducts({skus: ['product1']});
+        } catch (error) {
+          thrown = error;
+        }
+      });
 
-    expect(onError).toHaveBeenCalledWith(notConnected);
-    expect(thrown).toBe(notConnected);
-    expect(api.products).toEqual([]);
+      expect(onError).toHaveBeenCalledWith(notConnected);
+      expect(thrown).toBe(notConnected);
+      expect(api.products).toEqual([]);
+    } finally {
+      (Platform as any).OS = originalPlatform;
+    }
   });
 
   describe('onError callback', () => {

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -1178,7 +1178,7 @@ describe('hooks/useIAP (renderer)', () => {
       // purchaseUpdatedListener should have been called during init
       expect(IAP.purchaseUpdatedListener).toHaveBeenCalled();
 
-      // Clear and reconnect
+      await IAP.endConnection();
       (IAP.purchaseUpdatedListener as jest.Mock).mockClear();
       jest.spyOn(IAP, 'initConnection').mockResolvedValueOnce(true as any);
 
@@ -1186,9 +1186,24 @@ describe('hooks/useIAP (renderer)', () => {
         await api.reconnect();
       });
 
-      // Listeners are already active from init, so reconnect skips re-registration
-      // (guarded by !subscriptionsRef.current.purchaseUpdate check)
       expect(api.connected).toBe(true);
+      expect(IAP.purchaseUpdatedListener).toHaveBeenCalledTimes(1);
+
+      const purchase = {
+        id: 'after-reconnect',
+        productId: 'premium',
+        transactionDate: Date.now(),
+        platform: 'ios',
+        store: 'apple',
+        quantity: 1,
+        purchaseState: 'purchased',
+        isAutoRenewing: false,
+      };
+      act(() => {
+        capturedPurchaseListener?.(purchase);
+      });
+      await act(async () => {});
+      expect(onPurchaseSuccess).toHaveBeenCalledWith(purchase);
     });
   });
 

--- a/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
+++ b/libraries/react-native-iap/src/__tests__/hooks/useIAP.test.ts
@@ -599,11 +599,17 @@ describe('hooks/useIAP (renderer)', () => {
     await act(async () => {});
     expect(api.connected).toBe(false);
 
+    let thrown: unknown;
     await act(async () => {
-      await api.fetchProducts({skus: ['product1']});
+      try {
+        await api.fetchProducts({skus: ['product1']});
+      } catch (error) {
+        thrown = error;
+      }
     });
 
     expect(onError).toHaveBeenCalledWith(notConnected);
+    expect(thrown).toBe(notConnected);
     expect(api.products).toEqual([]);
   });
 

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -3685,8 +3685,8 @@ describe('Public API (src/index.ts)', () => {
       replaceNativeMethod('initConnection', jest.fn().mockResolvedValue(true));
       expect(IAP.isNitroReady()).toBe(true);
       (Platform as any).OS = 'android';
-      const staleListener = jest.fn();
-      IAP.purchaseUpdatedListener(staleListener);
+      const existingListener = jest.fn();
+      IAP.purchaseUpdatedListener(existingListener);
       replaceNativeMethod(
         'endConnection',
         jest.fn().mockRejectedValueOnce(new Error('end failed')),
@@ -3698,9 +3698,9 @@ describe('Public API (src/index.ts)', () => {
       await IAP.initConnection();
       const currentListener = jest.fn();
       IAP.purchaseUpdatedListener(currentListener);
-      expect(mockIap.addPurchaseUpdatedListener).toHaveBeenCalledTimes(2);
+      expect(mockIap.addPurchaseUpdatedListener).toHaveBeenCalledTimes(1);
 
-      const nativeHandler = mockIap.addPurchaseUpdatedListener.mock.calls[1][0];
+      const nativeHandler = mockIap.addPurchaseUpdatedListener.mock.calls[0][0];
       nativeHandler({
         id: 't1',
         transactionId: 't1',
@@ -3711,7 +3711,7 @@ describe('Public API (src/index.ts)', () => {
         purchaseState: 'purchased',
         isAutoRenewing: false,
       });
-      expect(staleListener).not.toHaveBeenCalled();
+      expect(existingListener).toHaveBeenCalledTimes(1);
       expect(currentListener).toHaveBeenCalledTimes(1);
     });
 

--- a/libraries/react-native-iap/src/__tests__/index.test.ts
+++ b/libraries/react-native-iap/src/__tests__/index.test.ts
@@ -703,6 +703,48 @@ describe('Public API (src/index.ts)', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
+    it('attaches a deferred purchase listener before an on-demand store call', async () => {
+      const callOrder: string[] = [];
+      const createHybridObject = jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Nitro runtime not installed');
+        })
+        .mockImplementation(() => mockIap);
+      jest.resetModules();
+      jest.doMock('react-native-nitro-modules', () => ({
+        NitroModules: {createHybridObject},
+      }));
+      const freshIAP = require('../index');
+      const listener = jest.fn();
+      mockIap.addPurchaseUpdatedListener.mockImplementationOnce(() => {
+        callOrder.push('listener');
+        return 1;
+      });
+      mockIap.requestPurchase.mockImplementationOnce(async () => {
+        callOrder.push('purchase');
+      });
+
+      freshIAP.purchaseUpdatedListener(listener);
+      await freshIAP.requestPurchase({
+        request: {apple: {sku: 'p1'}},
+        type: 'in-app',
+      });
+
+      expect(callOrder).toEqual(['listener', 'purchase']);
+      mockIap.addPurchaseUpdatedListener.mock.calls[0][0]({
+        id: 't1',
+        transactionId: 't1',
+        productId: 'p1',
+        transactionDate: Date.now(),
+        store: 'apple',
+        quantity: 1,
+        purchaseState: 'purchased',
+        isAutoRenewing: false,
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
     it('does not attach a deferred listener removed before initConnection', async () => {
       mockIap.addPurchaseUpdatedListener.mockImplementationOnce(() => {
         throw new Error('Nitro runtime not installed');

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -169,7 +169,7 @@ type UseIap = {
    *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
    * @returns Promise that resolves when the request is dispatched; results land in the
    *   hook's `onPurchaseSuccess` / `onPurchaseError` callbacks.
-   * @throws Synchronous rejection from the store (e.g. `E_NOT_PREPARED`, validation failure).
+   * @throws Synchronous rejection from the store (e.g. `not-prepared`, validation failure).
    *
    * @example
    * ```ts

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -169,7 +169,8 @@ type UseIap = {
    *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
    * @returns Promise that resolves when the request is dispatched; results land in the
    *   hook's `onPurchaseSuccess` / `onPurchaseError` callbacks.
-   * @throws Synchronous rejection from the store (e.g. `not-prepared`, validation failure).
+   * @throws Invalid arguments or failures that prevent dispatch. Store outcomes are event-based;
+   *   on Android, `not-prepared` is delivered through `onPurchaseError`.
    *
    * @example
    * ```ts
@@ -781,6 +782,8 @@ export function useIAP(options?: UseIapOptions): UseIap {
       }
 
       if (result) {
+        // endConnection invalidates these hook-owned subscription handles.
+        cleanupListeners();
         registerListeners();
         setConnected(true);
         return true;

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -109,11 +109,12 @@ type UseIap = {
    *
    * @example
    * ```ts
-   * const { availablePurchases, getAvailablePurchases, finishTransaction } = useIAP();
+   * const { connected, availablePurchases, getAvailablePurchases, finishTransaction } = useIAP();
    *
    * useEffect(() => {
+   *   if (!connected) return;
    *   void getAvailablePurchases();
-   * }, [getAvailablePurchases]);
+   * }, [connected, getAvailablePurchases]);
    *
    * useEffect(() => {
    *   for (const p of availablePurchases) {
@@ -139,14 +140,15 @@ type UseIap = {
    *
    * @example
    * ```ts
-   * const { products, fetchProducts } = useIAP();
+   * const { connected, products, fetchProducts } = useIAP();
    *
    * useEffect(() => {
+   *   if (!connected) return;
    *   void fetchProducts({
    *     skus: ['com.app.coins_100', 'com.app.premium'],
    *     type: 'in-app',
    *   });
-   * }, [fetchProducts]);
+   * }, [connected, fetchProducts]);
    *
    * // Render `products` directly from hook state.
    * ```
@@ -174,6 +176,9 @@ type UseIap = {
    *
    * @example
    * ```ts
+   * const { connected, requestPurchase } = useIAP();
+   * if (!connected) return;
+   *
    * await requestPurchase({
    *   request: {
    *     apple: { sku: 'com.app.premium' },

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -83,10 +83,12 @@ type UseIap = {
    *
    * @example
    * ```ts
-   * purchaseUpdatedListener(async (purchase) => {
-   *   if (await verifyOnServer(purchase)) {
-   *     await finishTransaction({ purchase, isConsumable: false });
-   *   }
+   * purchaseUpdatedListener((purchase) => {
+   *   void verifyOnServer(purchase)
+   *     .then((verified) => verified
+   *       ? finishTransaction({ purchase, isConsumable: false })
+   *       : undefined)
+   *     .catch((error) => console.warn('Transaction finalization failed:', error));
    * });
    * ```
    *

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -119,11 +119,15 @@ type UseIap = {
    * }, [connected, getAvailablePurchases]);
    *
    * useEffect(() => {
-   *   for (const p of availablePurchases) {
-   *     void verifyOnServer(p).then((ok) => {
-   *       if (ok) finishTransaction({ purchase: p, isConsumable: false });
-   *     });
-   *   }
+   *   void (async () => {
+   *     for (const p of availablePurchases) {
+   *       if (await verifyOnServer(p)) {
+   *         await finishTransaction({ purchase: p, isConsumable: false });
+   *       }
+   *     }
+   *   })().catch((error) => {
+   *     console.warn('Restored purchase processing failed', error);
+   *   });
    * }, [availablePurchases, finishTransaction]);
    * ```
    *

--- a/libraries/react-native-iap/src/hooks/useIAP.ts
+++ b/libraries/react-native-iap/src/hooks/useIAP.ts
@@ -113,7 +113,9 @@ type UseIap = {
    *
    * useEffect(() => {
    *   if (!connected) return;
-   *   void getAvailablePurchases();
+   *   void getAvailablePurchases().catch((error) => {
+   *     console.warn('Purchase restore failed', error);
+   *   });
    * }, [connected, getAvailablePurchases]);
    *
    * useEffect(() => {
@@ -147,6 +149,8 @@ type UseIap = {
    *   void fetchProducts({
    *     skus: ['com.app.coins_100', 'com.app.premium'],
    *     type: 'in-app',
+   *   }).catch((error) => {
+   *     console.warn('Product fetch failed', error);
    *   });
    * }, [connected, fetchProducts]);
    *

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1946,10 +1946,12 @@ export const requestPurchase: MutationField<'requestPurchase'> = async (
  *
  * @example
  * ```ts
- * purchaseUpdatedListener(async (purchase) => {
- *   if (await verifyOnServer(purchase)) {
- *     await finishTransaction({ purchase, isConsumable: false });
- *   }
+ * purchaseUpdatedListener((purchase) => {
+ *   void verifyOnServer(purchase)
+ *     .then((verified) => verified
+ *       ? finishTransaction({ purchase, isConsumable: false })
+ *       : undefined)
+ *     .catch((error) => console.warn('Transaction finalization failed:', error));
  * });
  * ```
  *

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1670,7 +1670,8 @@ export const restorePurchases: MutationField<'restorePurchases'> = async () => {
  *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
  *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
  * @returns The dispatched purchase payload. **Do not rely on it** for the actual outcome.
- * @throws Synchronous rejection from the store (e.g. `not-prepared`, validation failure).
+ * @throws Invalid arguments or failures that prevent dispatch. Store outcomes are event-based;
+ *   on Android, `not-prepared` is delivered through `purchaseErrorListener`.
  *
  * @example
  * ```ts

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1670,7 +1670,7 @@ export const restorePurchases: MutationField<'restorePurchases'> = async () => {
  *   - `type: 'in-app'` — pass `request.apple.sku` (iOS) and/or `request.google.skus` (Android).
  *   - `type: 'subs'`  — same shape, plus `request.google.subscriptionOffers: [{ sku, offerToken }]`.
  * @returns The dispatched purchase payload. **Do not rely on it** for the actual outcome.
- * @throws Synchronous rejection from the store (e.g. `E_NOT_PREPARED`, validation failure).
+ * @throws Synchronous rejection from the store (e.g. `not-prepared`, validation failure).
  *
  * @example
  * ```ts

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -170,6 +170,7 @@ export type {
 
 // Create the RnIap HybridObject instance lazily to avoid early JSI crashes
 let iapRef: RnIap | null = null;
+let attachingPendingNativeListeners = false;
 
 /**
  * Check if Nitro runtime is ready for IAP operations.
@@ -220,39 +221,52 @@ const isAndroidStoreRuntime = (): boolean => {
   return Platform.OS === 'android' || isVegaOS();
 };
 
+function getRawIapInstance(): RnIap {
+  if (iapRef) return iapRef;
+
+  if (isVegaOS()) {
+    const vegaModule = getVegaIapModule();
+    if (!vegaModule) {
+      throw new Error(
+        'Amazon Vega IAP module is unavailable. Install @amazon-devices/keplerscript-appstore-iap-lib in the Vega app target and build with the React Native for Vega kepler platform.',
+      );
+    }
+    iapRef = vegaModule;
+    return iapRef;
+  }
+
+  // Attempt to create the HybridObject and map common Nitro/JSI readiness errors
+  try {
+    iapRef = NitroModules.createHybridObject<RnIap>('RnIap');
+  } catch (e) {
+    const msg = toErrorMessage(e);
+    if (
+      msg.includes('Nitro') ||
+      msg.includes('JSI') ||
+      msg.includes('dispatcher') ||
+      msg.includes('HybridObject')
+    ) {
+      throw new Error(
+        'Nitro runtime not installed yet. Ensure react-native-nitro-modules is initialized before calling IAP.',
+      );
+    }
+    throw e;
+  }
+  return iapRef;
+}
+
 const IAP = {
   get instance(): RnIap {
-    if (iapRef) return iapRef;
-
-    if (isVegaOS()) {
-      const vegaModule = getVegaIapModule();
-      if (!vegaModule) {
-        throw new Error(
-          'Amazon Vega IAP module is unavailable. Install @amazon-devices/keplerscript-appstore-iap-lib in the Vega app target and build with the React Native for Vega kepler platform.',
-        );
+    const instance = getRawIapInstance();
+    if (!attachingPendingNativeListeners) {
+      attachingPendingNativeListeners = true;
+      try {
+        tryAttachPendingNativeListeners();
+      } finally {
+        attachingPendingNativeListeners = false;
       }
-      iapRef = vegaModule;
-      return iapRef;
     }
-
-    // Attempt to create the HybridObject and map common Nitro/JSI readiness errors
-    try {
-      iapRef = NitroModules.createHybridObject<RnIap>('RnIap');
-    } catch (e) {
-      const msg = toErrorMessage(e);
-      if (
-        msg.includes('Nitro') ||
-        msg.includes('JSI') ||
-        msg.includes('dispatcher') ||
-        msg.includes('HybridObject')
-      ) {
-        throw new Error(
-          'Nitro runtime not installed yet. Ensure react-native-nitro-modules is initialized before calling IAP.',
-        );
-      }
-      throw e;
-    }
-    return iapRef;
+    return instance;
   },
 };
 
@@ -270,7 +284,7 @@ function attachNativeListenerOrDefer(label: string, attach: () => void): void {
   } catch (error) {
     if (toErrorMessage(error).includes('Nitro runtime not installed')) {
       RnIapConsole.warn(
-        `[${label}] Nitro not ready yet; will retry after initConnection()`,
+        `[${label}] Nitro not ready yet; will retry on the next native operation`,
       );
       return;
     }
@@ -333,7 +347,7 @@ function tryAttachPurchaseUpdateNative(
       | undefined = receiveDuplicateTransactionUpdatesIOS
       ? {dedupeTransactionIOS: false}
       : undefined;
-    const token = IAP.instance.addPurchaseUpdatedListener(
+    const token = getRawIapInstance().addPurchaseUpdatedListener(
       receiveDuplicateTransactionUpdatesIOS
         ? purchaseUpdateDuplicateNativeHandler
         : purchaseUpdateNativeHandler,
@@ -383,7 +397,7 @@ const purchaseErrorNativeHandler: NitroPurchaseErrorListener = (error) => {
 function tryAttachPurchaseErrorNative(): void {
   if (purchaseErrorNativeAttached) return;
   attachNativeListenerOrDefer('purchaseErrorListener', () => {
-    IAP.instance.addPurchaseErrorListener(purchaseErrorNativeHandler);
+    getRawIapInstance().addPurchaseErrorListener(purchaseErrorNativeHandler);
     purchaseErrorNativeAttached = true;
   });
 }
@@ -413,7 +427,9 @@ const promotedProductNativeHandler: NitroPromotedProductListener = (
 function tryAttachPromotedProductNative(): void {
   if (promotedProductNativeAttached) return;
   attachNativeListenerOrDefer('promotedProductListenerIOS', () => {
-    IAP.instance.addPromotedProductListenerIOS(promotedProductNativeHandler);
+    getRawIapInstance().addPromotedProductListenerIOS(
+      promotedProductNativeHandler,
+    );
     promotedProductNativeAttached = true;
   });
 }
@@ -487,7 +503,7 @@ export const purchaseUpdatedListener = (
       }
 
       try {
-        IAP.instance.removePurchaseUpdatedListener(token);
+        getRawIapInstance().removePurchaseUpdatedListener(token);
         if (receiveDuplicateTransactionUpdatesIOS) {
           purchaseUpdateDuplicateNativeToken = null;
           purchaseUpdateDuplicateNativeAttached = false;
@@ -530,7 +546,9 @@ export const purchaseErrorListener = (
 
       if (purchaseErrorNativeAttached) {
         try {
-          IAP.instance.removePurchaseErrorListener(purchaseErrorNativeHandler);
+          getRawIapInstance().removePurchaseErrorListener(
+            purchaseErrorNativeHandler,
+          );
           purchaseErrorNativeAttached = false;
         } catch (e) {
           RnIapConsole.warn('[purchaseErrorListener] native remove failed:', e);
@@ -622,7 +640,7 @@ const userChoiceBillingNativeHandler: NitroUserChoiceBillingListener = (
 function tryAttachUserChoiceBillingNative(): void {
   if (userChoiceBillingNativeAttached) return;
   attachNativeListenerOrDefer('userChoiceBillingListenerAndroid', () => {
-    IAP.instance.addUserChoiceBillingListenerAndroid(
+    getRawIapInstance().addUserChoiceBillingListenerAndroid(
       userChoiceBillingNativeHandler,
     );
     userChoiceBillingNativeAttached = true;
@@ -660,7 +678,7 @@ export const userChoiceBillingListenerAndroid = (
         return;
       }
       try {
-        IAP.instance.removeUserChoiceBillingListenerAndroid(
+        getRawIapInstance().removeUserChoiceBillingListenerAndroid(
           userChoiceBillingNativeHandler,
         );
         userChoiceBillingNativeAttached = false;
@@ -724,7 +742,7 @@ const developerProvidedBillingNativeHandler: NitroDeveloperProvidedBillingListen
 function tryAttachDeveloperProvidedBillingNative(): void {
   if (developerProvidedBillingNativeAttached) return;
   attachNativeListenerOrDefer('developerProvidedBillingListenerAndroid', () => {
-    IAP.instance.addDeveloperProvidedBillingListenerAndroid(
+    getRawIapInstance().addDeveloperProvidedBillingListenerAndroid(
       developerProvidedBillingNativeHandler,
     );
     developerProvidedBillingNativeAttached = true;
@@ -812,7 +830,7 @@ const subscriptionBillingIssueNativeHandler: NitroSubscriptionBillingIssueListen
 function tryAttachSubscriptionBillingIssueNative(): void {
   if (subscriptionBillingIssueNativeAttached) return;
   attachNativeListenerOrDefer('subscriptionBillingIssueListener', () => {
-    IAP.instance.addSubscriptionBillingIssueListener(
+    getRawIapInstance().addSubscriptionBillingIssueListener(
       subscriptionBillingIssueNativeHandler,
     );
     subscriptionBillingIssueNativeAttached = true;

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1626,8 +1626,9 @@ export const initConnection: MutationField<'initConnection'> = async (
  */
 export const endConnection: MutationField<'endConnection'> = async () => {
   try {
-    if (!iapRef) return true;
-    return await IAP.instance.endConnection();
+    const result = iapRef ? await IAP.instance.endConnection() : true;
+    resetListenerState();
+    return result;
   } catch (error) {
     const parsedError = parseErrorAndLogIfNeeded(
       'Failed to end IAP connection:',
@@ -1639,8 +1640,6 @@ export const endConnection: MutationField<'endConnection'> = async () => {
       responseCode: parsedError.responseCode,
       debugMessage: parsedError.debugMessage,
     });
-  } finally {
-    resetListenerState();
   }
 };
 

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -607,7 +607,9 @@ export const promotedProductListenerIOS = (
  *   console.log('External transaction token received; send it to your backend without logging it.');
  *
  *   // Send token to backend for Google Play reporting
- *   await reportToGooglePlay(details.externalTransactionToken);
+ *   void reportToGooglePlay(details.externalTransactionToken).catch((error) => {
+ *     console.warn('Alternative billing report failed', error);
+ *   });
  * });
  *
  * // Later, remove the listener
@@ -707,10 +709,11 @@ export const userChoiceBillingListenerAndroid = (
  * @example
  * ```typescript
  * const subscription = developerProvidedBillingListenerAndroid((details) => {
- *   await processExternalPayment(details.products, details.linkUri);
- *   if (details.externalTransactionToken) {
- *     await reportToGooglePlay(details.externalTransactionToken);
- *   }
+ *   void processExternalPayment(details.products, details.linkUri)
+ *     .then(() => details.externalTransactionToken
+ *       ? reportToGooglePlay(details.externalTransactionToken)
+ *       : undefined)
+ *     .catch((error) => console.warn('Developer billing failed', error));
  * });
  *
  * // Later, remove the listener
@@ -2784,7 +2787,8 @@ const normalizeProductQueryType = (
  * ```typescript
  * // Enable external offers before connecting
  * enableBillingProgramAndroid('external-offer');
- * await initConnection();
+ * const connected = await initConnection();
+ * if (!connected) throw new Error('Store connection failed');
  * ```
  */
 export const enableBillingProgramAndroid = (

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1583,17 +1583,22 @@ export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
  *
  * @example
  * ```ts
- * await initConnection();
- * await initConnection({ enableBillingProgramAndroid: 'external-offer' });
- * await initConnection({
- *   enableBillingProgramAndroid: 'billing-choice',
- *   billingChoiceScreenTypeAndroid: 'developer-rendered',
- * });
+ * // Choose exactly one connection call for the session.
+ * const connected = await initConnection();
+ * // Or replace the call above with one Android billing program:
+ * // const connected = await initConnection({
+ * //   enableBillingProgramAndroid: 'external-offer',
+ * // });
+ * // const connected = await initConnection({
+ * //   enableBillingProgramAndroid: 'billing-choice',
+ * //   billingChoiceScreenTypeAndroid: 'developer-rendered',
+ * // });
+ * if (!connected) throw new Error('Store connection failed');
  * ```
  *
- * @remarks Both `useIAP()` hooks initialize on mount. Expo closes the connection
- *   on unmount; React Native removes hook listeners and keeps the native connection
- *   open across screens. Pass options to the hook instead of calling this directly.
+ * @remarks When using `useIAP()`, the connection initializes on mount. On unmount,
+ *   React Native removes hook listeners but keeps the native connection open across
+ *   screens. Pass options to the hook instead of calling this directly.
  *
  * @see {@link https://openiap.dev/docs/apis/init-connection}
  */

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1591,8 +1591,9 @@ export const getTransactionJwsIOS: QueryField<'getTransactionJwsIOS'> = async (
  * });
  * ```
  *
- * @remarks When using `useIAP()`, connection is auto-managed on mount/unmount —
- *   pass options to the hook instead of calling this directly.
+ * @remarks Both `useIAP()` hooks initialize on mount. Expo closes the connection
+ *   on unmount; React Native removes hook listeners and keeps the native connection
+ *   open across screens. Pass options to the hook instead of calling this directly.
  *
  * @see {@link https://openiap.dev/docs/apis/init-connection}
  */

--- a/libraries/react-native-iap/src/index.ts
+++ b/libraries/react-native-iap/src/index.ts
@@ -1693,6 +1693,9 @@ export const restorePurchases: MutationField<'restorePurchases'> = async () => {
  *
  * @example
  * ```ts
+ * const connected = await initConnection();
+ * if (!connected) return;
+ *
  * await requestPurchase({
  *   request: {
  *     apple: { sku: 'com.app.premium' },

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -243,11 +243,15 @@ const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP(
   },
 });
 
-await fetchProducts({ skus: ['premium'], type: 'in-app' });
-await requestPurchase({
-  request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
-  type: 'in-app',
-});
+// useIAP opens the connection for you; wait for it before calling the store.
+// Android rejects store calls with `not-prepared` until it is open.
+if (connected) {
+  await fetchProducts({ skus: ['premium'], type: 'in-app' });
+  await requestPurchase({
+    request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
+    type: 'in-app',
+  });
+}
 ```
 
 ### Flutter

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -257,12 +257,12 @@ function PremiumButton() {
     <Button
       title="Buy premium"
       disabled={!connected}
-      onPress={() =>
-        requestPurchase({
+      onPress={() => {
+        void requestPurchase({
           request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
           type: 'in-app',
-        })
-      }
+        });
+      }}
     />
   );
 }

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T12:28:16.430Z
+> Generated: 2026-08-30T13:52:16.208Z
 
 ## Table of Contents
 1. Installation
@@ -241,8 +241,10 @@ import { useIAP } from 'expo-iap'; // or 'react-native-iap'
 
 function PremiumButton() {
   const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      await finishTransaction({ purchase, isConsumable: true });
+    onPurchaseSuccess: (purchase) => {
+      void finishTransaction({ purchase, isConsumable: true }).catch((error) => {
+        console.warn('Transaction finalization failed:', error);
+      });
     },
   });
 

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T14:04:15.487Z
+> Generated: 2026-08-30T14:13:22.229Z
 
 ## Table of Contents
 1. Installation

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T14:13:22.229Z
+> Generated: 2026-08-30T14:27:27.189Z
 
 ## Table of Contents
 1. Installation
@@ -275,20 +275,26 @@ function PremiumButton() {
 ### Flutter
 ```dart
 final iap = FlutterInappPurchase.instance;
-await iap.initConnection();
+final connected = await iap.initConnection();
+if (!connected) throw StateError('Store connection failed');
 final products = await iap.fetchProducts<Product>(
   skus: ['premium'],
   type: ProductQueryType.InApp,
 );
-iap.purchaseUpdatedListener.listen((purchase) async {
-  await iap.finishTransaction(purchase: purchase, isConsumable: true);
+iap.purchaseUpdatedListener.listen((purchase) {
+  iap
+      .finishTransaction(purchase: purchase, isConsumable: true)
+      .catchError((Object error) => print('Transaction finalization failed: $error'));
 });
 ```
 
 ### Godot
 ```gdscript
 GodotIapPlugin.purchase_updated.connect(_on_purchase_updated)
-GodotIapPlugin.init_connection()
+var connected = await GodotIapPlugin.init_connection()
+if not connected:
+    push_error("Store connection failed")
+    return
 await GodotIapPlugin.fetch_products(request)
 GodotIapPlugin.request_purchase(props)
 ```
@@ -296,7 +302,8 @@ GodotIapPlugin.request_purchase(props)
 ### Kotlin Multiplatform
 ```kotlin
 val iap = KmpIAP()
-iap.initConnection()
+val connected = iap.initConnection()
+check(connected) { "Store connection failed" }
 val products = iap.fetchProducts {
     skus = listOf("premium")
     type = ProductQueryType.InApp
@@ -312,7 +319,8 @@ using OpenIap;
 using OpenIap.Maui;
 
 var iap = OpenIapClient.Instance;
-await ((MutationResolver)iap).InitConnectionAsync();
+var connected = await ((MutationResolver)iap).InitConnectionAsync();
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 await ((QueryResolver)iap).FetchProductsAsync(new ProductRequest
 {
@@ -320,13 +328,23 @@ await ((QueryResolver)iap).FetchProductsAsync(new ProductRequest
     Type = ProductQueryType.InApp,
 });
 
-((IOpenIap)iap).PurchaseUpdated.Subscribe(async purchase =>
+async Task FinishPurchaseSafelyAsync(Purchase purchase)
 {
-    await ((MutationResolver)iap).FinishTransactionAsync(
-        new PurchaseInput(purchase),
-        isConsumable: true
-    );
-});
+    try
+    {
+        await ((MutationResolver)iap).FinishTransactionAsync(
+            new PurchaseInput(purchase),
+            isConsumable: true
+        );
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Transaction finalization failed: {error.Message}");
+    }
+}
+
+((IOpenIap)iap).PurchaseUpdated.Subscribe(
+    purchase => _ = FinishPurchaseSafelyAsync(purchase));
 ```
 
 ---

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-29T02:53:33.696Z
+> Generated: 2026-08-30T07:53:06.299Z
 
 ## Table of Contents
 1. Installation

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T11:49:44.645Z
+> Generated: 2026-08-30T12:28:16.430Z
 
 ## Table of Contents
 1. Installation
@@ -261,6 +261,8 @@ function PremiumButton() {
         void requestPurchase({
           request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
           type: 'in-app',
+        }).catch((error) => {
+          console.warn('Purchase dispatch failed:', error);
         });
       }}
     />

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T14:27:27.189Z
+> Generated: 2026-08-30T15:06:51.142Z
 
 ## Table of Contents
 1. Installation
@@ -275,17 +275,17 @@ function PremiumButton() {
 ### Flutter
 ```dart
 final iap = FlutterInappPurchase.instance;
+iap.purchaseUpdatedListener.listen((purchase) {
+  iap
+      .finishTransaction(purchase: purchase, isConsumable: true)
+      .catchError((Object error) => print('Transaction finalization failed: $error'));
+});
 final connected = await iap.initConnection();
 if (!connected) throw StateError('Store connection failed');
 final products = await iap.fetchProducts<Product>(
   skus: ['premium'],
   type: ProductQueryType.InApp,
 );
-iap.purchaseUpdatedListener.listen((purchase) {
-  iap
-      .finishTransaction(purchase: purchase, isConsumable: true)
-      .catchError((Object error) => print('Transaction finalization failed: $error'));
-});
 ```
 
 ### Godot
@@ -302,15 +302,20 @@ GodotIapPlugin.request_purchase(props)
 ### Kotlin Multiplatform
 ```kotlin
 val iap = KmpIAP()
+val purchaseJob = appScope.launch(
+    start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+) {
+    iap.purchaseUpdatedListener.collect { purchase ->
+        iap.finishTransaction(purchase = purchase, isConsumable = true)
+    }
+}
 val connected = iap.initConnection()
 check(connected) { "Store connection failed" }
 val products = iap.fetchProducts {
     skus = listOf("premium")
     type = ProductQueryType.InApp
 }
-iap.purchaseUpdatedListener.collect { purchase ->
-    iap.finishTransaction(purchase = purchase, isConsumable = true)
-}
+// purchaseJob.cancel() at the connection owner's teardown boundary.
 ```
 
 ### .NET MAUI

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T08:33:36.232Z
+> Generated: 2026-08-30T11:49:44.645Z
 
 ## Table of Contents
 1. Installation
@@ -248,7 +248,9 @@ function PremiumButton() {
 
   useEffect(() => {
     if (!connected) return;
-    void fetchProducts({ skus: ['premium'], type: 'in-app' });
+    void fetchProducts({ skus: ['premium'], type: 'in-app' }).catch((error) =>
+      console.warn('Product fetch failed:', error),
+    );
   }, [connected, fetchProducts]);
 
   return (

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T07:53:06.299Z
+> Generated: 2026-08-30T08:33:36.232Z
 
 ## Table of Contents
 1. Installation
@@ -235,22 +235,34 @@ is selected at the runtime integration layer.
 
 ### React Native / Expo
 ```typescript
+import { useEffect } from 'react';
+import { Button } from 'react-native';
 import { useIAP } from 'expo-iap'; // or 'react-native-iap'
 
-const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP({
-  onPurchaseSuccess: async (purchase) => {
-    await finishTransaction({ purchase, isConsumable: true });
-  },
-});
-
-// useIAP opens the connection for you; wait for it before calling the store.
-// Android rejects store calls with `not-prepared` until it is open.
-if (connected) {
-  await fetchProducts({ skus: ['premium'], type: 'in-app' });
-  await requestPurchase({
-    request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
-    type: 'in-app',
+function PremiumButton() {
+  const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP({
+    onPurchaseSuccess: async (purchase) => {
+      await finishTransaction({ purchase, isConsumable: true });
+    },
   });
+
+  useEffect(() => {
+    if (!connected) return;
+    void fetchProducts({ skus: ['premium'], type: 'in-app' });
+  }, [connected, fetchProducts]);
+
+  return (
+    <Button
+      title="Buy premium"
+      disabled={!connected}
+      onPress={() =>
+        requestPurchase({
+          request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
+          type: 'in-app',
+        })
+      }
+    />
+  );
 }
 ```
 

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-08-30T13:52:16.208Z
+> Generated: 2026-08-30T14:04:15.487Z
 
 ## Table of Contents
 1. Installation

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T13:52:16.208Z
+> Generated: 2026-08-30T14:04:15.487Z
 
 ## Installation
 
@@ -163,11 +163,11 @@ import {
 } from 'expo-iap';
 
 // Set up before any purchase request
-const purchaseUpdateSubscription = purchaseUpdatedListener(async (purchase) => {
-  // 1. Verify purchase on server
-  // 2. Grant entitlement
-  // 3. Finish transaction
-  await finishTransaction({ purchase, isConsumable: false });
+const purchaseUpdateSubscription = purchaseUpdatedListener((purchase) => {
+  // After server verification and entitlement grant, finish the transaction.
+  void finishTransaction({ purchase, isConsumable: false }).catch((error) => {
+    console.warn('Transaction finalization failed:', error);
+  });
 });
 
 const purchaseErrorSubscription = purchaseErrorListener((error) => {

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T08:33:36.232Z
+> Generated: 2026-08-30T11:49:44.645Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T14:04:15.487Z
+> Generated: 2026-08-30T14:13:22.229Z
 
 ## Installation
 
@@ -91,13 +91,13 @@ Current NuGet package version: 2.4.1
 
 ### Connection
 ```typescript
-// Initialize (required before any operation)
-await initConnection();
+// Choose one call: remove the config for a standard connection.
+const connected = await initConnection({
+  enableBillingProgramAndroid: 'user-choice-billing',
+});
+if (!connected) throw new Error('Store connection failed');
 
-// With a billing program (Android)
-await initConnection({ enableBillingProgramAndroid: 'user-choice-billing' });
-
-// Cleanup on unmount
+// Cleanup at the connection owner's teardown boundary.
 await endConnection();
 ```
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T11:49:44.645Z
+> Generated: 2026-08-30T12:28:16.430Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T07:53:06.299Z
+> Generated: 2026-08-30T08:33:36.232Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-29T02:53:33.696Z
+> Generated: 2026-08-30T07:53:06.299Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T12:28:16.430Z
+> Generated: 2026-08-30T13:52:16.208Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T14:27:27.189Z
+> Generated: 2026-08-30T15:06:51.142Z
 
 ## Installation
 
@@ -98,7 +98,8 @@ const connected = await initConnection({
 if (!connected) throw new Error('Store connection failed');
 
 // Cleanup at the connection owner's teardown boundary.
-await endConnection();
+const ended = await endConnection();
+if (!ended) console.warn('Store teardown did not complete');
 ```
 
 ### Fetch Products
@@ -263,9 +264,9 @@ interface PurchaseError {
 
 ## Purchase Flow Summary
 
-1. initConnection()
-2. fetchProducts({ skus: [...], type: 'in-app' })
-3. Set up purchaseUpdatedListener
+1. Set up purchaseUpdatedListener and purchaseErrorListener
+2. initConnection()
+3. fetchProducts({ skus: [...], type: 'in-app' })
 4. requestPurchase({ request: { apple: { sku }, google: { skus: [sku] } }, type: 'in-app' })
 5. In listener: verify -> grant -> finishTransaction()
 6. endConnection() on cleanup

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Unified in-app purchase specification for iOS & Android
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-08-30T14:13:22.229Z
+> Generated: 2026-08-30T14:27:27.189Z
 
 ## Installation
 

--- a/packages/docs/src/components/StoreConnectionCallout.tsx
+++ b/packages/docs/src/components/StoreConnectionCallout.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+import Callout from './Callout';
+
+interface StoreConnectionCalloutProps {
+  purchaseErrorEvent?: boolean;
+}
+
+function StoreConnectionCallout({
+  purchaseErrorEvent = false,
+}: StoreConnectionCalloutProps) {
+  return (
+    <Callout kind="important" title="Requires an open connection">
+      <p>
+        <strong>React Native / Expo:</strong> wait for the hook&apos;s{' '}
+        <code>connected</code> flag, or call{' '}
+        <Link to="/docs/apis/init-connection">
+          <code>initConnection()</code>
+        </Link>{' '}
+        and require a <code>true</code> result. Android does not connect
+        implicitly;{' '}
+        {purchaseErrorEvent ? (
+          <>
+            a disconnected purchase reports <code>not-prepared</code> through
+            the purchase-error event
+          </>
+        ) : (
+          <>
+            a disconnected call rejects with <code>not-prepared</code>
+          </>
+        )}
+        . iOS can connect on demand, but the same gate keeps behavior consistent
+        across platforms.
+      </p>
+    </Callout>
+  );
+}
+
+export default StoreConnectionCallout;

--- a/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/acknowledge-purchase-android.tsx
@@ -4,6 +4,7 @@ import Callout from '../../../../components/Callout';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function AcknowledgePurchaseAndroid() {
@@ -52,6 +53,8 @@ function AcknowledgePurchaseAndroid() {
         API instead, which handles acknowledgment automatically and is the
         recommended path for new code.
       </Callout>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/consume-purchase-android.tsx
@@ -4,6 +4,7 @@ import Callout from '../../../../components/Callout';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function ConsumePurchaseAndroid() {
@@ -48,6 +49,8 @@ function ConsumePurchaseAndroid() {
         (or acknowledges) the purchase automatically and stays
         forward-compatible with the new Billing Programs API.
       </Callout>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/create-billing-program-reporting-details-android.tsx
@@ -4,6 +4,7 @@ import Callout from '../../../../components/Callout';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function CreateBillingProgramReportingDetailsAndroid() {
@@ -59,6 +60,8 @@ function CreateBillingProgramReportingDetailsAndroid() {
         from an earlier launch attempt. See the complete{' '}
         <Link to="/docs/features/external-purchase">External Offer flow</Link>.
       </Callout>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/enable-billing-program-android.tsx
@@ -125,29 +125,30 @@ func init_connection(config: InitConnectionConfig) -> bool`}</CodeBlock>
       <LanguageTabs>
         {{
           kotlin: (
-            <CodeBlock language="kotlin">{`openIapStore.initConnection(
+            <CodeBlock language="kotlin">{`check(openIapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
     )
-)`}</CodeBlock>
+)) { "Store connection failed" }`}</CodeBlock>
           ),
           kmp: (
             <CodeBlock language="kotlin">{`// kmp-iap (Android targets only)
-kmpIAP.initConnection(
+check(kmpIAP.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
     )
-)`}</CodeBlock>
+)) { "Store connection failed" }`}</CodeBlock>
           ),
           typescript: (
             <CodeBlock language="typescript">{`// expo-iap (also exported from react-native-iap)
 import { initConnection } from 'expo-iap';
 
-await initConnection({
+const connected = await initConnection({
   enableBillingProgramAndroid: 'external-offer',
   // 'user-choice-billing' | 'external-content-link' | 'external-offer'
   // | 'external-payments' | 'billing-choice'
 });
+if (!connected) throw new Error('Store connection failed');
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
 // useIAP auto-connects on mount and accepts the same enableBillingProgramAndroid
@@ -163,26 +164,30 @@ function App() {
           ),
           dart: (
             <CodeBlock language="dart">{`if (Platform.isAndroid) {
-  await FlutterInappPurchase.instance.initConnection(
+  final connected = await FlutterInappPurchase.instance.initConnection(
     enableBillingProgramAndroid: BillingProgramAndroid.ExternalOffer,
   );
+  if (!connected) throw StateError('Store connection failed');
 }`}</CodeBlock>
           ),
           csharp: (
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
     new InitConnectionConfig
     {
         EnableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer,
-    });`}</CodeBlock>
+    });
+if (!connected) throw new InvalidOperationException("Store connection failed");`}</CodeBlock>
           ),
           gdscript: (
             <CodeBlock language="gdscript">{`if iap.get_platform() == "Android":
     var config = InitConnectionConfig.new()
     config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-    await iap.init_connection(config)`}</CodeBlock>
+    var connected = await iap.init_connection(config)
+    if not connected:
+        push_error("Store connection failed")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/get-billing-choice-info-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/get-billing-choice-info-android.tsx
@@ -3,6 +3,7 @@ import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function GetBillingChoiceInfoAndroid() {
@@ -33,6 +34,8 @@ function GetBillingChoiceInfoAndroid() {
         </Link>{' '}
         returns <code>choiceScreenType: 'developer-rendered'</code>.
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/is-billing-program-available-android.tsx
@@ -3,6 +3,7 @@ import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function IsBillingProgramAvailableAndroid() {
@@ -43,6 +44,8 @@ function IsBillingProgramAvailableAndroid() {
         </a>
         .
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/launch-external-link-android.tsx
@@ -3,6 +3,7 @@ import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function LaunchExternalLinkAndroid() {
@@ -41,6 +42,8 @@ function LaunchExternalLinkAndroid() {
         </a>
         .
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/show-billing-program-information-dialog-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-billing-program-information-dialog-android.tsx
@@ -3,6 +3,7 @@ import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function ShowBillingProgramInformationDialogAndroid() {
@@ -32,6 +33,8 @@ function ShowBillingProgramInformationDialogAndroid() {
         <code>IN_APP</code> reporting token and before showing your choice
         screen. Google-rendered and external-link flows do not use this step.
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/android/show-in-app-messages-android.tsx
+++ b/packages/docs/src/pages/docs/apis/android/show-in-app-messages-android.tsx
@@ -3,6 +3,7 @@ import AnchorLink from '../../../../components/AnchorLink';
 import CodeBlock from '../../../../components/CodeBlock';
 import LanguageTabs from '../../../../components/LanguageTabs';
 import SEO from '../../../../components/SEO';
+import StoreConnectionCallout from '../../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../../hooks/useScrollToHash';
 
 function ShowInAppMessagesAndroid() {
@@ -43,6 +44,8 @@ function ShowInAppMessagesAndroid() {
         </a>
         .
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -92,37 +92,39 @@ function EndConnection() {
 import { Text } from 'react-native';
 
 // expo-iap
-import { endConnection, initConnection } from 'expo-iap';
+import { endConnection, initConnection, useIAP } from 'expo-iap';
 // Same API in react-native-iap:
-// import { endConnection, initConnection } from 'react-native-iap';
+// import { endConnection, initConnection, useIAP } from 'react-native-iap';
 
-// In React useEffect cleanup
-useEffect(() => {
-  void initConnection()
-    .then((connected) => {
-      if (!connected) throw new Error('Store connection failed');
-    })
-    .catch((error) => {
-      console.warn('Store connection failed:', error);
-    });
+function ManualStoreConnection() {
+  useEffect(() => {
+    void initConnection()
+      .then((connected) => {
+        if (!connected) throw new Error('Store connection failed');
+      })
+      .catch((error) => {
+        console.warn('Store connection failed:', error);
+      });
 
-  return () => {
-    void endConnection().catch((error) => {
-      console.warn('Store teardown failed:', error);
-    });
-  };
-}, []);
+    return () => {
+      void endConnection().catch((error) => {
+        console.warn('Store teardown failed:', error);
+      });
+    };
+  }, []);
+
+  return <Text>Manual store connection</Text>;
+}
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
-// useIAP automatically calls endConnection() when the component unmounts,
-// so you only need the module-level call when you want to tear the
-// connection down outside of the hook's lifecycle (e.g. on sign-out).
-import { useIAP } from 'expo-iap';
+// Expo calls endConnection() when the component unmounts. React Native removes
+// the hook's listeners but keeps the native connection open across screens;
+// call the module-level endConnection() at an app-level teardown boundary such
+// as sign-out when the connection should actually close.
 
 function PurchaseScreen() {
   const { connected } = useIAP();
 
-  // No explicit endConnection() call needed — the hook handles cleanup.
   return <Text>Store ready: {String(connected)}</Text>;
 }`}</CodeBlock>
           ),

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -110,9 +110,13 @@ function ManualStoreConnection() {
       });
 
     return () => {
-      void endConnection().catch((error) => {
-        console.warn('Store teardown failed:', error);
-      });
+      void endConnection()
+        .then((ended) => {
+          if (!ended) console.warn('Store teardown did not complete');
+        })
+        .catch((error) => {
+          console.warn('Store teardown failed:', error);
+        });
     };
   }, []);
 
@@ -132,27 +136,34 @@ function PurchaseScreen() {
 }`}</CodeBlock>
           ),
           swift: (
-            <CodeBlock language="swift">{`try await OpenIapModule.shared.endConnection()`}</CodeBlock>
+            <CodeBlock language="swift">{`let ended = try await OpenIapModule.shared.endConnection()
+if !ended { print("Store teardown did not complete") }`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`openIapStore.endConnection()`}</CodeBlock>
+            <CodeBlock language="kotlin">{`val ended = openIapStore.endConnection()
+if (!ended) println("Store teardown did not complete")`}</CodeBlock>
           ),
           kmp: (
-            <CodeBlock language="kotlin">{`kmpIAP.endConnection()`}</CodeBlock>
+            <CodeBlock language="kotlin">{`val ended = kmpIAP.endConnection()
+if (!ended) println("Store teardown did not complete")`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`await FlutterInappPurchase.instance.endConnection();`}</CodeBlock>
+            <CodeBlock language="dart">{`final ended = await FlutterInappPurchase.instance.endConnection();
+if (!ended) print('Store teardown did not complete');`}</CodeBlock>
           ),
           csharp: (
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-await ((MutationResolver)OpenIapClient.Instance).EndConnectionAsync();`}</CodeBlock>
+var ended = await ((MutationResolver)OpenIapClient.Instance).EndConnectionAsync();
+if (!ended) Console.WriteLine("Store teardown did not complete");`}</CodeBlock>
           ),
           gdscript: (
             <CodeBlock language="gdscript">{`# In _exit_tree or cleanup
 func _exit_tree():
-    await iap.end_connection()`}</CodeBlock>
+    var ended = await iap.end_connection()
+    if not ended:
+        push_warning("Store teardown did not complete")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -11,14 +11,16 @@ function EndConnection() {
     <div className="doc-page">
       <SEO
         title="endConnection"
-        description="End the OpenIAP connection to the store service. Call when your app closes or the IAP component unmounts."
+        description="End the OpenIAP connection to the store service when the app-wide IAP session is no longer needed."
         path="/docs/apis/end-connection"
         keywords="endConnection, OpenIAP cleanup, billing client close"
       />
       <h1>endConnection</h1>
       <p>
-        End connection to the store service. Call this when your app closes or
-        the IAP component unmounts to clean up resources.
+        End connection to the store service. Call this when the owner of a
+        manually managed connection unmounts or when the app-wide IAP session is
+        no longer needed. Hook cleanup differs by framework; see the example
+        below.
       </p>
       <p>
         <strong>iOS:</strong> Cancels the StoreKit{' '}

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -88,17 +88,28 @@ function EndConnection() {
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
-import { endConnection } from 'expo-iap';
+            <CodeBlock language="typescript">{`import { useEffect } from 'react';
+import { Text } from 'react-native';
+
+// expo-iap
+import { endConnection, initConnection } from 'expo-iap';
 // Same API in react-native-iap:
-// import { endConnection } from 'react-native-iap';
+// import { endConnection, initConnection } from 'react-native-iap';
 
 // In React useEffect cleanup
 useEffect(() => {
-  void initConnection();
+  void initConnection()
+    .then((connected) => {
+      if (!connected) throw new Error('Store connection failed');
+    })
+    .catch((error) => {
+      console.warn('Store connection failed:', error);
+    });
 
   return () => {
-    void endConnection();
+    void endConnection().catch((error) => {
+      console.warn('Store teardown failed:', error);
+    });
   };
 }, []);
 

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -45,11 +45,11 @@ function EndConnection() {
         .
       </p>
       <p>
-        <strong>React Native / Expo:</strong> cleanup after an unsuccessful
-        native teardown is platform-specific. Treat a rejection or{' '}
-        <code>false</code> as a failed teardown; when retrying, reconnect and
-        register fresh listeners instead of assuming existing listener handles
-        remain valid.
+        <strong>React Native / Expo:</strong> if native teardown throws, the
+        promise rejects without clearing the current connection or listener
+        state, so the app can retry. If teardown resolves <code>false</code>,
+        the bridge has already cleared its connection state and listeners;
+        reconnect and register fresh listeners before the next store call.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -42,6 +42,12 @@ function EndConnection() {
         </a>
         .
       </p>
+      <p>
+        <strong>React Native / Expo:</strong> if native teardown fails, the
+        promise rejects without clearing the current connection or listener
+        state. Cleanup happens only after a successful teardown, so the app can
+        retry without silently losing purchase events.
+      </p>
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/end-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/end-connection.tsx
@@ -45,10 +45,11 @@ function EndConnection() {
         .
       </p>
       <p>
-        <strong>React Native / Expo:</strong> if native teardown fails, the
-        promise rejects without clearing the current connection or listener
-        state. Cleanup happens only after a successful teardown, so the app can
-        retry without silently losing purchase events.
+        <strong>React Native / Expo:</strong> cleanup after an unsuccessful
+        native teardown is platform-specific. Treat a rejection or{' '}
+        <code>false</code> as a failed teardown; when retrying, reconnect and
+        register fresh listeners instead of assuming existing listener handles
+        remain valid.
       </p>
 
       <h2>Signature</h2>

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -51,6 +51,18 @@ function FetchProducts() {
         variants.
       </p>
 
+      <Callout kind="important" title="Requires an open connection">
+        <p>
+          Call{' '}
+          <Link to="/docs/apis/init-connection">
+            <code>initConnection()</code>
+          </Link>{' '}
+          first. On Android this call fails with <code>not-prepared</code>{' '}
+          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
+          flag so the same code works on both.
+        </p>
+      </Callout>
+
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs
       </AnchorLink>
@@ -372,14 +384,15 @@ import { FlatList, Text } from 'react-native';
 import { useIAP } from 'expo-iap';
 
 function ProductList() {
-  const { products, fetchProducts } = useIAP();
+  const { connected, products, fetchProducts } = useIAP();
 
   useEffect(() => {
+    if (!connected) return;
     void fetchProducts({
       skus: ['com.app.coins_100', 'com.app.premium'],
       type: 'in-app',
     });
-  }, [fetchProducts]);
+  }, [connected, fetchProducts]);
 
   return (
     <FlatList

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function FetchProducts() {
@@ -51,17 +52,7 @@ function FetchProducts() {
         variants.
       </p>
 
-      <Callout kind="important" title="Requires an open connection">
-        <p>
-          Call{' '}
-          <Link to="/docs/apis/init-connection">
-            <code>initConnection()</code>
-          </Link>{' '}
-          first. On Android this call fails with <code>not-prepared</code>{' '}
-          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
-          flag so the same code works on both.
-        </p>
-      </Callout>
+      <StoreConnectionCallout />
 
       <AnchorLink id="request-apis" level="h2">
         Note about <code>request*</code> APIs

--- a/packages/docs/src/pages/docs/apis/fetch-products.tsx
+++ b/packages/docs/src/pages/docs/apis/fetch-products.tsx
@@ -391,7 +391,7 @@ function ProductList() {
     void fetchProducts({
       skus: ['com.app.coins_100', 'com.app.premium'],
       type: 'in-app',
-    });
+    }).catch((error) => console.warn('Product fetch failed:', error));
   }, [connected, fetchProducts]);
 
   return (

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -136,14 +136,16 @@ import { finishTransaction, purchaseUpdatedListener } from 'expo-iap';
 // Same API in react-native-iap:
 // import { finishTransaction, purchaseUpdatedListener } from 'react-native-iap';
 
-purchaseUpdatedListener(async (purchase) => {
-  const verified = await verifyOnServer(purchase);
-  if (!verified) return;
+purchaseUpdatedListener((purchase) => {
+  void verifyOnServer(purchase)
+    .then(async (verified) => {
+      if (!verified) return;
 
-  await grantProduct(purchase.productId);
-
-  const isConsumable = purchase.productId.includes('coins');
-  await finishTransaction({ purchase, isConsumable });
+      await grantProduct(purchase.productId);
+      const isConsumable = purchase.productId.includes('coins');
+      await finishTransaction({ purchase, isConsumable });
+    })
+    .catch((error) => console.warn('Purchase finalization failed:', error));
 });
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
@@ -153,13 +155,18 @@ import { useIAP } from 'expo-iap';
 
 function PurchaseScreen() {
   const { finishTransaction } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      const verified = await verifyOnServer(purchase);
-      if (!verified) return;
+    onPurchaseSuccess: (purchase) => {
+      void verifyOnServer(purchase)
+        .then(async (verified) => {
+          if (!verified) return;
 
-      await grantProduct(purchase.productId);
-      const isConsumable = purchase.productId.includes('coins');
-      await finishTransaction({ purchase, isConsumable });
+          await grantProduct(purchase.productId);
+          const isConsumable = purchase.productId.includes('coins');
+          await finishTransaction({ purchase, isConsumable });
+        })
+        .catch((error) =>
+          console.warn('Purchase finalization failed:', error),
+        );
     },
   });
 

--- a/packages/docs/src/pages/docs/apis/finish-transaction.tsx
+++ b/packages/docs/src/pages/docs/apis/finish-transaction.tsx
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function FinishTransaction() {
@@ -46,6 +47,8 @@ function FinishTransaction() {
         </a>
         .
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
+import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -89,6 +90,18 @@ func get_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
           ),
         }}
       </LanguageTabs>
+
+      <Callout kind="important" title="Requires an open connection">
+        <p>
+          Call{' '}
+          <Link to="/docs/apis/init-connection">
+            <code>initConnection()</code>
+          </Link>{' '}
+          first. On Android this call fails with <code>not-prepared</code>{' '}
+          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
+          flag so the same code works on both.
+        </p>
+      </Callout>
 
       <AnchorLink id="parameters" level="h2">
         Parameters
@@ -200,11 +213,12 @@ import { FlatList, Text } from 'react-native';
 import { useIAP } from 'expo-iap';
 
 function SubscriptionStatus() {
-  const { activeSubscriptions, getActiveSubscriptions } = useIAP();
+  const { connected, activeSubscriptions, getActiveSubscriptions } = useIAP();
 
   useEffect(() => {
+    if (!connected) return;
     void getActiveSubscriptions();
-  }, [getActiveSubscriptions]);
+  }, [connected, getActiveSubscriptions]);
 
   return (
     <FlatList

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -217,7 +217,9 @@ function SubscriptionStatus() {
 
   useEffect(() => {
     if (!connected) return;
-    void getActiveSubscriptions();
+    void getActiveSubscriptions().catch((error) =>
+      console.warn('Subscription lookup failed:', error),
+    );
   }, [connected, getActiveSubscriptions]);
 
   return (

--- a/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/get-active-subscriptions.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
-import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function GetActiveSubscriptions() {
@@ -91,17 +91,7 @@ func get_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         }}
       </LanguageTabs>
 
-      <Callout kind="important" title="Requires an open connection">
-        <p>
-          Call{' '}
-          <Link to="/docs/apis/init-connection">
-            <code>initConnection()</code>
-          </Link>{' '}
-          first. On Android this call fails with <code>not-prepared</code>{' '}
-          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
-          flag so the same code works on both.
-        </p>
-      </Callout>
+      <StoreConnectionCallout />
 
       <AnchorLink id="parameters" level="h2">
         Parameters

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
-import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function GetAvailablePurchases() {
@@ -92,17 +92,7 @@ func get_available_purchases_result(options: PurchaseOptions = null) -> Dictiona
         }}
       </LanguageTabs>
 
-      <Callout kind="important" title="Requires an open connection">
-        <p>
-          Call{' '}
-          <Link to="/docs/apis/init-connection">
-            <code>initConnection()</code>
-          </Link>{' '}
-          first. On Android this call fails with <code>not-prepared</code>{' '}
-          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
-          flag so the same code works on both.
-        </p>
-      </Callout>
+      <StoreConnectionCallout />
 
       <AnchorLink id="parameters" level="h2">
         Parameters

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -170,25 +170,37 @@ func get_available_purchases_result(options: PurchaseOptions = null) -> Dictiona
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
-import { getAvailablePurchases, finishTransaction } from 'expo-iap';
+            <CodeBlock language="typescript">{`import { useEffect } from 'react';
+
+// expo-iap
+import {
+  getAvailablePurchases,
+  finishTransaction,
+  useIAP,
+} from 'expo-iap';
 // Same API in react-native-iap:
-// import { getAvailablePurchases, finishTransaction } from 'react-native-iap';
+// import {
+//   getAvailablePurchases,
+//   finishTransaction,
+//   useIAP,
+// } from 'react-native-iap';
 
-const purchases = await getAvailablePurchases();
+try {
+  const purchases = await getAvailablePurchases();
 
-for (const purchase of purchases) {
-  const verified = await verifyOnServer(purchase);
-  if (verified) {
-    await finishTransaction({ purchase, isConsumable: false });
+  for (const purchase of purchases) {
+    const verified = await verifyOnServer(purchase);
+    if (verified) {
+      await finishTransaction({ purchase, isConsumable: false });
+    }
   }
+} catch (error) {
+  console.warn('Purchase restore failed:', error);
 }
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
 // useIAP's getAvailablePurchases() returns Promise<void> and updates the
 // reactive availablePurchases array — process new entries inside an effect.
-import { useEffect } from 'react';
-import { useIAP } from 'expo-iap';
 
 function PendingPurchases() {
   const {
@@ -206,14 +218,16 @@ function PendingPurchases() {
   }, [connected, getAvailablePurchases]);
 
   useEffect(() => {
-    (async () => {
+    void (async () => {
       for (const purchase of availablePurchases) {
         const verified = await verifyOnServer(purchase);
         if (verified) {
           await finishTransaction({ purchase, isConsumable: false });
         }
       }
-    })();
+    })().catch((error) => {
+      console.warn('Restored purchase processing failed:', error);
+    });
   }, [availablePurchases, finishTransaction]);
 
   return null;

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
+import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -90,6 +91,18 @@ func get_available_purchases_result(options: PurchaseOptions = null) -> Dictiona
           ),
         }}
       </LanguageTabs>
+
+      <Callout kind="important" title="Requires an open connection">
+        <p>
+          Call{' '}
+          <Link to="/docs/apis/init-connection">
+            <code>initConnection()</code>
+          </Link>{' '}
+          first. On Android this call fails with <code>not-prepared</code>{' '}
+          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
+          flag so the same code works on both.
+        </p>
+      </Callout>
 
       <AnchorLink id="parameters" level="h2">
         Parameters
@@ -187,12 +200,17 @@ for (const purchase of purchases) {
 import { useIAP } from 'expo-iap';
 
 function PendingPurchases() {
-  const { availablePurchases, getAvailablePurchases, finishTransaction } =
-    useIAP();
+  const {
+    connected,
+    availablePurchases,
+    getAvailablePurchases,
+    finishTransaction,
+  } = useIAP();
 
   useEffect(() => {
+    if (!connected) return;
     void getAvailablePurchases();
-  }, [getAvailablePurchases]);
+  }, [connected, getAvailablePurchases]);
 
   useEffect(() => {
     (async () => {

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -187,6 +187,7 @@ for (const purchase of purchases) {
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
 // useIAP's getAvailablePurchases() returns Promise<void> and updates the
 // reactive availablePurchases array — process new entries inside an effect.
+import { useEffect } from 'react';
 import { useIAP } from 'expo-iap';
 
 function PendingPurchases() {

--- a/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/get-available-purchases.tsx
@@ -209,7 +209,9 @@ function PendingPurchases() {
 
   useEffect(() => {
     if (!connected) return;
-    void getAvailablePurchases();
+    void getAvailablePurchases().catch((error) =>
+      console.warn('Purchase restore failed:', error),
+    );
   }, [connected, getAvailablePurchases]);
 
   useEffect(() => {

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -89,13 +89,20 @@ function GetStorefront() {
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
+            <CodeBlock language="typescript">{`import { useEffect, useState } from 'react';
+import { Text } from 'react-native';
+
+// expo-iap
 import { getStorefront } from 'expo-iap';
 // Same API in react-native-iap:
 // import { getStorefront } from 'react-native-iap';
 
-const countryCode = await getStorefront();
-console.log(countryCode); // iOS: "USA"; Android/Amazon: "US"
+try {
+  const countryCode = await getStorefront();
+  console.log(countryCode); // iOS: "USA"; Android/Amazon: "US"
+} catch (error) {
+  console.warn('Storefront lookup failed:', error);
+}
 
 // --- Or alongside the useIAP() hook (also exported from react-native-iap) ---
 // getStorefront is a module-level helper; useIAP doesn't expose it on the
@@ -109,7 +116,11 @@ function StorefrontBadge() {
 
   useEffect(() => {
     if (!connected) return;
-    void getStorefront().then(setCountry);
+    void getStorefront()
+      .then(setCountry)
+      .catch((error) => {
+        console.warn('Storefront lookup failed:', error);
+      });
   }, [connected]);
 
   return <Text>Storefront: {country}</Text>;

--- a/packages/docs/src/pages/docs/apis/get-storefront.tsx
+++ b/packages/docs/src/pages/docs/apis/get-storefront.tsx
@@ -2,6 +2,7 @@ import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function GetStorefront() {
@@ -40,6 +41,8 @@ function GetStorefront() {
         </a>
         .
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
-import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function HasActiveSubscriptions() {
@@ -79,18 +79,12 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         }}
       </LanguageTabs>
 
-      <Callout kind="important" title="Requires an open connection">
-        <p>
-          Call{' '}
-          <Link to="/docs/apis/init-connection">
-            <code>initConnection()</code>
-          </Link>{' '}
-          first. React Native, Expo, and native promise APIs reject on failure.
-          React Native and Expo hooks call <code>onError</code> before
-          rethrowing. Gate hook examples on the <code>connected</code> flag and
-          handle failures separately from a valid <code>false</code> result.
-        </p>
-      </Callout>
+      <StoreConnectionCallout />
+      <p>
+        React Native, Expo, and native promise APIs reject on failure. React
+        Native and Expo hooks call <code>onError</code> before rethrowing.
+        Handle that rejection separately from a valid <code>false</code> result.
+      </p>
 
       <AnchorLink id="parameters" level="h2">
         Parameters

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -85,9 +85,11 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
           <Link to="/docs/apis/init-connection">
             <code>initConnection()</code>
           </Link>{' '}
-          first. React Native, Expo, and native promise APIs reject. The React
-          Native and Expo hooks call <code>onError</code> before rethrowing.
-          Gate hook examples on the <code>connected</code> flag.
+          first. React Native, Expo, and the native promise APIs reject when the
+          store cannot determine subscription status; the framework hooks call{' '}
+          <code>onError</code> before rethrowing. Gate hook examples on the{' '}
+          <code>connected</code> flag and handle failures separately from a
+          valid <code>false</code> result.
         </p>
       </Callout>
 
@@ -117,12 +119,12 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         when you only need a yes/no answer.
       </p>
       <p>
-        React Native, Expo, and native promise APIs reject on failure. The React
-        Native and Expo hooks call <code>onError</code> before rethrowing.
-        Godot's compatibility boolean helper still maps failure to{' '}
-        <code>false</code> and is not safe for granting or revoking access;
-        entitlement code must use <code>has_active_subscriptions_result()</code>
-        .
+        React Native, Expo, and the native promise APIs reject on store errors;
+        framework hooks call <code>onError</code> before rethrowing. Only a
+        successful empty query resolves <code>false</code>. Godot entitlement
+        code must use <code>has_active_subscriptions_result()</code>; the
+        compatibility boolean helper still maps failure to <code>false</code>{' '}
+        and is not safe for granting or revoking access.
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -85,10 +85,11 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
           <Link to="/docs/apis/init-connection">
             <code>initConnection()</code>
           </Link>{' '}
-          first. This helper reports <code>false</code> for any failure, so
-          without a connection a premium gate silently locks the user out
-          instead of reporting a problem. Gate on the <code>connected</code>{' '}
-          flag rather than relying on the return value alone.
+          first. React Native's root helper and hook map failures to{' '}
+          <code>false</code>, so a disconnected premium gate silently locks the
+          user out. Expo and native promise APIs reject; Expo's hook calls{' '}
+          <code>onError</code> before rethrowing. Gate hook examples on the{' '}
+          <code>connected</code> flag.
         </p>
       </Callout>
 
@@ -118,12 +119,13 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         when you only need a yes/no answer.
       </p>
       <p>
-        A store or bridge failure is not <code>false</code>. Promise-based SDKs
-        reject, and their React Native/Expo hooks call <code>onError</code>{' '}
-        before rethrowing. Godot entitlement code must use{' '}
-        <code>has_active_subscriptions_result()</code>; the compatibility
-        boolean helper still maps failure to <code>false</code> and is not safe
-        for granting or revoking access.
+        Failure behavior depends on the SDK layer. React Native's root helper
+        and hook map failures to <code>false</code> without calling{' '}
+        <code>onError</code>. Expo and native promise APIs reject; Expo's hook
+        calls <code>onError</code> before rethrowing. Godot entitlement code
+        must use <code>has_active_subscriptions_result()</code>; the
+        compatibility boolean helper still maps failure to <code>false</code>{' '}
+        and is not safe for granting or revoking access.
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -141,18 +141,37 @@ const isPremium = await hasActiveSubscriptions();
 const hasProPlan = await hasActiveSubscriptions(['pro_monthly', 'pro_yearly']);
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
+import { useEffect, useState } from 'react';
+import { Text } from 'react-native';
 import { useIAP } from 'expo-iap';
 
 function PremiumGate({ children }: { children: React.ReactNode }) {
   const { connected, hasActiveSubscriptions } = useIAP();
-  const [isPremium, setIsPremium] = useState(false);
+  const [status, setStatus] = useState<'checking' | 'active' | 'inactive' | 'error'>('checking');
 
   useEffect(() => {
-    if (!connected) return;
-    void hasActiveSubscriptions().then(setIsPremium);
+    if (!connected) {
+      setStatus('checking');
+      return;
+    }
+
+    let cancelled = false;
+    setStatus('checking');
+    void hasActiveSubscriptions()
+      .then((active) => {
+        if (!cancelled) setStatus(active ? 'active' : 'inactive');
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [connected, hasActiveSubscriptions]);
 
-  return isPremium ? <>{children}</> : <Text>Subscribe to unlock</Text>;
+  if (status === 'checking') return <Text>Checking subscription…</Text>;
+  if (status === 'error') return <Text>Unable to check subscription</Text>;
+  return status === 'active' ? <>{children}</> : <Text>Subscribe to unlock</Text>;
 }`}</CodeBlock>
           ),
           swift: (

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import AnchorLink from '../../../components/AnchorLink';
+import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
@@ -78,6 +79,18 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         }}
       </LanguageTabs>
 
+      <Callout kind="important" title="Requires an open connection">
+        <p>
+          Call{' '}
+          <Link to="/docs/apis/init-connection">
+            <code>initConnection()</code>
+          </Link>{' '}
+          first. On Android this call fails with <code>not-prepared</code>{' '}
+          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
+          flag so the same code works on both.
+        </p>
+      </Callout>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -128,12 +141,13 @@ const hasProPlan = await hasActiveSubscriptions(['pro_monthly', 'pro_yearly']);
 import { useIAP } from 'expo-iap';
 
 function PremiumGate({ children }: { children: React.ReactNode }) {
-  const { hasActiveSubscriptions } = useIAP();
+  const { connected, hasActiveSubscriptions } = useIAP();
   const [isPremium, setIsPremium] = useState(false);
 
   useEffect(() => {
+    if (!connected) return;
     void hasActiveSubscriptions().then(setIsPremium);
-  }, [hasActiveSubscriptions]);
+  }, [connected, hasActiveSubscriptions]);
 
   return isPremium ? <>{children}</> : <Text>Subscribe to unlock</Text>;
 }`}</CodeBlock>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -85,11 +85,10 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
           <Link to="/docs/apis/init-connection">
             <code>initConnection()</code>
           </Link>{' '}
-          first. React Native, Expo, and the native promise APIs reject when the
-          store cannot determine subscription status; the framework hooks call{' '}
-          <code>onError</code> before rethrowing. Gate hook examples on the{' '}
-          <code>connected</code> flag and handle failures separately from a
-          valid <code>false</code> result.
+          first. React Native, Expo, and native promise APIs reject on failure.
+          React Native and Expo hooks call <code>onError</code> before
+          rethrowing. Gate hook examples on the <code>connected</code> flag and
+          handle failures separately from a valid <code>false</code> result.
         </p>
       </Callout>
 
@@ -119,12 +118,10 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         when you only need a yes/no answer.
       </p>
       <p>
-        React Native, Expo, and the native promise APIs reject on store errors;
-        framework hooks call <code>onError</code> before rethrowing. Only a
-        successful empty query resolves <code>false</code>. Godot entitlement
-        code must use <code>has_active_subscriptions_result()</code>; the
-        compatibility boolean helper still maps failure to <code>false</code>{' '}
-        and is not safe for granting or revoking access.
+        Only a successful empty query resolves <code>false</code>. Godot
+        entitlement code must use <code>has_active_subscriptions_result()</code>
+        ; Godot's compatibility boolean helper still maps failure to{' '}
+        <code>false</code> and is not safe for granting or revoking access.
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -85,11 +85,9 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
           <Link to="/docs/apis/init-connection">
             <code>initConnection()</code>
           </Link>{' '}
-          first. React Native's root helper and hook map failures to{' '}
-          <code>false</code>, so a disconnected premium gate silently locks the
-          user out. Expo and native promise APIs reject; Expo's hook calls{' '}
-          <code>onError</code> before rethrowing. Gate hook examples on the{' '}
-          <code>connected</code> flag.
+          first. React Native, Expo, and native promise APIs reject. The React
+          Native and Expo hooks call <code>onError</code> before rethrowing.
+          Gate hook examples on the <code>connected</code> flag.
         </p>
       </Callout>
 
@@ -119,13 +117,11 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
         when you only need a yes/no answer.
       </p>
       <p>
-        Failure behavior depends on the SDK layer. React Native's root helper
-        and hook map failures to <code>false</code> without calling{' '}
-        <code>onError</code>. Expo and native promise APIs reject; Expo's hook
-        calls <code>onError</code> before rethrowing. Godot entitlement code
-        must use <code>has_active_subscriptions_result()</code>; the
-        compatibility boolean helper still maps failure to <code>false</code>{' '}
-        and is not safe for granting or revoking access.
+        React Native, Expo, and native promise APIs reject on failure. The React
+        Native and Expo hooks call <code>onError</code> before rethrowing. Godot
+        entitlement code must use <code>has_active_subscriptions_result()</code>
+        ; the compatibility boolean helper still maps failure to{' '}
+        <code>false</code> and is not safe for granting or revoking access.
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -118,10 +118,11 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
       </p>
       <p>
         React Native, Expo, and native promise APIs reject on failure. The React
-        Native and Expo hooks call <code>onError</code> before rethrowing. Godot
+        Native and Expo hooks call <code>onError</code> before rethrowing.
+        Godot's compatibility boolean helper still maps failure to{' '}
+        <code>false</code> and is not safe for granting or revoking access;
         entitlement code must use <code>has_active_subscriptions_result()</code>
-        ; the compatibility boolean helper still maps failure to{' '}
-        <code>false</code> and is not safe for granting or revoking access.
+        .
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
+++ b/packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx
@@ -85,9 +85,10 @@ func has_active_subscriptions_result(subscription_ids: Array[String] = []) -> Di
           <Link to="/docs/apis/init-connection">
             <code>initConnection()</code>
           </Link>{' '}
-          first. On Android this call fails with <code>not-prepared</code>{' '}
-          without it; iOS connects on demand. Gate on the <code>connected</code>{' '}
-          flag so the same code works on both.
+          first. This helper reports <code>false</code> for any failure, so
+          without a connection a premium gate silently locks the user out
+          instead of reporting a problem. Gate on the <code>connected</code>{' '}
+          flag rather than relying on the return value alone.
         </p>
       </Callout>
 

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -12,14 +12,14 @@ function InitConnection() {
     <div className="doc-page">
       <SEO
         title="initConnection"
-        description="Initialize the OpenIAP connection to the store service. Must be called before any other IAP operations."
+        description="Initialize the OpenIAP connection before store operations and wait for a successful result."
         path="/docs/apis/init-connection"
         keywords="initConnection, OpenIAP init, billing client, store connection"
       />
       <h1>initConnection</h1>
       <p>
-        Initialize connection to the store service. Must be called before any
-        other IAP operations.
+        Initialize the store connection and wait for a successful result before
+        starting store operations.
       </p>
       <p>
         <strong>iOS:</strong> Verifies <code>AppStore.canMakePayments</code>,
@@ -34,12 +34,15 @@ function InitConnection() {
         >
           Apple docs
         </a>
-        . <strong>Android:</strong> Starts <code>BillingClient</code> and waits
-        for <code>onBillingSetupFinished</code>. Required before any other Play
-        Billing call. Meta Horizon additionally requires a current foreground{' '}
-        <code>Activity</code>; initialization fails with{' '}
-        <code>MissingCurrentActivity</code> instead of falling back to an
-        application context.{' '}
+        . React Native and Expo can connect on demand on iOS, but an explicit
+        call keeps listener setup and cross-platform gating predictable.{' '}
+        <strong>Android:</strong> Starts <code>BillingClient</code> and waits
+        for <code>onBillingSetupFinished</code>. React Native and Expo do not
+        open it implicitly; wait for <code>true</code> or the hook&apos;s{' '}
+        <code>connected</code> flag before another Play Billing call. Meta
+        Horizon additionally requires a current foreground <code>Activity</code>
+        ; initialization fails with <code>MissingCurrentActivity</code> instead
+        of falling back to an application context.{' '}
         <a
           href="https://developer.android.com/reference/com/android/billingclient/api/BillingClient#startConnection(com.android.billingclient.api.BillingClientStateListener)"
           target="_blank"
@@ -147,18 +150,21 @@ import { initConnection } from 'expo-iap';
 // import { initConnection } from 'react-native-iap';
 
 // Standard connection
-await initConnection();
+const connected = await initConnection();
+if (!connected) throw new Error('Store connection failed');
 
 // Android with a billing program (preferred — see InitConnectionConfig)
-await initConnection({
+const externalOfferConnected = await initConnection({
   enableBillingProgramAndroid: 'external-offer',
 });
+if (!externalOfferConnected) throw new Error('Store connection failed');
 
 // Developer-rendered Billing Choice (must match Play Console)
-await initConnection({
+const billingChoiceConnected = await initConnection({
   enableBillingProgramAndroid: 'billing-choice',
   billingChoiceScreenTypeAndroid: 'developer-rendered',
 });
+if (!billingChoiceConnected) throw new Error('Store connection failed');
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
 // useIAP auto-connects on mount and disconnects on unmount, so you almost

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -187,67 +187,62 @@ function PurchaseScreen() {
           swift: (
             <CodeBlock language="swift">{`import OpenIap
 
-try await OpenIapModule.shared.initConnection()`}</CodeBlock>
+let connected = try await OpenIapModule.shared.initConnection()
+precondition(connected, "Store connection failed")`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`// Standard connection
-openIapStore.initConnection()
-
-// Developer-rendered Billing Choice
-openIapStore.initConnection(
+            <CodeBlock language="kotlin">{`// Choose one call. Remove the config for a standard connection.
+val connected = openIapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.BillingChoice,
         billingChoiceScreenTypeAndroid = BillingChoiceScreenTypeAndroid.DeveloperRendered
     )
-)`}</CodeBlock>
+)
+check(connected) { "Store connection failed" }`}</CodeBlock>
           ),
           kmp: (
             <CodeBlock language="kotlin">{`import io.github.hyochan.kmpiap.KmpIAP
 
 val kmpIAP = KmpIAP()
 
-// Standard connection
-kmpIAP.initConnection()
-
-// Developer-rendered Billing Choice
-kmpIAP.initConnection(
+// Choose one call. Remove the config for a standard connection.
+val connected = kmpIAP.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.BillingChoice,
         billingChoiceScreenTypeAndroid = BillingChoiceScreenTypeAndroid.DeveloperRendered
     )
-)`}</CodeBlock>
+)
+check(connected) { "Store connection failed" }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`await FlutterInappPurchase.instance.initConnection(
+            <CodeBlock language="dart">{`final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.BillingChoice,
   billingChoiceScreenTypeAndroid:
       BillingChoiceScreenTypeAndroid.DeveloperRendered,
-);`}</CodeBlock>
+);
+if (!connected) throw StateError('Store connection failed');`}</CodeBlock>
           ),
           csharp: (
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-// Standard connection
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync();
-
-// Developer-rendered Billing Choice
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
+// Choose one call. Remove the config for a standard connection.
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
     new InitConnectionConfig
     {
         EnableBillingProgramAndroid = BillingProgramAndroid.BillingChoice,
         BillingChoiceScreenTypeAndroid = BillingChoiceScreenTypeAndroid.DeveloperRendered,
-    });`}</CodeBlock>
+    });
+if (!connected) throw new InvalidOperationException("Store connection failed");`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`# Standard connection
-var success = await iap.init_connection()
-
-# Developer-rendered Billing Choice (Android)
+            <CodeBlock language="gdscript">{`# Choose one call. Omit the config for a standard connection.
 var config = InitConnectionConfig.new()
 config.enable_billing_program_android = BillingProgramAndroid.BILLING_CHOICE
 config.billing_choice_screen_type_android = BillingChoiceScreenTypeAndroid.DEVELOPER_RENDERED
-var success = await iap.init_connection(config)`}</CodeBlock>
+var success = await iap.init_connection(config)
+if not success:
+    push_error("Store connection failed")`}</CodeBlock>
           ),
         }}
       </LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -144,7 +144,9 @@ function InitConnection() {
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
+            <CodeBlock language="typescript">{`import { Text } from 'react-native';
+
+// expo-iap
 import { initConnection } from 'expo-iap';
 // Same API in react-native-iap:
 // import { initConnection } from 'react-native-iap';
@@ -167,10 +169,10 @@ const billingChoiceConnected = await initConnection({
 if (!billingChoiceConnected) throw new Error('Store connection failed');
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
-// useIAP auto-connects on mount and disconnects on unmount, so you almost
-// never need to call initConnection() yourself. Pass connection options
-// (e.g. enableBillingProgramAndroid) to the hook directly, and read the
-// reactive "connected" flag from its return value.
+// Both hooks auto-connect on mount. Expo closes the connection on unmount;
+// React Native removes the screen's listeners but keeps the native connection
+// open across screens. Pass connection options to the hook and read its
+// reactive "connected" flag.
 import { useIAP } from 'expo-iap';
 
 function PurchaseScreen() {

--- a/packages/docs/src/pages/docs/apis/init-connection.tsx
+++ b/packages/docs/src/pages/docs/apis/init-connection.tsx
@@ -151,22 +151,23 @@ import { initConnection } from 'expo-iap';
 // Same API in react-native-iap:
 // import { initConnection } from 'react-native-iap';
 
+// Choose exactly one connection call for the session.
+
 // Standard connection
 const connected = await initConnection();
+
+// Android external offer (replace the standard call above):
+// const connected = await initConnection({
+//   enableBillingProgramAndroid: 'external-offer',
+// });
+
+// Android developer-rendered Billing Choice (replace the standard call above):
+// const connected = await initConnection({
+//   enableBillingProgramAndroid: 'billing-choice',
+//   billingChoiceScreenTypeAndroid: 'developer-rendered',
+// });
+
 if (!connected) throw new Error('Store connection failed');
-
-// Android with a billing program (preferred — see InitConnectionConfig)
-const externalOfferConnected = await initConnection({
-  enableBillingProgramAndroid: 'external-offer',
-});
-if (!externalOfferConnected) throw new Error('Store connection failed');
-
-// Developer-rendered Billing Choice (must match Play Console)
-const billingChoiceConnected = await initConnection({
-  enableBillingProgramAndroid: 'billing-choice',
-  billingChoiceScreenTypeAndroid: 'developer-rendered',
-});
-if (!billingChoiceConnected) throw new Error('Store connection failed');
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
 // Both hooks auto-connect on mount. Expo closes the connection on unmount;

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -245,6 +245,7 @@ type RequestPurchaseProps =
         {{
           typescript: (
             <CodeBlock language="typescript">{`// expo-iap
+import { Button } from 'react-native';
 import { initConnection, requestPurchase } from 'expo-iap';
 // Same API in react-native-iap:
 // import { initConnection, requestPurchase } from 'react-native-iap';
@@ -420,14 +421,25 @@ await iap.request_purchase(props)`}</CodeBlock>
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
+async Task HandlePurchaseSafelyAsync(Purchase purchase)
+{
+    try
+    {
+        // 1. Validate on your server, 2. Grant entitlement,
+        // 3. Finish transaction (Android auto-refunds after 3 days otherwise!)
+        await ((MutationResolver)OpenIapClient.Instance).FinishTransactionAsync(
+            purchase: new PurchaseInput(purchase),
+            isConsumable: true);
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Purchase processing failed: {error.Message}");
+    }
+}
+
 // Subscribe to results FIRST — requestPurchase is event-based.
-OpenIapClient.Instance.PurchaseUpdated.Subscribe(async purchase => {
-    // 1. Validate on your server, 2. Grant entitlement,
-    // 3. Finish transaction (Android auto-refunds after 3 days otherwise!)
-    await ((MutationResolver)OpenIapClient.Instance).FinishTransactionAsync(
-        purchase: new PurchaseInput(purchase),
-        isConsumable: true);
-});
+OpenIapClient.Instance.PurchaseUpdated.Subscribe(
+    purchase => _ = HandlePurchaseSafelyAsync(purchase));
 
 OpenIapClient.Instance.PurchaseError.Subscribe(error => {
     Console.WriteLine($"{error.Code}: {error.Message}");

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -307,6 +307,8 @@ function BuyButton({ sku }: { sku: string }) {
         void requestPurchase({
           request: { apple: { sku }, google: { skus: [sku] } },
           type: 'in-app',
+        }).catch((error) => {
+          console.warn('Purchase dispatch failed', error);
         });
       }}
     />

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -259,7 +259,8 @@ import { initConnection, requestPurchase } from 'expo-iap';
 // Same API in react-native-iap:
 // import { initConnection, requestPurchase } from 'react-native-iap';
 
-await initConnection();
+const connected = await initConnection();
+if (!connected) throw new Error('Store connection failed');
 
 // One-time product
 await requestPurchase({
@@ -323,7 +324,7 @@ function BuyButton({ sku }: { sku: string }) {
 }`}</CodeBlock>
           ),
           swift: (
-            <CodeBlock language="swift">{`_ = try await OpenIapModule.shared.initConnection()
+            <CodeBlock language="swift">{`guard try await OpenIapModule.shared.initConnection() else { return }
 try await OpenIapModule.shared.requestPurchase(
     RequestPurchaseProps(
         request: .purchase(RequestPurchasePropsByPlatforms(
@@ -334,7 +335,7 @@ try await OpenIapModule.shared.requestPurchase(
 )`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`openIapStore.initConnection()
+            <CodeBlock language="kotlin">{`check(openIapStore.initConnection()) { "Store connection failed" }
 openIapStore.requestPurchase(
     RequestPurchaseProps(
         request = RequestPurchaseProps.Request.Purchase(
@@ -347,7 +348,7 @@ openIapStore.requestPurchase(
 )`}</CodeBlock>
           ),
           kmp: (
-            <CodeBlock language="kotlin">{`kmpIAP.initConnection()
+            <CodeBlock language="kotlin">{`check(kmpIAP.initConnection()) { "Store connection failed" }
 kmpIAP.requestPurchase(
     RequestPurchaseProps(
         request = RequestPurchaseProps.Request.Purchase(
@@ -380,7 +381,8 @@ kmpIAP.requestPurchase {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`await FlutterInappPurchase.instance.initConnection();
+            <CodeBlock language="dart">{`final connected = await FlutterInappPurchase.instance.initConnection();
+if (!connected) throw StateError('Store connection failed');
 await FlutterInappPurchase.instance.requestPurchase(
   RequestPurchaseProps.inApp((
     apple: RequestPurchaseIosProps(sku: 'com.app.premium'),
@@ -411,7 +413,9 @@ await iap.requestPurchaseWithBuilder(
 );`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`await iap.init_connection()
+            <CodeBlock language="gdscript">{`if not await iap.init_connection():
+    push_error("Store connection failed")
+    return
 
 var props = RequestPurchaseProps.new()
 props.request = RequestPurchasePropsByPlatforms.new()
@@ -437,7 +441,8 @@ OpenIapClient.Instance.PurchaseError.Subscribe(error => {
     Console.WriteLine($"{error.Code}: {error.Message}");
 });
 
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync();
+if (!await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync())
+    return;
 
 // Then request the purchase
 await ((MutationResolver)OpenIapClient.Instance).RequestPurchaseAsync(new RequestPurchaseProps {

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -125,10 +125,10 @@ type RequestPurchaseProps =
           <Link to="/docs/apis/init-connection">
             <code>initConnection()</code>
           </Link>{' '}
-          first. On Android a purchase started without it is rejected with{' '}
-          <code>not-prepared</code>; iOS connects on demand. Gate the buy
-          control on the <code>connected</code> flag so the same code works on
-          both.
+          first. React Native reports an Android purchase started without it as
+          a <code>not-prepared</code> purchase-error event; iOS connects on
+          demand. Gate the buy control on the <code>connected</code> flag so the
+          same code works on both.
         </p>
       </Callout>
 
@@ -243,8 +243,11 @@ type RequestPurchaseProps =
         Throws
       </AnchorLink>
       <p>
-        Synchronous rejection from the store (<code>not-prepared</code>, missing
-        offerToken on subs, etc.).
+        Invalid arguments or failures that prevent dispatch can reject the
+        promise. Store outcomes are event-based in React Native; Android{' '}
+        <code>not-prepared</code> arrives through{' '}
+        <code>purchaseErrorListener</code> or the hook&apos;s{' '}
+        <code>onPurchaseError</code> callback.
       </p>
 
       <h2>Example</h2>

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -291,7 +291,7 @@ import { useIAP } from 'expo-iap';
 
 function BuyButton({ sku }: { sku: string }) {
   const { connected, requestPurchase } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
+    onPurchaseSuccess: (purchase) => {
       // verify + finishTransaction here
     },
     onPurchaseError: (error) => {

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -312,12 +312,12 @@ function BuyButton({ sku }: { sku: string }) {
     <Button
       title="Buy"
       disabled={!connected}
-      onPress={() =>
-        requestPurchase({
+      onPress={() => {
+        void requestPurchase({
           request: { apple: { sku }, google: { skus: [sku] } },
           type: 'in-app',
-        })
-      }
+        });
+      }}
     />
   );
 }`}</CodeBlock>

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -425,8 +425,11 @@ async Task HandlePurchaseSafelyAsync(Purchase purchase)
 {
     try
     {
-        // 1. Validate on your server, 2. Grant entitlement,
-        // 3. Finish transaction (Android auto-refunds after 3 days otherwise!)
+        if (!await VerifyPurchaseOnServerAsync(purchase))
+            throw new InvalidOperationException("Purchase verification failed");
+        await GrantEntitlementAsync(purchase.ProductId);
+
+        // Finish last (Android auto-refunds after 3 days otherwise!).
         await ((MutationResolver)OpenIapClient.Instance).FinishTransactionAsync(
             purchase: new PurchaseInput(purchase),
             isConsumable: true);

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -243,8 +243,8 @@ type RequestPurchaseProps =
         Throws
       </AnchorLink>
       <p>
-        Synchronous rejection from the store (<code>E_NOT_PREPARED</code>,
-        missing offerToken on subs, etc.).
+        Synchronous rejection from the store (<code>not-prepared</code>, missing
+        offerToken on subs, etc.).
       </p>
 
       <h2>Example</h2>
@@ -252,9 +252,11 @@ type RequestPurchaseProps =
         {{
           typescript: (
             <CodeBlock language="typescript">{`// expo-iap
-import { requestPurchase } from 'expo-iap';
+import { initConnection, requestPurchase } from 'expo-iap';
 // Same API in react-native-iap:
-// import { requestPurchase } from 'react-native-iap';
+// import { initConnection, requestPurchase } from 'react-native-iap';
+
+await initConnection();
 
 // One-time product
 await requestPurchase({
@@ -318,7 +320,8 @@ function BuyButton({ sku }: { sku: string }) {
 }`}</CodeBlock>
           ),
           swift: (
-            <CodeBlock language="swift">{`try await OpenIapModule.shared.requestPurchase(
+            <CodeBlock language="swift">{`_ = try await OpenIapModule.shared.initConnection()
+try await OpenIapModule.shared.requestPurchase(
     RequestPurchaseProps(
         request: .purchase(RequestPurchasePropsByPlatforms(
             apple: RequestPurchaseIosProps(sku: "com.app.premium")
@@ -328,7 +331,8 @@ function BuyButton({ sku }: { sku: string }) {
 )`}</CodeBlock>
           ),
           kotlin: (
-            <CodeBlock language="kotlin">{`openIapStore.requestPurchase(
+            <CodeBlock language="kotlin">{`openIapStore.initConnection()
+openIapStore.requestPurchase(
     RequestPurchaseProps(
         request = RequestPurchaseProps.Request.Purchase(
             RequestPurchasePropsByPlatforms(
@@ -340,7 +344,8 @@ function BuyButton({ sku }: { sku: string }) {
 )`}</CodeBlock>
           ),
           kmp: (
-            <CodeBlock language="kotlin">{`kmpIAP.requestPurchase(
+            <CodeBlock language="kotlin">{`kmpIAP.initConnection()
+kmpIAP.requestPurchase(
     RequestPurchaseProps(
         request = RequestPurchaseProps.Request.Purchase(
             RequestPurchasePropsByPlatforms(
@@ -372,7 +377,8 @@ kmpIAP.requestPurchase {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`await FlutterInappPurchase.instance.requestPurchase(
+            <CodeBlock language="dart">{`await FlutterInappPurchase.instance.initConnection();
+await FlutterInappPurchase.instance.requestPurchase(
   RequestPurchaseProps.inApp((
     apple: RequestPurchaseIosProps(sku: 'com.app.premium'),
     google: RequestPurchaseAndroidProps(skus: ['com.app.premium']),
@@ -402,7 +408,9 @@ await iap.requestPurchaseWithBuilder(
 );`}</CodeBlock>
           ),
           gdscript: (
-            <CodeBlock language="gdscript">{`var props = RequestPurchaseProps.new()
+            <CodeBlock language="gdscript">{`await iap.init_connection()
+
+var props = RequestPurchaseProps.new()
 props.request = RequestPurchasePropsByPlatforms.new()
 props.request.apple = RequestPurchaseIosProps.new()
 props.request.apple.sku = "com.app.premium"
@@ -425,6 +433,8 @@ OpenIapClient.Instance.PurchaseUpdated.Subscribe(async purchase => {
 OpenIapClient.Instance.PurchaseError.Subscribe(error => {
     Console.WriteLine($"{error.Code}: {error.Message}");
 });
+
+await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync();
 
 // Then request the purchase
 await ((MutationResolver)OpenIapClient.Instance).RequestPurchaseAsync(new RequestPurchaseProps {

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function RequestPurchase() {
@@ -119,18 +120,7 @@ type RequestPurchaseProps =
         }}
       </LanguageTabs>
 
-      <Callout kind="important" title="Requires an open connection">
-        <p>
-          Call{' '}
-          <Link to="/docs/apis/init-connection">
-            <code>initConnection()</code>
-          </Link>{' '}
-          first. React Native reports an Android purchase started without it as
-          a <code>not-prepared</code> purchase-error event; iOS connects on
-          demand. Gate the buy control on the <code>connected</code> flag so the
-          same code works on both.
-        </p>
-      </Callout>
+      <StoreConnectionCallout purchaseErrorEvent />
 
       <AnchorLink id="parameters" level="h2">
         Parameters

--- a/packages/docs/src/pages/docs/apis/request-purchase.tsx
+++ b/packages/docs/src/pages/docs/apis/request-purchase.tsx
@@ -119,6 +119,19 @@ type RequestPurchaseProps =
         }}
       </LanguageTabs>
 
+      <Callout kind="important" title="Requires an open connection">
+        <p>
+          Call{' '}
+          <Link to="/docs/apis/init-connection">
+            <code>initConnection()</code>
+          </Link>{' '}
+          first. On Android a purchase started without it is rejected with{' '}
+          <code>not-prepared</code>; iOS connects on demand. Gate the buy
+          control on the <code>connected</code> flag so the same code works on
+          both.
+        </p>
+      </Callout>
+
       <AnchorLink id="parameters" level="h2">
         Parameters
       </AnchorLink>
@@ -281,7 +294,7 @@ await requestPurchase({
 import { useIAP } from 'expo-iap';
 
 function BuyButton({ sku }: { sku: string }) {
-  const { requestPurchase } = useIAP({
+  const { connected, requestPurchase } = useIAP({
     onPurchaseSuccess: async (purchase) => {
       // verify + finishTransaction here
     },
@@ -293,6 +306,7 @@ function BuyButton({ sku }: { sku: string }) {
   return (
     <Button
       title="Buy"
+      disabled={!connected}
       onPress={() =>
         requestPurchase({
           request: { apple: { sku }, google: { skus: [sku] } },

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -3,6 +3,7 @@ import AnchorLink from '../../../components/AnchorLink';
 import CodeBlock from '../../../components/CodeBlock';
 import LanguageTabs from '../../../components/LanguageTabs';
 import SEO from '../../../components/SEO';
+import StoreConnectionCallout from '../../../components/StoreConnectionCallout';
 import { useScrollToHash } from '../../../hooks/useScrollToHash';
 
 function RestorePurchases() {
@@ -48,6 +49,8 @@ function RestorePurchases() {
         </a>
         .
       </p>
+
+      <StoreConnectionCallout />
 
       <h2>Signature</h2>
       <LanguageTabs>

--- a/packages/docs/src/pages/docs/apis/restore-purchases.tsx
+++ b/packages/docs/src/pages/docs/apis/restore-purchases.tsx
@@ -97,64 +97,81 @@ function RestorePurchases() {
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`// expo-iap
+            <CodeBlock language="typescript">{`import { useEffect } from 'react';
+import { Button } from 'react-native';
+
+// expo-iap
 import {
   restorePurchases,
   getAvailablePurchases,
   finishTransaction,
+  useIAP,
 } from 'expo-iap';
 // Same API in react-native-iap:
 // import {
 //   restorePurchases,
 //   getAvailablePurchases,
 //   finishTransaction,
+//   useIAP,
 // } from 'react-native-iap';
 
-const handleRestore = async () => {
-  await restorePurchases();
-  const purchases = await getAvailablePurchases();
+const handleRestore = () => {
+  void (async () => {
+    await restorePurchases();
+    const purchases = await getAvailablePurchases();
 
-  for (const purchase of purchases) {
-    // Always verify before granting — restored purchases can include
-    // refunded or revoked transactions that must not re-grant entitlement.
-    // yourBackend is your authenticated verification client.
-    if (!(await yourBackend.verifyPurchase(purchase))) continue;
+    for (const purchase of purchases) {
+      // Always verify before granting — restored purchases can include
+      // refunded or revoked transactions that must not re-grant entitlement.
+      // yourBackend is your authenticated verification client.
+      if (!(await yourBackend.verifyPurchase(purchase))) continue;
 
-    await grantProduct(purchase.productId);
-    await finishTransaction({ purchase, isConsumable: false });
-  }
+      await grantProduct(purchase.productId);
+      await finishTransaction({ purchase, isConsumable: false });
+    }
+  })().catch((error) => {
+    console.warn('Purchase restore failed:', error);
+  });
 };
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
 // useIAP's restorePurchases() and getAvailablePurchases() both return
 // Promise<void> and update the reactive availablePurchases array — react
 // to it inside an effect.
-import { useIAP } from 'expo-iap';
 
 function RestoreButton() {
   const {
+    connected,
     availablePurchases,
     restorePurchases,
-    getAvailablePurchases,
     finishTransaction,
   } = useIAP();
 
-  const handleRestore = async () => {
-    await restorePurchases();
-    await getAvailablePurchases();
+  const handleRestore = () => {
+    void restorePurchases().catch((error) => {
+      console.warn('Purchase restore failed:', error);
+    });
   };
 
   useEffect(() => {
-    (async () => {
+    void (async () => {
       for (const purchase of availablePurchases) {
         if (!(await yourBackend.verifyPurchase(purchase))) continue;
         await grantProduct(purchase.productId);
         await finishTransaction({ purchase, isConsumable: false });
       }
-    })();
+    })().catch((error) => {
+      console.warn('Restored purchase processing failed:', error);
+    });
   }, [availablePurchases, finishTransaction]);
 
-  return <Button title="Restore Purchases" onPress={handleRestore} />;
+  return (
+    <Button
+      title="Restore Purchases"
+      disabled={!connected}
+      onPress={handleRestore}
+    />
+  );
 }`}</CodeBlock>
           ),
           swift: (

--- a/packages/docs/src/pages/docs/events/android/developer-provided-billing-listener-android.tsx
+++ b/packages/docs/src/pages/docs/events/android/developer-provided-billing-listener-android.tsx
@@ -86,17 +86,22 @@ IDisposable subscription = OpenIapClient.Instance.DeveloperProvidedBillingAndroi
 } = useIAP({
   enableBillingProgramAndroid: 'billing-choice',
   billingChoiceScreenTypeAndroid: 'google-rendered',
-  onDeveloperProvidedBillingAndroid: async (details) => {
-    await processDeveloperBilling(details);
+  onDeveloperProvidedBillingAndroid: (details) => {
+    void processDeveloperBilling(details).catch((error) => {
+      console.error('Developer billing failed', error);
+    });
   },
 });`}</CodeBlock>
 
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`import { developerProvidedBillingListenerAndroid } from 'expo-iap';
+            <CodeBlock language="typescript">{`import {
+  developerProvidedBillingListenerAndroid,
+  type DeveloperProvidedBillingDetailsAndroid,
+} from 'expo-iap';
 
-const subscription = developerProvidedBillingListenerAndroid(async (details) => {
+async function handleDeveloperBilling(details: DeveloperProvidedBillingDetailsAndroid) {
   // Use products and linkUri to choose your in-app or external-link checkout.
   const paymentResult = await processPaymentWithYourGateway({
     products: details.products,
@@ -111,6 +116,12 @@ const subscription = developerProvidedBillingListenerAndroid(async (details) => 
     }
     grantUserAccess();
   }
+}
+
+const subscription = developerProvidedBillingListenerAndroid((details) => {
+  void handleDeveloperBilling(details).catch((error) => {
+    console.error('Developer billing failed', error);
+  });
 });
 
 // Cleanup when done
@@ -158,11 +169,11 @@ lifecycleScope.launch {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+            <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
 // Android only (8.3.0+) - will not fire on iOS or older Android
-final subscription = FlutterInappPurchase.instance.developerProvidedBillingAndroid
-    .listen((details) async {
+Future<void> handleDeveloperBilling(DeveloperProvidedBillingDetailsAndroid details) async {
   final paymentResult = await processPaymentWithYourGateway(
     products: details.products,
     linkUri: details.linkUri,
@@ -175,6 +186,13 @@ final subscription = FlutterInappPurchase.instance.developerProvidedBillingAndro
     }
     grantUserAccess();
   }
+}
+
+final subscription = FlutterInappPurchase.instance.developerProvidedBillingAndroid
+    .listen((details) {
+  unawaited(handleDeveloperBilling(details).catchError(
+    (Object error) => print('Developer billing failed: $error'),
+  ));
 });
 
 // Cleanup when done
@@ -184,21 +202,31 @@ subscription.cancel();`}</CodeBlock>
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-var subscription = OpenIapClient.Instance.DeveloperProvidedBillingAndroid.Subscribe(async details =>
+async Task HandleDeveloperBillingSafelyAsync(DeveloperProvidedBillingDetailsAndroid details)
 {
-    var paymentResult = await ProcessPaymentWithYourGatewayAsync(
-        details.Products,
-        details.LinkUri);
-
-    if (paymentResult.Success)
+    try
     {
-        if (details.ExternalTransactionToken is { Length: > 0 } token)
+        var paymentResult = await ProcessPaymentWithYourGatewayAsync(
+            details.Products,
+            details.LinkUri);
+
+        if (paymentResult.Success)
         {
-            await ReportExternalTransactionToGoogleAsync(token);
+            if (details.ExternalTransactionToken is { Length: > 0 } token)
+            {
+                await ReportExternalTransactionToGoogleAsync(token);
+            }
+            await GrantUserAccessAsync();
         }
-        await GrantUserAccessAsync();
     }
-});
+    catch (Exception error)
+    {
+        Console.WriteLine($"Developer billing failed: {error.Message}");
+    }
+}
+
+var subscription = OpenIapClient.Instance.DeveloperProvidedBillingAndroid.Subscribe(
+    details => _ = HandleDeveloperBillingSafelyAsync(details));
 
 // Cleanup when done.
 subscription.Dispose();`}</CodeBlock>

--- a/packages/docs/src/pages/docs/events/android/user-choice-billing-listener-android.tsx
+++ b/packages/docs/src/pages/docs/events/android/user-choice-billing-listener-android.tsx
@@ -71,9 +71,12 @@ IObservable<UserChoiceBillingDetails> UserChoiceBillingAndroid { get; }`}</CodeB
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`import { userChoiceBillingListenerAndroid } from 'expo-iap';
+            <CodeBlock language="typescript">{`import {
+  userChoiceBillingListenerAndroid,
+  type UserChoiceBillingDetails,
+} from 'expo-iap';
 
-const subscription = userChoiceBillingListenerAndroid(async (details) => {
+async function handleUserChoiceBilling(details: UserChoiceBillingDetails) {
   console.log('User chose alternative billing');
   console.log('Products:', details.products);
   console.log('External transaction token received; send it to your backend without logging it.');
@@ -88,6 +91,12 @@ const subscription = userChoiceBillingListenerAndroid(async (details) => {
     // Backend should report token to Google Play within 24 hours
     grantUserAccess(details.products);
   }
+}
+
+const subscription = userChoiceBillingListenerAndroid((details) => {
+  void handleUserChoiceBilling(details).catch((error) => {
+    console.error('Alternative billing failed', error);
+  });
 });
 
 // Cleanup when done
@@ -144,10 +153,11 @@ lifecycleScope.launch {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+            <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
 // Android only - will not fire on iOS
-final subscription = FlutterInappPurchase.instance.userChoiceBillingAndroid.listen((details) async {
+Future<void> handleUserChoiceBilling(UserChoiceBillingDetails details) async {
   print('User chose alternative billing');
   print('Products: \${details.products}');
   print('External transaction token received; send it to your backend without logging it.');
@@ -162,6 +172,12 @@ final subscription = FlutterInappPurchase.instance.userChoiceBillingAndroid.list
     // Backend should report token to Google Play within 24 hours
     grantUserAccess(details.products);
   }
+}
+
+final subscription = FlutterInappPurchase.instance.userChoiceBillingAndroid.listen((details) {
+  unawaited(handleUserChoiceBilling(details).catchError(
+    (Object error) => print('Alternative billing failed: $error'),
+  ));
 });
 
 // Cleanup when done
@@ -172,6 +188,18 @@ subscription.cancel();`}</CodeBlock>
 using OpenIap.Maui;
 using System;
 
+async Task ProcessUserChoiceBillingSafelyAsync(UserChoiceBillingDetails details)
+{
+    try
+    {
+        await ProcessUserChoiceBillingAsync(details);
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Alternative billing failed: {error.Message}");
+    }
+}
+
 using var subscription = OpenIapClient.Instance.UserChoiceBillingAndroid.Subscribe(details =>
 {
     Console.WriteLine("User chose alternative billing");
@@ -179,7 +207,7 @@ using var subscription = OpenIapClient.Instance.UserChoiceBillingAndroid.Subscri
     Console.WriteLine("External transaction token received; send it to your backend without logging it.");
 
     // Process payment with your backend.
-    _ = ProcessUserChoiceBillingAsync(details);
+    _ = ProcessUserChoiceBillingSafelyAsync(details);
 });`}</CodeBlock>
           ),
         }}

--- a/packages/docs/src/pages/docs/events/ios/promoted-product-listener-ios.tsx
+++ b/packages/docs/src/pages/docs/events/ios/promoted-product-listener-ios.tsx
@@ -216,11 +216,12 @@ scope.launch {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+            <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
 // iOS only - will not fire on Android
 final iap = FlutterInappPurchase.instance;
-final subscription = iap.purchasePromoted.listen((productId) async {
+Future<void> handlePromotedProduct(String? productId) async {
   if (productId == null) return;
   try {
     print('Promoted product tapped: $productId');
@@ -254,6 +255,10 @@ final subscription = iap.purchasePromoted.listen((productId) async {
   } catch (error) {
     print('Promoted purchase failed: $error');
   }
+}
+
+final subscription = iap.purchasePromoted.listen((productId) {
+  unawaited(handlePromotedProduct(productId));
 });
 
 // Cleanup when done

--- a/packages/docs/src/pages/docs/events/purchase-error-listener.tsx
+++ b/packages/docs/src/pages/docs/events/purchase-error-listener.tsx
@@ -196,27 +196,34 @@ subscription.cancel();`}</CodeBlock>
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-var subscription = OpenIapClient.Instance.PurchaseError.Subscribe(async error =>
+async Task HandlePurchaseErrorSafelyAsync(PurchaseError error)
 {
-    Console.WriteLine($"Purchase error: {error.Code} - {error.Message}");
-
-    switch (error.Code)
+    try
     {
-        case ErrorCode.UserCancelled:
-            // User cancelled - no action needed.
-            break;
-        case ErrorCode.AlreadyOwned:
-            // Restore purchases instead.
-            await ((MutationResolver)OpenIapClient.Instance).RestorePurchasesAsync();
-            break;
-        case ErrorCode.NetworkError:
-            ShowRetryDialog();
-            break;
-        default:
-            ShowErrorMessage(error.Message);
-            break;
+        Console.WriteLine($"Purchase error: {error.Code} - {error.Message}");
+        switch (error.Code)
+        {
+            case ErrorCode.UserCancelled:
+                break;
+            case ErrorCode.AlreadyOwned:
+                await ((MutationResolver)OpenIapClient.Instance).RestorePurchasesAsync();
+                break;
+            case ErrorCode.NetworkError:
+                ShowRetryDialog();
+                break;
+            default:
+                ShowErrorMessage(error.Message);
+                break;
+        }
     }
-});
+    catch (Exception failure)
+    {
+        Console.WriteLine($"Purchase error recovery failed: {failure.Message}");
+    }
+}
+
+var subscription = OpenIapClient.Instance.PurchaseError.Subscribe(
+    error => _ = HandlePurchaseErrorSafelyAsync(error));
 
 // Cleanup when done.
 subscription.Dispose();`}</CodeBlock>

--- a/packages/docs/src/pages/docs/events/purchase-updated-listener.tsx
+++ b/packages/docs/src/pages/docs/events/purchase-updated-listener.tsx
@@ -133,11 +133,15 @@ iap.set_purchase_updated_listener_options(options)`}</CodeBlock>
       <LanguageTabs>
         {{
           typescript: (
-            <CodeBlock language="typescript">{`import { finishTransaction, purchaseUpdatedListener } from 'expo-iap';
+            <CodeBlock language="typescript">{`import {
+  finishTransaction,
+  purchaseUpdatedListener,
+  type Purchase,
+} from 'expo-iap';
 // Same API in react-native-iap:
 // import { finishTransaction, purchaseUpdatedListener } from 'react-native-iap';
 
-const subscription = purchaseUpdatedListener(async (purchase) => {
+async function handlePurchase(purchase: Purchase) {
   console.log('Purchase updated:', purchase.productId);
 
   // Verify with your backend or IAPKit before granting content.
@@ -150,6 +154,12 @@ const subscription = purchaseUpdatedListener(async (purchase) => {
     // Finish the transaction
     await finishTransaction({ purchase, isConsumable: false });
   }
+}
+
+const subscription = purchaseUpdatedListener((purchase) => {
+  void handlePurchase(purchase).catch((error) => {
+    console.error('Purchase processing failed', error);
+  });
 });
 
 // Cleanup when done
@@ -212,9 +222,10 @@ lifecycleScope.launch {
 }`}</CodeBlock>
           ),
           dart: (
-            <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+            <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
-final subscription = FlutterInappPurchase.instance.purchaseUpdatedListener.listen((purchase) async {
+Future<void> handlePurchase(Purchase purchase) async {
   print('Purchase updated: \${purchase.productId}');
 
   // Verify with your backend or IAPKit before granting content.
@@ -227,6 +238,12 @@ final subscription = FlutterInappPurchase.instance.purchaseUpdatedListener.liste
     // Finish the transaction
     await FlutterInappPurchase.instance.finishTransaction(purchase: purchase);
   }
+}
+
+final subscription = FlutterInappPurchase.instance.purchaseUpdatedListener.listen((purchase) {
+  unawaited(handlePurchase(purchase).catchError(
+    (Object error) => print('Purchase processing failed: $error'),
+  ));
 });
 
 // Cleanup when done
@@ -236,26 +253,35 @@ subscription.cancel();`}</CodeBlock>
             <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-var subscription = OpenIapClient.Instance.PurchaseUpdated.Subscribe(async purchase =>
+async Task HandlePurchaseSafelyAsync(Purchase purchase)
 {
-    if (purchase is PurchaseCommon purchaseInfo)
+    try
     {
-        Console.WriteLine($"Purchase updated: {purchaseInfo.ProductId}");
-    }
-
-    // Verify and deliver
-    if (await VerifyPurchaseOnServerAsync(purchase))
-    {
-        if (purchase is PurchaseCommon validPurchase)
+        if (purchase is PurchaseCommon purchaseInfo)
         {
-            await DeliverProductAsync(validPurchase.ProductId);
+            Console.WriteLine($"Purchase updated: {purchaseInfo.ProductId}");
         }
 
-        await ((MutationResolver)OpenIapClient.Instance).FinishTransactionAsync(
-            new PurchaseInput(purchase),
-            isConsumable: false);
+        if (await VerifyPurchaseOnServerAsync(purchase))
+        {
+            if (purchase is PurchaseCommon validPurchase)
+            {
+                await DeliverProductAsync(validPurchase.ProductId);
+            }
+
+            await ((MutationResolver)OpenIapClient.Instance).FinishTransactionAsync(
+                new PurchaseInput(purchase),
+                isConsumable: false);
+        }
     }
-});
+    catch (Exception error)
+    {
+        Console.WriteLine($"Purchase processing failed: {error.Message}");
+    }
+}
+
+var subscription = OpenIapClient.Instance.PurchaseUpdated.Subscribe(
+    purchase => _ = HandlePurchaseSafelyAsync(purchase));
 
 // Cleanup when done.
 subscription.Dispose();`}</CodeBlock>

--- a/packages/docs/src/pages/docs/features/debugging.tsx
+++ b/packages/docs/src/pages/docs/features/debugging.tsx
@@ -176,15 +176,17 @@ const handlePurchase = async (basePlanId: string) => {
 };
 
 // 2. Use YOUR tracked value in onPurchaseSuccess
-onPurchaseSuccess: async (purchase) => {
+onPurchaseSuccess: (purchase) => {
   // DON'T rely on purchase.currentPlanId - it may be wrong!
   const actualBasePlanId = purchasedBasePlanId;
 
-  // Save to your backend
-  await saveToBackend({
+  // Save to your backend; hook callback promises are not observed.
+  void saveToBackend({
     purchaseToken: purchase.purchaseToken,
     basePlanId: actualBasePlanId,  // Use YOUR tracked value
     productId: purchase.productId,
+  }).catch((error) => {
+    console.error('Failed to save purchase metadata', error);
   });
 }`}</CodeBlock>
 

--- a/packages/docs/src/pages/docs/features/external-purchase.tsx
+++ b/packages/docs/src/pages/docs/features/external-purchase.tsx
@@ -669,7 +669,8 @@ func handle_external_purchase_flow() -> void:
 } from 'expo-iap';
 
 // Step 0: Enable billing program BEFORE initConnection
-await initConnection({ enableBillingProgramAndroid: 'external-offer' });
+const connected = await initConnection({ enableBillingProgramAndroid: 'external-offer' });
+if (!connected) throw new Error('Store connection failed');
 
 // External Offer flow with Billing Programs API (8.2.1+)
 async function handleExternalPurchaseWithBillingPrograms(productId: string) {
@@ -722,11 +723,11 @@ import dev.hyo.openiap.*
 // Initialize store
 val iapStore = OpenIapStore(context = applicationContext)
 
-iapStore.initConnection(
+check(iapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
     )
-)
+)) { "Store connection failed" }
 
 // External Offer flow with Billing Programs API (8.2.1+)
 suspend fun handleExternalPurchaseWithBillingPrograms(productId: String) {
@@ -783,11 +784,11 @@ import io.github.hyochan.kmpiap.openiap.*
 // Initialize store
 val kmpIAP = KmpIAP()
 
-kmpIAP.initConnection(
+check(kmpIAP.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
     )
-)
+)) { "Store connection failed" }
 
 // External Offer flow with Billing Programs API (8.2.1+)
 suspend fun handleExternalPurchaseWithBillingPrograms(productId: String) {
@@ -839,9 +840,10 @@ suspend fun handleExternalPurchaseWithBillingPrograms(productId: String) {
                     dart: (
                       <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
-await FlutterInappPurchase.instance.initConnection(
+final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalOffer,
 );
+if (!connected) throw StateError('Store connection failed');
 
 // External Offer flow with Billing Programs API (8.2.1+)
 Future<void> handleExternalPurchaseWithBillingPrograms(String productId) async {
@@ -895,10 +897,11 @@ Future<void> handleExternalPurchaseWithBillingPrograms(String productId) async {
 using OpenIap.Maui;
 
 var mutate = (MutationResolver)OpenIapClient.Instance;
-await mutate.InitConnectionAsync(new InitConnectionConfig
+var connected = await mutate.InitConnectionAsync(new InitConnectionConfig
 {
     EnableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer,
 });
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 async Task HandleExternalPurchaseWithBillingProgramsAsync(string productId)
 {
@@ -938,7 +941,10 @@ async Task HandleExternalPurchaseWithBillingProgramsAsync(string productId)
 func _ready() -> void:
     var config = InitConnectionConfig.new()
     config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-    await iap.init_connection(config)
+    var connected = await iap.init_connection(config)
+    if not connected:
+        push_error("Store connection failed")
+        return
 
 # External Offer flow with Billing Programs API (8.2.1+)
 func handle_external_purchase_with_billing_programs(product_id: String) -> void:
@@ -1039,7 +1045,8 @@ func handle_external_purchase_with_billing_programs(product_id: String) -> void:
   type DeveloperProvidedBillingDetailsAndroid,
 } from 'expo-iap';
 
-await initConnection({ enableBillingProgramAndroid: 'external-payments' });
+const connected = await initConnection({ enableBillingProgramAndroid: 'external-payments' });
+if (!connected) throw new Error('Store connection failed');
 
 // Step 1: Set up listener for when user selects developer billing
 const developerBillingSubscription = developerProvidedBillingListenerAndroid(
@@ -1116,11 +1123,11 @@ import dev.hyo.openiap.*
 // Initialize store
 val iapStore = OpenIapStore(context = applicationContext)
 
-iapStore.initConnection(
+check(iapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments
     )
-)
+)) { "Store connection failed" }
 
 // Step 1: Set up listener for when user selects developer billing
 iapStore.addDeveloperProvidedBillingListener { details ->
@@ -1202,15 +1209,19 @@ import io.github.hyochan.kmpiap.openiap.*
 val kmpIAP = KmpIAP()
 
 scope.launch {
-    val details = kmpIAP.developerProvidedBillingAndroid()
-    yourBackend.handleDeveloperBilling(details)
+    try {
+        val details = kmpIAP.developerProvidedBillingAndroid()
+        yourBackend.handleDeveloperBilling(details)
+    } catch (e: Exception) {
+        Log.e("IAP", "Developer billing error: \${e.message}")
+    }
 }
 
-kmpIAP.initConnection(
+check(kmpIAP.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments
     )
-)
+)) { "Store connection failed" }
 
 suspend fun handlePurchaseWithExternalPayments(productId: String) {
     val availability = kmpIAP.isBillingProgramAvailableAndroid(
@@ -1240,9 +1251,10 @@ suspend fun handlePurchaseWithExternalPayments(productId: String) {
                     dart: (
                       <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
-await FlutterInappPurchase.instance.initConnection(
+final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalPayments,
 );
+if (!connected) throw StateError('Store connection failed');
 
 // Step 1: Set up listener for when user selects developer billing
 FlutterInappPurchase.instance.developerProvidedBillingAndroid.listen((details) async {
@@ -1314,13 +1326,27 @@ using OpenIap.Maui;
 
 var iap = OpenIapClient.Instance;
 var mutate = (MutationResolver)iap;
-using var developerBillingSubscription = iap.DeveloperProvidedBillingAndroid.Subscribe(
-    details => _ = YourBackend.HandleDeveloperBillingAsync(details));
 
-await mutate.InitConnectionAsync(new InitConnectionConfig
+async Task HandleDeveloperBillingSafelyAsync(DeveloperProvidedBillingDetailsAndroid details)
+{
+    try
+    {
+        await YourBackend.HandleDeveloperBillingAsync(details);
+    }
+    catch (Exception error)
+    {
+        System.Diagnostics.Debug.WriteLine($"Developer billing error: {error.Message}");
+    }
+}
+
+using var developerBillingSubscription = iap.DeveloperProvidedBillingAndroid.Subscribe(
+    details => _ = HandleDeveloperBillingSafelyAsync(details));
+
+var connected = await mutate.InitConnectionAsync(new InitConnectionConfig
 {
     EnableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments,
 });
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 var availability = await mutate.IsBillingProgramAvailableAndroidAsync(
     BillingProgramAndroid.ExternalPayments);
@@ -1350,7 +1376,10 @@ if (availability.IsAvailable)
 func _ready() -> void:
     var config = InitConnectionConfig.new()
     config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_PAYMENTS
-    await iap.init_connection(config)
+    var connected = await iap.init_connection(config)
+    if not connected:
+        push_error("Store connection failed")
+        return
 
     # Step 1: Set up listener for when user selects developer billing
     iap.developer_provided_billing_android.connect(_on_developer_provided_billing)

--- a/packages/docs/src/pages/docs/features/external-purchase.tsx
+++ b/packages/docs/src/pages/docs/features/external-purchase.tsx
@@ -1567,72 +1567,72 @@ func handle_purchase_with_external_payments(product_id: String) -> void:
                     typescript: (
                       <CodeBlock language="typescript">{`import { initConnection } from 'expo-iap';
 
-// External Offer (recommended replacement for Alternative Billing Only)
-await initConnection({
-  enableBillingProgramAndroid: 'external-offer',
+// Choose one program for this connection.
+const billingProgram = 'external-offer'; // Or 'user-choice-billing'
+const connected = await initConnection({
+  enableBillingProgramAndroid: billingProgram,
 });
-
-// Or User Choice mode
-await initConnection({
-  enableBillingProgramAndroid: 'user-choice-billing',
-});`}</CodeBlock>
+if (!connected) throw new Error('Store connection failed');`}</CodeBlock>
                     ),
                     kotlin: (
                       <CodeBlock language="kotlin">{`val iapStore = OpenIapStore(applicationContext)
 
-iapStore.initConnection(
+val connected = iapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
         // or BillingProgramAndroid.UserChoiceBilling
     )
-)`}</CodeBlock>
+)
+check(connected) { "Store connection failed" }`}</CodeBlock>
                     ),
                     kmp: (
                       <CodeBlock language="kotlin">{`val kmpIAP = KmpIAP()
 
-kmpIAP.initConnection(
+val connected = kmpIAP.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
         // or BillingProgramAndroid.UserChoiceBilling
     )
-)`}</CodeBlock>
+)
+check(connected) { "Store connection failed" }`}</CodeBlock>
                     ),
                     dart: (
                       <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
-// External Offer (recommended replacement for Alternative Billing Only)
-await FlutterInappPurchase.instance.initConnection(
+// Choose ExternalOffer or UserChoiceBilling for this connection.
+final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalOffer,
 );
-
-// Or User Choice mode
-await FlutterInappPurchase.instance.initConnection(
-  enableBillingProgramAndroid: BillingProgramAndroid.UserChoiceBilling,
-);`}</CodeBlock>
+if (!connected) throw StateError('Store connection failed');`}</CodeBlock>
                     ),
                     csharp: (
                       <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
     new InitConnectionConfig
     {
         EnableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer,
         // or BillingProgramAndroid.UserChoiceBilling
-    });`}</CodeBlock>
+    });
+if (!connected) throw new InvalidOperationException("Store connection failed");`}</CodeBlock>
                     ),
                     gdscript: (
                       <CodeBlock language="gdscript">{`# External Offer (recommended)
 func _ready_external_offer() -> void:
     var config = InitConnectionConfig.new()
     config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-    await iap.init_connection(config)
+    var success = await iap.init_connection(config)
+    if not success:
+        push_error("Store connection failed")
 
 # Or User Choice mode
 func _ready_user_choice() -> void:
     var config = InitConnectionConfig.new()
     config.enable_billing_program_android = BillingProgramAndroid.USER_CHOICE_BILLING
-    await iap.init_connection(config)`}</CodeBlock>
+    var success = await iap.init_connection(config)
+    if not success:
+        push_error("Store connection failed")`}</CodeBlock>
                     ),
                   }}
                 </LanguageTabs>

--- a/packages/docs/src/pages/docs/features/external-purchase.tsx
+++ b/packages/docs/src/pages/docs/features/external-purchase.tsx
@@ -1049,8 +1049,7 @@ const connected = await initConnection({ enableBillingProgramAndroid: 'external-
 if (!connected) throw new Error('Store connection failed');
 
 // Step 1: Set up listener for when user selects developer billing
-const developerBillingSubscription = developerProvidedBillingListenerAndroid(
-  async (details: DeveloperProvidedBillingDetailsAndroid) => {
+async function handleDeveloperBilling(details: DeveloperProvidedBillingDetailsAndroid) {
     console.log('User selected developer billing');
     console.log('External transaction token received; send it to your backend without logging it.');
 
@@ -1076,6 +1075,11 @@ const developerBillingSubscription = developerProvidedBillingListenerAndroid(
     } catch (error) {
       console.error('External payment error:', error);
     }
+}
+
+const developerBillingSubscription = developerProvidedBillingListenerAndroid(
+  (details) => {
+    void handleDeveloperBilling(details);
   }
 );
 
@@ -1249,7 +1253,8 @@ suspend fun handlePurchaseWithExternalPayments(productId: String) {
 }`}</CodeBlock>
                     ),
                     dart: (
-                      <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+                      <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
 final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalPayments,
@@ -1257,7 +1262,7 @@ final connected = await FlutterInappPurchase.instance.initConnection(
 if (!connected) throw StateError('Store connection failed');
 
 // Step 1: Set up listener for when user selects developer billing
-FlutterInappPurchase.instance.developerProvidedBillingAndroid.listen((details) async {
+Future<void> handleDeveloperBilling(DeveloperProvidedBillingDetailsAndroid details) async {
   print('User selected developer billing');
   print('External transaction token received; send it to your backend without logging it.');
 
@@ -1283,6 +1288,10 @@ FlutterInappPurchase.instance.developerProvidedBillingAndroid.listen((details) a
   } catch (e) {
     print('External payment error: \$e');
   }
+}
+
+FlutterInappPurchase.instance.developerProvidedBillingAndroid.listen((details) {
+  unawaited(handleDeveloperBilling(details));
 });
 
 // Purchase flow with External Payments

--- a/packages/docs/src/pages/docs/features/offer-code-redemption.tsx
+++ b/packages/docs/src/pages/docs/features/offer-code-redemption.tsx
@@ -129,7 +129,8 @@ function OfferCodeRedemption() {
 let subscription: ReturnType<typeof purchaseUpdatedListener> | undefined;
 
 export async function startIap() {
-  await initConnection();
+  const connected = await initConnection();
+  if (!connected) throw new Error('Store connection failed');
   subscription = purchaseUpdatedListener((purchase) => {
     console.log('Redeemed product:', purchase.productId);
   });
@@ -153,6 +154,8 @@ export async function stopIap() {
 
 @MainActor
 final class RedemptionManager {
+    enum RedemptionError: Error { case storeConnectionFailed }
+
     private let iapStore = OpenIapStore()
 
     func start() async throws {
@@ -160,6 +163,9 @@ final class RedemptionManager {
             print("Redeemed product: \(purchase.productId)")
         }
         try await iapStore.initConnection()
+        guard iapStore.isConnected else {
+            throw RedemptionError.storeConnectionFailed
+        }
     }
 
     func redeemCode() async throws -> PurchaseIOS? {
@@ -187,7 +193,7 @@ class RedemptionManager(private val scope: CoroutineScope) {
     private var purchaseJob: Job? = null
 
     suspend fun start() {
-        iap.initConnection()
+        check(iap.initConnection()) { "Store connection failed" }
         purchaseJob = scope.launch {
             iap.purchaseUpdatedListener.collect { purchase ->
                 println("Redeemed product: " + purchase.productId)
@@ -213,7 +219,8 @@ class RedemptionManager {
   StreamSubscription<Purchase>? subscription;
 
   Future<void> start() async {
-    await iap.initConnection();
+    final connected = await iap.initConnection();
+    if (!connected) throw StateError('Store connection failed');
     subscription = iap.purchaseUpdatedListener.listen((purchase) {
       print('Redeemed product: ' + purchase.productId);
     });
@@ -240,7 +247,8 @@ public sealed class RedemptionManager : IDisposable
     {
         _purchaseSubscription = _iap.PurchaseUpdated.Subscribe(
             purchase => Console.WriteLine("Redeemed product: " + purchase.ProductId));
-        await ((MutationResolver)_iap).InitConnectionAsync();
+        var connected = await ((MutationResolver)_iap).InitConnectionAsync();
+        if (!connected) throw new InvalidOperationException("Store connection failed");
     }
 
     public Task<Purchase?> RedeemCodeAsync() =>
@@ -362,7 +370,8 @@ export async function openRedeemPage() {
 
 // Call this from the app's foreground/resume handler after the user returns.
 export async function reconcileAfterResume() {
-  await initConnection();
+  const connected = await initConnection();
+  if (!connected) throw new Error('Store connection failed');
   const purchases = await getAvailablePurchases();
 
   for (const purchase of purchases) {
@@ -441,7 +450,8 @@ Future<Purchase?> openRedeemPage() =>
 
 Future<void> reconcileAfterResume() async {
   final iap = FlutterInappPurchase.instance;
-  await iap.initConnection();
+  final connected = await iap.initConnection();
+  if (!connected) throw StateError('Store connection failed');
   final purchases = await iap.getAvailablePurchases();
 
   for (final purchase in purchases) {

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -73,9 +73,9 @@ function Purchase() {
           Setup Purchase Listeners
         </AnchorLink>
         <p>
-          Register purchase listeners <strong>before</strong> making any
-          purchase requests. These listeners handle successful purchases and
-          errors.
+          Register purchase listeners <strong>before</strong> initializing the
+          store connection or making purchase requests. These listeners handle
+          successful purchases and errors.
         </p>
 
         <LanguageTabs>
@@ -106,25 +106,25 @@ function App() {
     let purchaseUpdateSubscription: ReturnType<typeof purchaseUpdatedListener>;
     let purchaseErrorSubscription: ReturnType<typeof purchaseErrorListener>;
 
+    // 1. Subscribe before initialization can replay unfinished purchases.
+    purchaseUpdateSubscription = purchaseUpdatedListener((purchase) => {
+      console.log('Purchase received:', purchase.productId);
+      // Handle the purchase (verify + finish)
+      void handlePurchase(purchase).catch((error) => {
+        console.warn('Purchase processing failed:', error);
+      });
+    });
+
+    // 2. Setup error listener
+    purchaseErrorSubscription = purchaseErrorListener((error) => {
+      console.warn('Purchase error:', error);
+      handlePurchaseError(error);
+    });
+
     const init = async () => {
-      // 1. Initialize connection first
+      // 3. Initialize after both listeners are ready.
       const connected = await initConnection();
       if (!connected) throw new Error('Store connection failed');
-
-      // 2. Setup purchase success listener
-      purchaseUpdateSubscription = purchaseUpdatedListener((purchase) => {
-        console.log('Purchase received:', purchase.productId);
-        // Handle the purchase (verify + finish)
-        void handlePurchase(purchase).catch((error) => {
-          console.warn('Purchase processing failed:', error);
-        });
-      });
-
-      // 3. Setup error listener
-      purchaseErrorSubscription = purchaseErrorListener((error) => {
-        console.warn('Purchase error:', error);
-        handlePurchaseError(error);
-      });
     };
 
     void init().catch((error) => {
@@ -135,9 +135,13 @@ function App() {
     return () => {
       purchaseUpdateSubscription?.remove();
       purchaseErrorSubscription?.remove();
-      void endConnection().catch((error) => {
-        console.warn('Store teardown failed:', error);
-      });
+      void endConnection()
+        .then((ended) => {
+          if (!ended) console.warn('Store teardown did not complete');
+        })
+        .catch((error) => {
+          console.warn('Store teardown failed:', error);
+        });
     };
   }, []);
 
@@ -261,6 +265,7 @@ class PurchaseManager(
             kmp: (
               <CodeBlock language="kotlin">{`import io.github.hyochan.kmpiap.KmpIAP
 import io.github.hyochan.kmpiap.openiap.*
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
@@ -276,7 +281,7 @@ class PurchaseManager(
 
     private fun setupListeners() {
         // 1. Collect purchase updates using Flow
-        lifecycleScope.launch {
+        lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
             kmpIAP.purchaseUpdatedListener.collect { purchase ->
                 println("Purchase received: \${purchase.productId}")
                 handlePurchase(purchase)
@@ -284,7 +289,7 @@ class PurchaseManager(
         }
 
         // 2. Collect error updates
-        lifecycleScope.launch {
+        lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
             kmpIAP.purchaseErrorListener.collect { error ->
                 println("Purchase error: \${error.message}")
                 handlePurchaseError(error)
@@ -315,11 +320,7 @@ class PurchaseManager {
   StreamSubscription<PurchaseError>? _errorSubscription;
 
   Future<void> initialize() async {
-    // 1. Initialize connection first
-    final connected = await _iap.initConnection();
-    if (!connected) throw StateError('Store connection failed');
-
-    // 2. Setup purchase success listener
+    // 1. Subscribe before initialization can replay unfinished purchases.
     _purchaseSubscription = _iap.purchaseUpdatedListener.listen((purchase) {
       print('Purchase received: \${purchase.productId}');
       unawaited(_handlePurchase(purchase).catchError((Object error) {
@@ -327,19 +328,27 @@ class PurchaseManager {
       }));
     });
 
-    // 3. Setup error listener
+    // 2. Setup error listener
     _errorSubscription = _iap.purchaseErrorListener.listen((error) {
       print('Purchase error: \${error.message}');
       _handlePurchaseError(error);
     });
+
+    // 3. Initialize after both stream subscriptions are ready.
+    final connected = await _iap.initConnection();
+    if (!connected) throw StateError('Store connection failed');
   }
 
   void dispose() {
     unawaited(_purchaseSubscription?.cancel());
     unawaited(_errorSubscription?.cancel());
-    unawaited(_iap.endConnection().then<void>((_) {}).catchError((Object error) {
-      print('Store teardown failed: \$error');
-    }));
+    unawaited(
+      _iap.endConnection().then<void>((ended) {
+        if (!ended) print('Store teardown did not complete');
+      }).catchError((Object error) {
+        print('Store teardown failed: \$error');
+      }),
+    );
   }
 }`}</CodeBlock>
             ),
@@ -1526,6 +1535,13 @@ function PurchaseProvider({ children }: { children: React.ReactNode }) {
     let purchaseSub: ReturnType<typeof purchaseUpdatedListener>;
     let errorSub: ReturnType<typeof purchaseErrorListener>;
 
+    purchaseSub = purchaseUpdatedListener((purchase) => {
+      void handlePurchase(purchase).catch((error) => {
+        console.warn('Purchase processing failed:', error);
+      });
+    });
+    errorSub = purchaseErrorListener(handleError);
+
     const init = async () => {
       const connected = await initConnection();
       if (!connected) return;
@@ -1536,14 +1552,6 @@ function PurchaseProvider({ children }: { children: React.ReactNode }) {
         type: 'in-app',
       });
       setProducts((items ?? []) as Product[]);
-
-      // Setup listeners
-      purchaseSub = purchaseUpdatedListener((purchase) => {
-        void handlePurchase(purchase).catch((error) => {
-          console.warn('Purchase processing failed:', error);
-        });
-      });
-      errorSub = purchaseErrorListener(handleError);
     };
 
     void init().catch((error) => {
@@ -1553,9 +1561,13 @@ function PurchaseProvider({ children }: { children: React.ReactNode }) {
     return () => {
       purchaseSub?.remove();
       errorSub?.remove();
-      void endConnection().catch((error) => {
-        console.warn('Store teardown failed:', error);
-      });
+      void endConnection()
+        .then((ended) => {
+          if (!ended) console.warn('Store teardown did not complete');
+        })
+        .catch((error) => {
+          console.warn('Store teardown failed:', error);
+        });
     };
   }, [handlePurchase, handleError]);
 
@@ -1806,6 +1818,7 @@ class PurchaseManager(
               <CodeBlock language="kotlin">{`import io.github.hyochan.kmpiap.KmpIAP
 import io.github.hyochan.kmpiap.*
 import io.github.hyochan.kmpiap.openiap.*
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.*
 
 class PurchaseManager(
@@ -1841,13 +1854,13 @@ class PurchaseManager(
     }
 
     private fun setupListeners() {
-        scope.launch {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             kmpIAP.purchaseUpdatedListener.collect { purchase ->
                 handlePurchase(purchase as PurchaseAndroid)
             }
         }
 
-        scope.launch {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             kmpIAP.purchaseErrorListener.collect { error ->
                 _isProcessing.value = false
                 println("Purchase error: \${error.message}")
@@ -1913,6 +1926,7 @@ class PurchaseManager extends ChangeNotifier {
   StreamSubscription<PurchaseError>? _errorSub;
 
   Future<void> initialize() async {
+    _setupListeners();
     final connected = await _iap.initConnection();
     if (!connected) throw StateError('Store connection failed');
     products = await _iap.fetchProducts<Product>(
@@ -1920,7 +1934,6 @@ class PurchaseManager extends ChangeNotifier {
       type: ProductQueryType.InApp,
     );
     notifyListeners();
-    _setupListeners();
   }
 
   void _setupListeners() {
@@ -1983,7 +1996,9 @@ class PurchaseManager extends ChangeNotifier {
   void dispose() {
     unawaited(_purchaseSub?.cancel());
     unawaited(_errorSub?.cancel());
-    unawaited(_iap.endConnection().then<void>((_) {}).catchError(
+    unawaited(_iap.endConnection().then<void>((ended) {
+      if (!ended) print('Store teardown did not complete');
+    }).catchError(
       (Object error) => print('Store teardown failed: $error'),
     ));
     super.dispose();
@@ -2068,7 +2083,8 @@ sealed class PurchaseManager : IAsyncDisposable
     {
         purchaseSubscription.Dispose();
         errorSubscription.Dispose();
-        await mutate.EndConnectionAsync();
+        if (!await mutate.EndConnectionAsync())
+            Console.WriteLine("Store teardown did not complete");
     }
 }`}</CodeBlock>
             ),
@@ -2230,11 +2246,11 @@ const checkPendingPurchases = async () => {
 // Call on app launch after setting up listeners
 useEffect(() => {
   const init = async () => {
+    // Register purchase update/error listeners before this initialization.
     const connected = await initConnection();
     if (!connected) throw new Error('Store connection failed');
-    // Setup listeners first...
 
-    // Then check for pending purchases
+    // Then check for pending purchases.
     await checkPendingPurchases();
   };
 

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -455,15 +455,15 @@ function BuyButton({ productId }: { productId: string }) {
     <Button
       title="Buy"
       disabled={!connected}
-      onPress={() =>
-        requestPurchase({
+      onPress={() => {
+        void requestPurchase({
           request: {
             apple: { sku: productId },
             google: { skus: [productId] },
           },
           type: 'in-app',
-        })
-      }
+        });
+      }}
     />
   );
 }`}</CodeBlock>

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -657,10 +657,12 @@ import { useIAP } from 'expo-iap';
 
 function PurchaseScreen() {
   useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      if (!(await verifyOnServer(purchase))) {
-        console.error('Verification failed');
-      }
+    onPurchaseSuccess: (purchase) => {
+      void verifyOnServer(purchase)
+        .then((verified) => {
+          if (!verified) console.error('Verification failed');
+        })
+        .catch((error) => console.warn('Verification failed:', error));
     },
   });
 
@@ -909,25 +911,27 @@ import { useIAP } from 'expo-iap';
 
 function PurchaseScreen() {
   const { verifyPurchaseWithProvider } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      const result = await verifyPurchaseWithProvider({
-        provider: 'iapkit',
-        iapkit: {
-          apiKey: process.env.EXPO_PUBLIC_IAPKIT_PUBLISHABLE_KEY,
-          ...(await iapkitPayloadFor(purchase)),
-        },
-      });
-      const verified = result.iapkit;
-      if (
-        verified?.isValid !== true ||
-        (verified.store === 'amazon' &&
-          verified.environment !==
-            (amazonSandbox ? 'Sandbox' : 'Production')) ||
-        verified.productId == null ||
-        verified.productId !== purchase.productId
-      ) {
-        console.error('IAPKit verification failed');
-      }
+    onPurchaseSuccess: (purchase) => {
+      void (async () => {
+        const result = await verifyPurchaseWithProvider({
+          provider: 'iapkit',
+          iapkit: {
+            apiKey: process.env.EXPO_PUBLIC_IAPKIT_PUBLISHABLE_KEY,
+            ...(await iapkitPayloadFor(purchase)),
+          },
+        });
+        const verified = result.iapkit;
+        if (
+          verified?.isValid !== true ||
+          (verified.store === 'amazon' &&
+            verified.environment !==
+              (amazonSandbox ? 'Sandbox' : 'Production')) ||
+          verified.productId == null ||
+          verified.productId !== purchase.productId
+        ) {
+          console.error('IAPKit verification failed');
+        }
+      })().catch((error) => console.warn('IAPKit verification failed:', error));
     },
   });
 
@@ -1247,13 +1251,11 @@ const handlePurchase = async (purchase: Purchase) => {
 import { useIAP } from 'expo-iap';
 
 function PurchaseScreen() {
-  const { finishTransaction } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      const isValid = await verifyPurchase(purchase);
-      if (!isValid) return;
-      await grantProductToUser(purchase.productId);
-      const isConsumable = purchase.productId.includes('consumable');
-      await finishTransaction({ purchase, isConsumable });
+  useIAP({
+    onPurchaseSuccess: (purchase) => {
+      void handlePurchase(purchase).catch((error) =>
+        console.warn('Purchase processing failed:', error),
+      );
     },
   });
 
@@ -1533,19 +1535,25 @@ import { useIAP } from 'expo-iap';
 function PurchaseProviderWithHook({ children }: { children: React.ReactNode }) {
   const [isProcessing, setIsProcessing] = useState(false);
 
-  const { connected, products, fetchProducts, finishTransaction } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      setIsProcessing(true);
-      try {
-        if (!(await verifyOnServer(purchase))) return;
+  const processPurchase = useCallback(async (purchase: Purchase) => {
+    setIsProcessing(true);
+    try {
+      if (!(await verifyOnServer(purchase))) return;
 
-        await grantProductToUser(purchase.productId);
+      await grantProductToUser(purchase.productId);
 
-        const isConsumable = purchase.productId.includes('coins');
-        await finishTransaction({ purchase, isConsumable });
-      } finally {
-        setIsProcessing(false);
-      }
+      const isConsumable = purchase.productId.includes('coins');
+      await finishTransaction({ purchase, isConsumable });
+    } finally {
+      setIsProcessing(false);
+    }
+  }, []);
+
+  const { connected, products, fetchProducts } = useIAP({
+    onPurchaseSuccess: (purchase) => {
+      void processPurchase(purchase).catch((error) => {
+        console.warn('Purchase processing failed:', error);
+      });
     },
     onPurchaseError: (error) => {
       console.warn('Purchase error:', error.code, error.message);

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -108,13 +108,16 @@ function App() {
 
     const init = async () => {
       // 1. Initialize connection first
-      await initConnection();
+      const connected = await initConnection();
+      if (!connected) throw new Error('Store connection failed');
 
       // 2. Setup purchase success listener
       purchaseUpdateSubscription = purchaseUpdatedListener((purchase) => {
         console.log('Purchase received:', purchase.productId);
         // Handle the purchase (verify + finish)
-        void handlePurchase(purchase);
+        void handlePurchase(purchase).catch((error) => {
+          console.warn('Purchase processing failed:', error);
+        });
       });
 
       // 3. Setup error listener
@@ -124,13 +127,17 @@ function App() {
       });
     };
 
-    void init();
+    void init().catch((error) => {
+      console.warn('Store initialization failed:', error);
+    });
 
     // Cleanup on unmount
     return () => {
       purchaseUpdateSubscription?.remove();
       purchaseErrorSubscription?.remove();
-      void endConnection();
+      void endConnection().catch((error) => {
+        console.warn('Store teardown failed:', error);
+      });
     };
   }, []);
 
@@ -145,7 +152,9 @@ import { useIAP } from 'expo-iap';
 function AppWithHook() {
   useIAP({
     onPurchaseSuccess: (purchase) => {
-      void handlePurchase(purchase);
+      void handlePurchase(purchase).catch((error) => {
+        console.warn('Purchase processing failed:', error);
+      });
     },
     onPurchaseError: (error) => {
       handlePurchaseError(error);
@@ -1503,7 +1512,11 @@ function PurchaseProvider({ children }: { children: React.ReactNode }) {
       setProducts((items ?? []) as Product[]);
 
       // Setup listeners
-      purchaseSub = purchaseUpdatedListener((p) => void handlePurchase(p));
+      purchaseSub = purchaseUpdatedListener((purchase) => {
+        void handlePurchase(purchase).catch((error) => {
+          console.warn('Purchase processing failed:', error);
+        });
+      });
       errorSub = purchaseErrorListener(handleError);
     };
 
@@ -2177,7 +2190,9 @@ useEffect(() => {
     await checkPendingPurchases();
   };
 
-  void init();
+  void init().catch((error) => {
+    console.warn('Pending purchase initialization failed:', error);
+  });
 }, []);
 
 // --- Or via the useIAP() hook (also exported from react-native-iap) ---
@@ -2188,7 +2203,11 @@ import { useIAP } from 'expo-iap';
 
 function PendingPurchaseHandler() {
   const { connected, availablePurchases, getAvailablePurchases } = useIAP({
-    onPurchaseSuccess: (purchase) => void handlePurchase(purchase),
+    onPurchaseSuccess: (purchase) => {
+      void handlePurchase(purchase).catch((error) => {
+        console.warn('Pending purchase processing failed:', error);
+      });
+    },
   });
 
   useEffect(() => {
@@ -2199,7 +2218,11 @@ function PendingPurchaseHandler() {
   }, [connected, getAvailablePurchases]);
 
   useEffect(() => {
-    availablePurchases.forEach((purchase) => void handlePurchase(purchase));
+    availablePurchases.forEach((purchase) => {
+      void handlePurchase(purchase).catch((error) => {
+        console.warn('Pending purchase processing failed:', error);
+      });
+    });
   }, [availablePurchases]);
 
   return null;

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -449,11 +449,12 @@ await purchaseProduct('com.app.coins_100');
 import { useIAP } from 'expo-iap';
 
 function BuyButton({ productId }: { productId: string }) {
-  const { requestPurchase } = useIAP();
+  const { connected, requestPurchase } = useIAP();
 
   return (
     <Button
       title="Buy"
+      disabled={!connected}
       onPress={() =>
         requestPurchase({
           request: {

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -195,6 +195,10 @@ class PurchaseManager: ObservableObject {
         Task {
             do {
                 try await iapStore.initConnection()
+                guard iapStore.isConnected else {
+                    print("Store connection failed")
+                    return
+                }
                 print("Store connection established")
             } catch {
                 print("Failed to connect: \\(error.localizedDescription)")
@@ -312,12 +316,15 @@ class PurchaseManager {
 
   Future<void> initialize() async {
     // 1. Initialize connection first
-    await _iap.initConnection();
+    final connected = await _iap.initConnection();
+    if (!connected) throw StateError('Store connection failed');
 
     // 2. Setup purchase success listener
     _purchaseSubscription = _iap.purchaseUpdatedListener.listen((purchase) {
       print('Purchase received: \${purchase.productId}');
-      _handlePurchase(purchase);
+      unawaited(_handlePurchase(purchase).catchError((Object error) {
+        print('Purchase processing failed: \$error');
+      }));
     });
 
     // 3. Setup error listener
@@ -328,9 +335,11 @@ class PurchaseManager {
   }
 
   void dispose() {
-    _purchaseSubscription?.cancel();
-    _errorSubscription?.cancel();
-    _iap.endConnection();
+    unawaited(_purchaseSubscription?.cancel());
+    unawaited(_errorSubscription?.cancel());
+    unawaited(_iap.endConnection().then<void>((_) {}).catchError((Object error) {
+      print('Store teardown failed: \$error');
+    }));
   }
 }`}</CodeBlock>
             ),
@@ -347,12 +356,27 @@ sealed class PurchaseManager : IDisposable
     public PurchaseManager()
     {
         purchaseSubscription = iap.PurchaseUpdated.Subscribe(purchase =>
-            HandlePurchaseAsync(purchase));
+            _ = HandlePurchaseSafelyAsync(purchase));
         errorSubscription = iap.PurchaseError.Subscribe(HandlePurchaseError);
     }
 
-    public async Task InitializeAsync() =>
-        await ((MutationResolver)iap).InitConnectionAsync();
+    private async Task HandlePurchaseSafelyAsync(Purchase purchase)
+    {
+        try
+        {
+            await HandlePurchaseAsync(purchase);
+        }
+        catch (Exception error)
+        {
+            Console.WriteLine($"Purchase processing failed: {error.Message}");
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        var connected = await ((MutationResolver)iap).InitConnectionAsync();
+        if (!connected) throw new InvalidOperationException("Store connection failed");
+    }
 
     public void Dispose()
     {
@@ -378,8 +402,10 @@ func setup_listeners() -> void:
 
     # 3. Initialize connection
     var connected = await iap.init_connection(null)
-    if connected:
-        print("Store connection established")
+    if not connected:
+        push_error("Store connection failed")
+        return
+    print("Store connection established")
 
 func _on_purchase_received(purchase: Purchase) -> void:
     print("Purchase received: %s" % purchase.product_id)
@@ -1606,6 +1632,10 @@ class PurchaseManager: ObservableObject {
         Task {
             do {
                 try await iapStore.initConnection()
+                guard iapStore.isConnected else {
+                    print("Store connection failed")
+                    return
+                }
                 try await iapStore.fetchProducts(
                     skus: ["com.app.premium", "com.app.coins_100"],
                     type: .inApp
@@ -1695,7 +1725,7 @@ class PurchaseManager(
         setupListeners()
         scope.launch {
             try {
-                iapStore.initConnection()
+                check(iapStore.initConnection()) { "Store connection failed" }
                 val request = ProductRequest(
                     skus = listOf("com.app.premium", "com.app.coins_100"),
                     type = ProductQueryType.InApp
@@ -1794,7 +1824,7 @@ class PurchaseManager(
         setupListeners()
         scope.launch {
             try {
-                kmpIAP.initConnection()
+                check(kmpIAP.initConnection()) { "Store connection failed" }
                 val request = ProductRequest(
                     skus = listOf("com.app.premium", "com.app.coins_100"),
                     type = ProductQueryType.InApp
@@ -1883,7 +1913,8 @@ class PurchaseManager extends ChangeNotifier {
   StreamSubscription<PurchaseError>? _errorSub;
 
   Future<void> initialize() async {
-    await _iap.initConnection();
+    final connected = await _iap.initConnection();
+    if (!connected) throw StateError('Store connection failed');
     products = await _iap.fetchProducts<Product>(
       skus: ['com.app.premium', 'com.app.coins_100'],
       type: ProductQueryType.InApp,
@@ -1893,7 +1924,11 @@ class PurchaseManager extends ChangeNotifier {
   }
 
   void _setupListeners() {
-    _purchaseSub = _iap.purchaseUpdatedListener.listen(_handlePurchase);
+    _purchaseSub = _iap.purchaseUpdatedListener.listen((purchase) {
+      unawaited(_handlePurchase(purchase).catchError(
+        (Object error) => print('Purchase processing failed: $error'),
+      ));
+    });
 
     _errorSub = _iap.purchaseErrorListener.listen((e) {
       isProcessing = false;
@@ -1946,9 +1981,11 @@ class PurchaseManager extends ChangeNotifier {
   }
 
   void dispose() {
-    _purchaseSub?.cancel();
-    _errorSub?.cancel();
-    _iap.endConnection();
+    unawaited(_purchaseSub?.cancel());
+    unawaited(_errorSub?.cancel());
+    unawaited(_iap.endConnection().then<void>((_) {}).catchError(
+      (Object error) => print('Store teardown failed: $error'),
+    ));
     super.dispose();
   }
 }`}</CodeBlock>
@@ -1983,7 +2020,8 @@ sealed class PurchaseManager : IAsyncDisposable
 
     public async Task InitializeAsync()
     {
-        await mutate.InitConnectionAsync();
+        if (!await mutate.InitConnectionAsync())
+            throw new InvalidOperationException("Store connection failed");
         var result = await query.FetchProductsAsync(new ProductRequest
         {
             Skus = new[] { "com.app.premium", "com.app.coins_100" },
@@ -2015,6 +2053,10 @@ sealed class PurchaseManager : IAsyncDisposable
             await mutate.FinishTransactionAsync(
                 new PurchaseInput(purchase),
                 purchase.ProductId.Contains("coins", StringComparison.OrdinalIgnoreCase));
+        }
+        catch (Exception error)
+        {
+            Console.WriteLine($"Purchase processing failed: {error.Message}");
         }
         finally
         {
@@ -2050,7 +2092,8 @@ var is_processing: bool:
 const PRODUCT_IDS = ["com.app.premium", "com.app.coins_100"]
 
 func _ready() -> void:
-    setup_listeners()
+    if not await setup_listeners():
+        return
 
     # Fetch products directly
     var request = ProductRequest.new()
@@ -2059,10 +2102,14 @@ func _ready() -> void:
     products = await iap.fetch_products(request)
     products_loaded.emit()
 
-func setup_listeners() -> void:
+func setup_listeners() -> bool:
     iap.purchase_updated.connect(_on_purchase_updated)
     iap.purchase_error.connect(_on_purchase_error)
-    await iap.init_connection(null)
+    var connected = await iap.init_connection(null)
+    if not connected:
+        push_error("Store connection failed")
+        return false
+    return true
 
 func purchase(product_id: String) -> void:
     is_processing = true
@@ -2183,7 +2230,8 @@ const checkPendingPurchases = async () => {
 // Call on app launch after setting up listeners
 useEffect(() => {
   const init = async () => {
-    await initConnection();
+    const connected = await initConnection();
+    if (!connected) throw new Error('Store connection failed');
     // Setup listeners first...
 
     // Then check for pending purchases

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -462,6 +462,8 @@ function BuyButton({ productId }: { productId: string }) {
             google: { skus: [productId] },
           },
           type: 'in-app',
+        }).catch((error) => {
+          console.warn('Purchase dispatch failed', error);
         });
       }}
     />
@@ -1488,7 +1490,8 @@ function PurchaseProvider({ children }: { children: React.ReactNode }) {
     let errorSub: ReturnType<typeof purchaseErrorListener>;
 
     const init = async () => {
-      await initConnection();
+      const connected = await initConnection();
+      if (!connected) return;
 
       // Fetch products
       const items = await fetchProducts({
@@ -1502,12 +1505,16 @@ function PurchaseProvider({ children }: { children: React.ReactNode }) {
       errorSub = purchaseErrorListener(handleError);
     };
 
-    void init();
+    void init().catch((error) => {
+      console.warn('Store initialization failed:', error);
+    });
 
     return () => {
       purchaseSub?.remove();
       errorSub?.remove();
-      void endConnection();
+      void endConnection().catch((error) => {
+        console.warn('Store teardown failed:', error);
+      });
     };
   }, [handlePurchase, handleError]);
 

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -1548,7 +1548,9 @@ function PurchaseProviderWithHook({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!connected) return;
-    void fetchProducts({ skus: PRODUCT_IDS, type: 'in-app' });
+    void fetchProducts({ skus: PRODUCT_IDS, type: 'in-app' }).catch((error) =>
+      console.warn('Product fetch failed:', error),
+    );
   }, [connected, fetchProducts]);
 
   return (
@@ -2176,7 +2178,9 @@ function PendingPurchaseHandler() {
 
   useEffect(() => {
     if (!connected) return;
-    void getAvailablePurchases();
+    void getAvailablePurchases().catch((error) =>
+      console.warn('Pending purchase lookup failed:', error),
+    );
   }, [connected, getAvailablePurchases]);
 
   useEffect(() => {

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -1525,7 +1525,7 @@ import { useIAP } from 'expo-iap';
 function PurchaseProviderWithHook({ children }: { children: React.ReactNode }) {
   const [isProcessing, setIsProcessing] = useState(false);
 
-  const { products, fetchProducts, finishTransaction } = useIAP({
+  const { connected, products, fetchProducts, finishTransaction } = useIAP({
     onPurchaseSuccess: async (purchase) => {
       setIsProcessing(true);
       try {
@@ -1546,8 +1546,9 @@ function PurchaseProviderWithHook({ children }: { children: React.ReactNode }) {
   });
 
   useEffect(() => {
+    if (!connected) return;
     void fetchProducts({ skus: PRODUCT_IDS, type: 'in-app' });
-  }, [fetchProducts]);
+  }, [connected, fetchProducts]);
 
   return (
     <PurchaseContext.Provider value={{ products, isProcessing }}>
@@ -2168,13 +2169,14 @@ useEffect(() => {
 import { useIAP } from 'expo-iap';
 
 function PendingPurchaseHandler() {
-  const { availablePurchases, getAvailablePurchases } = useIAP({
+  const { connected, availablePurchases, getAvailablePurchases } = useIAP({
     onPurchaseSuccess: (purchase) => void handlePurchase(purchase),
   });
 
   useEffect(() => {
+    if (!connected) return;
     void getAvailablePurchases();
-  }, [getAvailablePurchases]);
+  }, [connected, getAvailablePurchases]);
 
   useEffect(() => {
     availablePurchases.forEach((purchase) => void handlePurchase(purchase));

--- a/packages/docs/src/pages/docs/features/subscription-billing-issue.tsx
+++ b/packages/docs/src/pages/docs/features/subscription-billing-issue.tsx
@@ -176,9 +176,11 @@ import {
 
 const subscription = subscriptionBillingIssueListener((purchase) => {
   console.warn('Subscription needs attention:', purchase.productId);
-  deepLinkToSubscriptions({
+  void deepLinkToSubscriptions({
     skuAndroid: purchase.productId,
     packageNameAndroid: 'com.example.app',
+  }).catch((error) => {
+    console.error('Failed to open subscription settings', error);
   });
 });
 
@@ -186,14 +188,18 @@ const subscription = subscriptionBillingIssueListener((purchase) => {
 subscription.remove();`}</CodeBlock>
             ),
             dart: (
-              <CodeBlock language="dart">{`final iap = FlutterInappPurchase.instance;
+              <CodeBlock language="dart">{`import 'dart:async';
 
-final sub = iap.subscriptionBillingIssueListener.listen((purchase) async {
+final iap = FlutterInappPurchase.instance;
+
+final sub = iap.subscriptionBillingIssueListener.listen((purchase) {
   debugPrint('Needs attention: \${purchase.productId}');
-  await iap.deepLinkToSubscriptions(
+  unawaited(iap.deepLinkToSubscriptions(
     skuAndroid: purchase.productId,
     packageNameAndroid: 'com.example.app',
-  );
+  ).catchError(
+    (Object error) => debugPrint('Failed to open subscription settings: $error'),
+  ));
 });
 
 await sub.cancel();`}</CodeBlock>
@@ -203,16 +209,26 @@ await sub.cancel();`}</CodeBlock>
 using OpenIap.Maui;
 
 var mutate = (MutationResolver)OpenIapClient.Instance;
-using var subscription = OpenIapClient.Instance.SubscriptionBillingIssue.Subscribe(
-    purchase =>
+
+async Task OpenSubscriptionSettingsSafelyAsync(Purchase purchase)
+{
+    if (purchase is not PurchaseCommon info) return;
+    try
     {
-        if (purchase is not PurchaseCommon info) return;
-        _ = mutate.DeepLinkToSubscriptionsAsync(new DeepLinkOptions
+        await mutate.DeepLinkToSubscriptionsAsync(new DeepLinkOptions
         {
             SkuAndroid = info.ProductId,
             PackageNameAndroid = "com.example.app",
         });
-    });`}</CodeBlock>
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Failed to open subscription settings: {error.Message}");
+    }
+}
+
+using var subscription = OpenIapClient.Instance.SubscriptionBillingIssue.Subscribe(
+    purchase => _ = OpenSubscriptionSettingsSafelyAsync(purchase));`}</CodeBlock>
             ),
             gdscript: (
               <CodeBlock language="gdscript">{`# godot-iap signal

--- a/packages/docs/src/pages/docs/features/subscription/index.tsx
+++ b/packages/docs/src/pages/docs/features/subscription/index.tsx
@@ -1813,15 +1813,17 @@ const handlePurchase = async (
 };
 
 // 2. Use YOUR tracked value in onPurchaseSuccess
-onPurchaseSuccess: async (purchase) => {
+onPurchaseSuccess: (purchase) => {
   // DON'T use purchase.currentPlanId - it may be wrong!
   const actualBasePlanId = purchasedBasePlanId;
 
-  // Save to your backend
-  await saveToBackend({
+  // Save to your backend; hook callback promises are not observed.
+  void saveToBackend({
     purchaseToken: purchase.purchaseToken,
     basePlanIdAndroid: actualBasePlanId,  // Use YOUR tracked value
     productId: purchase.productId,
+  }).catch((error) => {
+    console.error('Failed to save purchase metadata', error);
   });
 };`}</CodeBlock>
                     ),

--- a/packages/docs/src/pages/docs/getting-started.tsx
+++ b/packages/docs/src/pages/docs/getting-started.tsx
@@ -107,10 +107,12 @@ function GettingStarted() {
   requestPurchase,
   finishTransaction,
   purchaseUpdatedListener,
+  type Purchase,
 } from 'expo-iap';
 
 // 1. Open the store connection on app start.
-await initConnection();
+const connected = await initConnection();
+if (!connected) throw new Error('Store connection failed');
 
 // 2. Fetch products by SKU.
 const products = await fetchProducts({
@@ -119,13 +121,19 @@ const products = await fetchProducts({
 });
 
 // 3. Listen for purchase results — requestPurchase is event-based.
-const purchaseSubscription = purchaseUpdatedListener(async (purchase) => {
+async function handlePurchase(purchase: Purchase) {
   // Your backend verifies the store token/JWS and returns an entitlement decision.
   const { isValid } = await yourBackend.verifyPurchase(purchase);
   if (!isValid) return;
 
   await grantEntitlement(purchase.productId);
   await finishTransaction({ purchase, isConsumable: false });
+}
+
+const purchaseSubscription = purchaseUpdatedListener((purchase) => {
+  void handlePurchase(purchase).catch((error) => {
+    console.error('Purchase processing failed', error);
+  });
 });
 
 // On app shutdown: purchaseSubscription.remove();
@@ -145,7 +153,8 @@ await requestPurchase({
 let store = OpenIapModule.shared
 
 // 1. Open the store connection on app start.
-try await store.initConnection()
+let connected = try await store.initConnection()
+precondition(connected, "Store connection failed")
 
 // 2. Fetch products by SKU.
 let products = try await store.fetchProducts(
@@ -189,7 +198,7 @@ import dev.hyo.openiap.listener.OpenIapPurchaseUpdateListener
 val store = OpenIapStore(context)
 
 // 1. Open the store connection on app start.
-store.initConnection(null)
+check(store.initConnection(null)) { "Store connection failed" }
 
 // 2. Fetch products by SKU.
 val products = store.fetchProducts(
@@ -232,7 +241,7 @@ import io.github.hyochan.kmpiap.openiap.*
 val kmpIAP = KmpIAP()
 
 // 1. Open the store connection on app start.
-kmpIAP.initConnection()
+check(kmpIAP.initConnection()) { "Store connection failed" }
 
 // 2. Fetch products by SKU.
 val products = kmpIAP.fetchProducts(
@@ -283,12 +292,14 @@ kmpIAP.finishTransaction(
 )`}</CodeBlock>
             ),
             dart: (
-              <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+              <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
 final iap = FlutterInappPurchase.instance;
 
 // 1. Open the store connection on app start.
-await iap.initConnection();
+final connected = await iap.initConnection();
+if (!connected) throw StateError('Store connection failed');
 
 // 2. Fetch products by SKU.
 final products = await iap.fetchProducts<Product>(
@@ -297,9 +308,15 @@ final products = await iap.fetchProducts<Product>(
 );
 
 // 3. Listen for purchase results.
-final purchaseSubscription = iap.purchaseUpdatedListener.listen((purchase) async {
+Future<void> handlePurchase(Purchase purchase) async {
   // Verify on your backend, grant entitlement, then finish.
   await iap.finishTransaction(purchase: purchase, isConsumable: false);
+}
+
+final purchaseSubscription = iap.purchaseUpdatedListener.listen((purchase) {
+  unawaited(handlePurchase(purchase).catchError(
+    (Object error) => print('Purchase processing failed: $error'),
+  ));
 });
 
 // 4. Initiate a purchase.
@@ -333,7 +350,8 @@ var query = (QueryResolver)OpenIapClient.Instance;
 var mutation = (MutationResolver)OpenIapClient.Instance;
 
 // 1. Open the store connection on app start.
-await mutation.InitConnectionAsync();
+var connected = await mutation.InitConnectionAsync();
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 // 2. Fetch products by SKU.
 var products = await query.FetchProductsAsync(new ProductRequest
@@ -343,13 +361,22 @@ var products = await query.FetchProductsAsync(new ProductRequest
 });
 
 // 3. Listen for purchase results.
-var subscription = OpenIapClient.Instance.PurchaseUpdated.Subscribe(async purchase =>
+async Task HandlePurchaseSafelyAsync(Purchase purchase)
 {
-    // Verify on your backend, grant entitlement, then finish.
-    await mutation.FinishTransactionAsync(
-        new PurchaseInput(purchase),
-        isConsumable: false);
-});
+    try
+    {
+        await mutation.FinishTransactionAsync(
+            new PurchaseInput(purchase),
+            isConsumable: false);
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Purchase processing failed: {error.Message}");
+    }
+}
+
+var subscription = OpenIapClient.Instance.PurchaseUpdated.Subscribe(
+    purchase => _ = HandlePurchaseSafelyAsync(purchase));
 
 // 4. Initiate a purchase.
 await mutation.RequestPurchaseAsync(new RequestPurchaseProps
@@ -369,7 +396,9 @@ void DisposePurchaseListener() => subscription.Dispose();`}</CodeBlock>
             ),
             gdscript: (
               <CodeBlock language="gdscript">{`# 1. Open the store connection on app start.
-await iap.init_connection()
+if not await iap.init_connection():
+    push_error("Store connection failed")
+    return
 
 # 2. Fetch products by SKU.
 var request = ProductRequest.new()

--- a/packages/docs/src/pages/docs/setup/expo.tsx
+++ b/packages/docs/src/pages/docs/setup/expo.tsx
@@ -401,8 +401,11 @@ function Store() {
   });
 
   useEffect(() => {
-    fetchProducts({ skus: ['premium'] });
-  }, []);
+    if (!connected) return;
+    void fetchProducts({ skus: ['premium'] }).catch((error) => {
+      console.warn('Product fetch failed:', error);
+    });
+  }, [connected, fetchProducts]);
 
   return (
     <FlatList
@@ -410,7 +413,8 @@ function Store() {
       keyExtractor={(product) => product.id}
       renderItem={({ item }) => (
         <Button
-          title={\`\${item.title} - \${item.localizedPrice}\`}
+          title={\`\${item.title} - \${item.displayPrice}\`}
+          disabled={!connected}
           onPress={() =>
             requestPurchase({
               request: {

--- a/packages/docs/src/pages/docs/setup/expo.tsx
+++ b/packages/docs/src/pages/docs/setup/expo.tsx
@@ -415,15 +415,17 @@ function Store() {
         <Button
           title={\`\${item.title} - \${item.displayPrice}\`}
           disabled={!connected}
-          onPress={() =>
-            requestPurchase({
+          onPress={() => {
+            void requestPurchase({
               request: {
                 apple: { sku: item.id },
                 google: { skus: [item.id] },
               },
               type: 'in-app',
-            })
-          }
+            }).catch((error) =>
+              console.warn('Purchase request failed:', error),
+            );
+          }}
         />
       )}
     />

--- a/packages/docs/src/pages/docs/setup/expo.tsx
+++ b/packages/docs/src/pages/docs/setup/expo.tsx
@@ -387,12 +387,17 @@ function Store() {
     fetchProducts,
     requestPurchase,
   } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
+    onPurchaseSuccess: (purchase) => {
       // 1. Validate receipt with your backend or IAPKit
       // 2. Grant entitlement
       // 3. CRITICAL: Finish the transaction
       //    (Android auto-refunds after 3 days if not called!)
-      await finishTransaction({ purchase, isConsumable: false }); // true for consumables
+      void finishTransaction({
+        purchase,
+        isConsumable: false, // true for consumables
+      }).catch((error) => {
+        console.warn('Transaction finalization failed:', error);
+      });
     },
     onPurchaseError: (error) => {
       if (error.code === ErrorCode.UserCancelled) return;

--- a/packages/docs/src/pages/docs/setup/expo.tsx
+++ b/packages/docs/src/pages/docs/setup/expo.tsx
@@ -330,17 +330,17 @@ cd ios && pod install`}
         </h2>
 
         <p>
-          Under the hood, the typical flow is{' '}
-          <Link to="/docs/apis/init-connection">
-            <code>initConnection</code>
-          </Link>{' '}
-          → set up{' '}
+          Under the hood, the typical flow is set up{' '}
           <Link to="/docs/events/purchase-updated-listener">
             <code>purchaseUpdatedListener</code>
           </Link>{' '}
           and{' '}
           <Link to="/docs/events/purchase-error-listener">
             <code>purchaseErrorListener</code>
+          </Link>{' '}
+          →{' '}
+          <Link to="/docs/apis/init-connection">
+            <code>initConnection</code>
           </Link>{' '}
           →{' '}
           <Link to="/docs/apis/fetch-products">

--- a/packages/docs/src/pages/docs/setup/flutter.tsx
+++ b/packages/docs/src/pages/docs/setup/flutter.tsx
@@ -289,15 +289,12 @@ class _StoreScreenState extends State<StoreScreen> {
 
   Future<void> _init() async {
     // Initialize connection
-    await iap.initConnection();
+    final connected = await iap.initConnection();
+    if (!connected) throw StateError('Store connection failed');
 
     // Setup listeners
-    purchaseSub = iap.purchaseUpdatedListener.listen((purchase) async {
-      // Verify the purchase (server-side), then finish it
-      await iap.finishTransaction(
-        purchase: purchase,
-        isConsumable: false, // true for consumables
-      );
+    purchaseSub = iap.purchaseUpdatedListener.listen((purchase) {
+      unawaited(_handlePurchase(purchase));
     });
 
     errorSub = iap.purchaseErrorListener.listen((error) {
@@ -306,11 +303,29 @@ class _StoreScreenState extends State<StoreScreen> {
     });
   }
 
+  Future<void> _handlePurchase(Purchase purchase) async {
+    try {
+      // Verify the purchase (server-side), then finish it
+      await iap.finishTransaction(
+        purchase: purchase,
+        isConsumable: false, // true for consumables
+      );
+    } catch (error) {
+      print('Purchase processing failed: $error');
+    }
+  }
+
   @override
   void dispose() {
-    purchaseSub?.cancel();
-    errorSub?.cancel();
-    unawaited(iap.endConnection());
+    unawaited(purchaseSub?.cancel().catchError(
+      (Object error) => print('Listener cleanup failed: $error'),
+    ));
+    unawaited(errorSub?.cancel().catchError(
+      (Object error) => print('Listener cleanup failed: $error'),
+    ));
+    unawaited(iap.endConnection().then<void>((_) {}).catchError(
+      (Object error) => print('Store teardown failed: $error'),
+    ));
     super.dispose();
   }
 

--- a/packages/docs/src/pages/docs/setup/godot.tsx
+++ b/packages/docs/src/pages/docs/setup/godot.tsx
@@ -512,7 +512,9 @@ func _ready():
     iap.purchase_error.connect(_on_purchase_error)
 
     # Initialize
-    await iap.init_connection()
+    if not await iap.init_connection():
+        push_error("Store connection failed")
+        return
 
 func _on_purchase_updated(purchase):
     # Validate receipt with your backend or IAPKit, then:

--- a/packages/docs/src/pages/docs/setup/maui.tsx
+++ b/packages/docs/src/pages/docs/setup/maui.tsx
@@ -271,7 +271,8 @@ var iap = OpenIapClient.Instance;
 var query = (QueryResolver)iap;
 var mutate = (MutationResolver)iap;
 
-await mutate.InitConnectionAsync();
+var connected = await mutate.InitConnectionAsync();
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 var result = await query.FetchProductsAsync(new ProductRequest
 {
@@ -324,17 +325,27 @@ var products = result is FetchProductsResultProducts { Value: { } list }
           values.
         </p>
         <CodeBlock language="csharp">
-          {`IDisposable purchaseSub = iap.PurchaseUpdated.Subscribe(async purchase =>
+          {`async Task HandlePurchaseSafelyAsync(Purchase purchase)
 {
-    bool verified = await VerifyOnServerAsync(purchase);
-    if (!verified) return;
+    try
+    {
+        bool verified = await VerifyOnServerAsync(purchase);
+        if (!verified) return;
 
-    await mutate.FinishTransactionAsync(
-        purchase: new PurchaseInput(purchase),
-        isConsumable: true);
+        await mutate.FinishTransactionAsync(
+            purchase: new PurchaseInput(purchase),
+            isConsumable: true);
 
-    GrantEntitlement(purchase.ProductId);
-});
+        GrantEntitlement(purchase.ProductId);
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Purchase processing failed: {error.Message}");
+    }
+}
+
+IDisposable purchaseSub = iap.PurchaseUpdated.Subscribe(
+    purchase => _ = HandlePurchaseSafelyAsync(purchase));
 
 IDisposable errorSub = iap.PurchaseError.Subscribe(error =>
 {

--- a/packages/docs/src/pages/docs/setup/react-native.tsx
+++ b/packages/docs/src/pages/docs/setup/react-native.tsx
@@ -201,8 +201,10 @@ npm install react-native-iap react-native-nitro-modules`}
           <a href="/docs/apis/end-connection">
             <code>endConnection</code>
           </a>{' '}
-          on teardown. The <code>useIAP</code> hook manages the connection and
-          listener steps for you. See the{' '}
+          only when the app-level owner shuts down or signs out. The{' '}
+          <code>useIAP</code> hook manages listener setup and removes its
+          listeners when the component unmounts, while keeping the native store
+          connection available across screens. See the{' '}
           <a href="/docs/features/purchase">Purchase Guide</a> for the complete
           flow.
         </p>
@@ -215,8 +217,9 @@ npm install react-native-iap react-native-nitro-modules`}
         </h3>
         <p>
           The <code>useIAP</code> hook is the recommended way to use
-          react-native-iap. It manages connection lifecycle, state, and error
-          normalization automatically.
+          react-native-iap. It manages listener lifecycle, connection state, and
+          error normalization automatically. Unmounting the hook removes its
+          listeners without ending the app-level native store connection.
         </p>
         <CodeBlock language="typescript">
           {`import React, { useEffect } from 'react';
@@ -375,7 +378,8 @@ function Store() {
 } from 'react-native-iap';
 
 // Initialize
-await initConnection();
+const connected = await initConnection();
+if (!connected) throw new Error('Store connection failed');
 
 // Listen for events BEFORE requesting purchases
 const purchaseSub = purchaseUpdatedListener((purchase) => {

--- a/packages/docs/src/pages/docs/setup/react-native.tsx
+++ b/packages/docs/src/pages/docs/setup/react-native.tsx
@@ -258,15 +258,17 @@ function Store() {
         <Button
           title={\`\${item.title} - \${item.displayPrice}\`}
           disabled={!connected}
-          onPress={() =>
-            requestPurchase({
+          onPress={() => {
+            void requestPurchase({
               request: {
                 apple: { sku: item.id },
                 google: { skus: [item.id] },
               },
               type: 'in-app',
-            })
-          }
+            }).catch((error) =>
+              console.warn('Purchase request failed:', error),
+            );
+          }}
         />
       )}
     />

--- a/packages/docs/src/pages/docs/setup/react-native.tsx
+++ b/packages/docs/src/pages/docs/setup/react-native.tsx
@@ -225,6 +225,7 @@ import { useIAP, ErrorCode, finishTransaction } from 'react-native-iap';
 
 function Store() {
   const {
+    connected,
     products,
     fetchProducts,
     requestPurchase,
@@ -243,8 +244,11 @@ function Store() {
   });
 
   useEffect(() => {
-    fetchProducts({ skus: ['premium', 'coins_100'] });
-  }, []);
+    if (!connected) return;
+    void fetchProducts({ skus: ['premium', 'coins_100'] }).catch((error) => {
+      console.warn('Product fetch failed:', error);
+    });
+  }, [connected, fetchProducts]);
 
   return (
     <FlatList
@@ -253,6 +257,7 @@ function Store() {
       renderItem={({ item }) => (
         <Button
           title={\`\${item.title} - \${item.displayPrice}\`}
+          disabled={!connected}
           onPress={() =>
             requestPurchase({
               request: {

--- a/packages/docs/src/pages/docs/setup/react-native.tsx
+++ b/packages/docs/src/pages/docs/setup/react-native.tsx
@@ -230,12 +230,17 @@ function Store() {
     fetchProducts,
     requestPurchase,
   } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
+    onPurchaseSuccess: (purchase) => {
       // 1. Validate receipt with your backend or IAPKit
       // 2. Grant entitlement
       // 3. CRITICAL: Finish the transaction
       //    (Android auto-refunds after 3 days if not called!)
-      await finishTransaction({ purchase, isConsumable: false }); // true for consumables
+      void finishTransaction({
+        purchase,
+        isConsumable: false, // true for consumables
+      }).catch((error) => {
+        console.warn('Transaction finalization failed:', error);
+      });
     },
     onPurchaseError: (error) => {
       if (error.code === ErrorCode.UserCancelled) return;
@@ -373,10 +378,13 @@ function Store() {
 await initConnection();
 
 // Listen for events BEFORE requesting purchases
-const purchaseSub = purchaseUpdatedListener(async (purchase) => {
-  // Validate on server, then finish transaction
+const purchaseSub = purchaseUpdatedListener((purchase) => {
+  // Validate on server, then finish transaction.
   // CRITICAL: Android auto-refunds after 3 days if not called!
-  await finishTransaction({ purchase, isConsumable: false }); // true for consumables
+  // Use isConsumable: true for consumables.
+  void finishTransaction({ purchase, isConsumable: false }).catch((error) => {
+    console.warn('Transaction finalization failed:', error);
+  });
 });
 
 const errorSub = purchaseErrorListener((error) => {

--- a/packages/docs/src/pages/docs/setup/store/onside.tsx
+++ b/packages/docs/src/pages/docs/setup/store/onside.tsx
@@ -219,8 +219,10 @@ export default function App() {
 
 function StoreScreen() {
   const { products, fetchProducts, requestPurchase } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      await finishTransaction({ purchase, isConsumable: false });
+    onPurchaseSuccess: (purchase) => {
+      void finishTransaction({ purchase, isConsumable: false }).catch((error) => {
+        reportPurchaseError(error);
+      });
     },
     onPurchaseError: (error) => {
       reportPurchaseError(error);

--- a/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
+++ b/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
@@ -272,13 +272,17 @@ val userChoiceListener = object : OpenIapUserChoiceBillingListener {
 
         // Process payment with your backend using the token
         lifecycleScope.launch {
-            val paymentResult = yourBackend.processPayment(
-                products = details.products,
-                token = details.externalTransactionToken
-            )
+            try {
+                val paymentResult = yourBackend.processPayment(
+                    products = details.products,
+                    token = details.externalTransactionToken
+                )
 
-            if (paymentResult.success) {
-                grantUserAccess()
+                if (paymentResult.success) {
+                    grantUserAccess()
+                }
+            } catch (e: Exception) {
+                Log.e("IAP", "Alternative billing failed: \${e.message}")
             }
         }
     }
@@ -325,18 +329,16 @@ fun disposeUserChoiceListener() {
 }`}</CodeBlock>
             ),
             dart: (
-              <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+              <CodeBlock language="dart">{`import 'dart:async';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
-// Step 1: Set up listener for when user selects alternative billing
-final userChoiceSubscription = FlutterInappPurchase.instance.userChoiceBillingAndroid
-    .listen((details) async {
+Future<void> handleUserChoiceBilling(UserChoiceBillingDetails details) async {
   print('User chose alternative billing');
   for (final productId in details.products) {
     print('Product: \$productId');
   }
   print('External transaction token received; send it to your backend without logging it.');
 
-  // Process payment with your backend using the token
   final paymentResult = await yourBackend.processPayment(
     products: details.products,
     token: details.externalTransactionToken,
@@ -345,6 +347,14 @@ final userChoiceSubscription = FlutterInappPurchase.instance.userChoiceBillingAn
   if (paymentResult.success) {
     grantUserAccess();
   }
+}
+
+// Step 1: Set up listener for when user selects alternative billing
+final userChoiceSubscription = FlutterInappPurchase.instance.userChoiceBillingAndroid
+    .listen((details) {
+  unawaited(handleUserChoiceBilling(details).catchError(
+    (Object error) => print('Alternative billing failed: \$error'),
+  ));
 });
 
 // Step 2: Initialize with user choice billing (recommended)
@@ -380,22 +390,32 @@ Future<void> disposeUserChoiceListener() => userChoiceSubscription.cancel();`}</
               <CodeBlock language="csharp">{`using OpenIap;
 using OpenIap.Maui;
 
-// Step 1: Set up listener for when user selects alternative billing.
-var userChoiceSubscription = OpenIapClient.Instance.UserChoiceBillingAndroid.Subscribe(async details =>
+async Task HandleUserChoiceBillingSafelyAsync(UserChoiceBillingDetails details)
 {
-    Console.WriteLine("User chose alternative billing");
-    Console.WriteLine($"Products: {string.Join(", ", details.Products)}");
-    Console.WriteLine("External transaction token received; send it to your backend without logging it.");
-
-    var paymentResult = await ProcessPaymentWithBackendAsync(
-        products: details.Products,
-        token: details.ExternalTransactionToken);
-
-    if (paymentResult.Success)
+    try
     {
-        await GrantUserAccessAsync();
+        Console.WriteLine("User chose alternative billing");
+        Console.WriteLine($"Products: {string.Join(", ", details.Products)}");
+        Console.WriteLine("External transaction token received; send it to your backend without logging it.");
+
+        var paymentResult = await ProcessPaymentWithBackendAsync(
+            products: details.Products,
+            token: details.ExternalTransactionToken);
+
+        if (paymentResult.Success)
+        {
+            await GrantUserAccessAsync();
+        }
     }
-});
+    catch (Exception error)
+    {
+        Console.WriteLine($"Alternative billing failed: {error.Message}");
+    }
+}
+
+// Step 1: Set up listener for when user selects alternative billing.
+var userChoiceSubscription = OpenIapClient.Instance.UserChoiceBillingAndroid.Subscribe(
+    details => _ = HandleUserChoiceBillingSafelyAsync(details));
 
 // Step 2: Initialize with user choice billing (recommended).
 var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig

--- a/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
+++ b/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
@@ -207,29 +207,32 @@ if not success:
 } from 'expo-iap';
 
 // Step 1: Set up listener for when user selects alternative billing
-const userChoiceSubscription = userChoiceBillingListenerAndroid(async (details) => {
-  console.log('User chose alternative billing');
-  const products = details.products ?? [];
-  for (const productId of products) {
-    console.log('Product:', productId);
-  }
-  console.log('External transaction token received; send it to your backend without logging it.');
+const userChoiceSubscription = userChoiceBillingListenerAndroid((details) => {
+  void (async () => {
+    console.log('User chose alternative billing');
+    const products = details.products ?? [];
+    for (const productId of products) {
+      console.log('Product:', productId);
+    }
+    console.log('External transaction token received; send it to your backend without logging it.');
 
-  // Process payment with your backend using the token
-  const paymentResult = await yourBackend.processPayment({
-    products,
-    token: details.externalTransactionToken,
-  });
+    // Process payment with your backend using the token
+    const paymentResult = await yourBackend.processPayment({
+      products,
+      token: details.externalTransactionToken,
+    });
 
-  if (paymentResult.success) {
-    grantUserAccess();
-  }
+    if (paymentResult.success) {
+      grantUserAccess();
+    }
+  })().catch((error) => console.warn('Alternative payment failed:', error));
 });
 
 // Step 2: Initialize with user choice billing (recommended)
-await initConnection({
+const connected = await initConnection({
   enableBillingProgramAndroid: 'user-choice-billing',
 });
+if (!connected) throw new Error('Store connection failed');
 
 // Step 3: Fetch products and purchase as normal
 const products = await fetchProducts({
@@ -283,11 +286,12 @@ val userChoiceListener = object : OpenIapUserChoiceBillingListener {
 iapStore.addUserChoiceBillingListener(userChoiceListener)
 
 // Step 2: Initialize with user choice billing (recommended)
-iapStore.initConnection(
+val connected = iapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.UserChoiceBilling
     )
 )
+check(connected) { "Store connection failed" }
 
 // Step 3: Fetch products and purchase as normal
 val products = iapStore.fetchProducts(
@@ -344,9 +348,10 @@ final userChoiceSubscription = FlutterInappPurchase.instance.userChoiceBillingAn
 });
 
 // Step 2: Initialize with user choice billing (recommended)
-await FlutterInappPurchase.instance.initConnection(
+final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.UserChoiceBilling,
 );
+if (!connected) throw StateError('Store connection failed');
 
 // Step 3: Fetch products and purchase as normal
 final products = await FlutterInappPurchase.instance
@@ -393,10 +398,11 @@ var userChoiceSubscription = OpenIapClient.Instance.UserChoiceBillingAndroid.Sub
 });
 
 // Step 2: Initialize with user choice billing (recommended).
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig
 {
     EnableBillingProgramAndroid = BillingProgramAndroid.UserChoiceBilling,
 });
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 // Step 3: Fetch products and purchase as normal.
 await ((QueryResolver)OpenIapClient.Instance).FetchProductsAsync(new ProductRequest
@@ -445,7 +451,10 @@ iap.user_choice_billing_android.connect(_on_user_choice_billing)
 # Step 2: Initialize with user choice billing (recommended)
 var config = InitConnectionConfig.new()
 config.enable_billing_program_android = BillingProgramAndroid.USER_CHOICE_BILLING
-await iap.init_connection(config)
+var connected = await iap.init_connection(config)
+if not connected:
+    push_error("Store connection failed")
+    return
 
 # Step 3: Fetch products and purchase as normal
 var request = ProductRequest.new()
@@ -492,9 +501,10 @@ func _exit_tree() -> void:
 } from 'expo-iap';
 
 // Step 1: Initialize with external offer (recommended)
-await initConnection({
+const connected = await initConnection({
   enableBillingProgramAndroid: 'external-offer',
 });
+if (!connected) throw new Error('Store connection failed');
 
 // Step 2: Check if alternative billing is available
 const availability = await isBillingProgramAvailableAndroid('external-offer');
@@ -541,11 +551,12 @@ import dev.hyo.openiap.store.OpenIapStore
 val iapStore = OpenIapStore(context)
 
 // Step 1: Initialize with external offer (recommended)
-iapStore.initConnection(
+val connected = iapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
     )
 )
+check(connected) { "Store connection failed" }
 
 // Step 2: Check whether External Offer is available for this user.
 val availability = iapStore.isBillingProgramAvailable(
@@ -605,9 +616,10 @@ lifecycleScope.launch {
 final iap = FlutterInappPurchase.instance;
 
 // Step 1: Initialize with external offer (recommended)
-await iap.initConnection(
+final connected = await iap.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalOffer,
 );
+if (!connected) throw StateError('Store connection failed');
 
 // Step 2: Check whether External Offer is available for this user.
 final availability = await iap.isBillingProgramAvailableAndroid(
@@ -656,10 +668,11 @@ using OpenIap.Maui;
 using System.Linq;
 
 // Step 1: Initialize with external offer (recommended).
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig
 {
     EnableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer,
 });
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 var mutate = (MutationResolver)OpenIapClient.Instance;
 
@@ -715,7 +728,10 @@ if (paymentResult.Success)
               <CodeBlock language="gdscript">{`# Step 1: Initialize with external offer (recommended)
 var config = InitConnectionConfig.new()
 config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-await iap.init_connection(config)
+var connected = await iap.init_connection(config)
+if not connected:
+    push_error("Store connection failed")
+    return
 
 # Step 2: Check whether External Offer is available for this user.
 var availability = await iap.is_billing_program_available_android(

--- a/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
+++ b/packages/docs/src/pages/docs/types/alternative-billing-types.tsx
@@ -116,97 +116,45 @@ function AlternativeBillingTypes() {
             typescript: (
               <CodeBlock language="typescript">{`// Choose one configuration. End the current connection before changing programs.
 
-// Initialize with user choice billing (7.0+)
-await initConnection({
-  enableBillingProgramAndroid: 'user-choice-billing'
-});
+const config = {
+  // Also supported: 'user-choice-billing', 'external-payments', or 'billing-choice'.
+  enableBillingProgramAndroid: 'external-offer',
+  // For developer-rendered Billing Choice, also set:
+  // billingChoiceScreenTypeAndroid: 'developer-rendered',
+} as const;
 
-// Initialize with external offer (alternative only)
-await initConnection({
-  enableBillingProgramAndroid: 'external-offer'
-});
-
-// Initialize with external payments (Japan only, 8.3.0+)
-await initConnection({
-  enableBillingProgramAndroid: 'external-payments'
-});
-
-// Developer-rendered Billing Choice (must match Play Console, 9.1.0+)
-await initConnection({
-  enableBillingProgramAndroid: 'billing-choice',
-  billingChoiceScreenTypeAndroid: 'developer-rendered'
-});
-
-// Standard billing (default)
-await initConnection();`}</CodeBlock>
+// Pass no config instead for standard billing.
+const connected = await initConnection(config);
+if (!connected) throw new Error('Store connection failed');`}</CodeBlock>
             ),
             swift: (
               <CodeBlock language="swift">{`// iOS uses standard StoreKit billing
 // Alternative billing is Android-only
-let isConnected = try await OpenIapModule.shared.initConnection()`}</CodeBlock>
+let connected = try await OpenIapModule.shared.initConnection()
+precondition(connected, "Store connection failed")`}</CodeBlock>
             ),
             kotlin: (
               <CodeBlock language="kotlin">{`// Choose one configuration. End the current connection before changing programs.
 
-// Initialize with user choice billing (7.0+)
-openIapStore.initConnection(
-    InitConnectionConfig(
-        enableBillingProgramAndroid = BillingProgramAndroid.UserChoiceBilling
-    )
+val config = InitConnectionConfig(
+    // Also supported: UserChoiceBilling, ExternalPayments, or BillingChoice.
+    enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
+    // For developer-rendered Billing Choice, also set billingChoiceScreenTypeAndroid.
 )
 
-// Initialize with external offer (alternative only)
-openIapStore.initConnection(
-    InitConnectionConfig(
-        enableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer
-    )
-)
-
-// Initialize with external payments (Japan only, 8.3.0+)
-openIapStore.initConnection(
-    InitConnectionConfig(
-        enableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments
-    )
-)
-
-// Developer-rendered Billing Choice (must match Play Console, 9.1.0+)
-openIapStore.initConnection(
-    InitConnectionConfig(
-        enableBillingProgramAndroid = BillingProgramAndroid.BillingChoice,
-        billingChoiceScreenTypeAndroid = BillingChoiceScreenTypeAndroid.DeveloperRendered
-    )
-)
-
-// Standard billing (default)
-openIapStore.initConnection()`}</CodeBlock>
+// Pass no config instead for standard billing.
+val connected = openIapStore.initConnection(config)
+check(connected) { "Store connection failed" }`}</CodeBlock>
             ),
             dart: (
               <CodeBlock language="dart">{`// Choose one configuration. End the current connection before changing programs.
 
-// Initialize with user choice billing (7.0+)
-await FlutterInappPurchase.instance.initConnection(
-  enableBillingProgramAndroid: BillingProgramAndroid.UserChoiceBilling,
-);
-
-// Initialize with external offer (alternative only)
-await FlutterInappPurchase.instance.initConnection(
+// Also supported: UserChoiceBilling, ExternalPayments, or BillingChoice.
+final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalOffer,
 );
-
-// Initialize with external payments (Japan only, 8.3.0+)
-await FlutterInappPurchase.instance.initConnection(
-  enableBillingProgramAndroid: BillingProgramAndroid.ExternalPayments,
-);
-
-// Developer-rendered Billing Choice (must match Play Console, 9.1.0+)
-await FlutterInappPurchase.instance.initConnection(
-  enableBillingProgramAndroid: BillingProgramAndroid.BillingChoice,
-  billingChoiceScreenTypeAndroid:
-      BillingChoiceScreenTypeAndroid.DeveloperRendered,
-);
-
-// Standard billing (default)
-await FlutterInappPurchase.instance.initConnection();`}</CodeBlock>
+// Omit the named arguments instead for standard billing.
+if (!connected) throw StateError('Store connection failed');`}</CodeBlock>
             ),
             csharp: (
               <CodeBlock language="csharp">{`using OpenIap;
@@ -214,61 +162,29 @@ using OpenIap.Maui;
 
 // Choose one configuration. End the current connection before changing programs.
 
-// Initialize with user choice billing (7.0+)
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
-    new InitConnectionConfig
-    {
-        EnableBillingProgramAndroid = BillingProgramAndroid.UserChoiceBilling,
-    });
+var config = new InitConnectionConfig
+{
+    // Also supported: UserChoiceBilling, ExternalPayments, or BillingChoice.
+    EnableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer,
+    // For developer-rendered Billing Choice, also set BillingChoiceScreenTypeAndroid.
+};
 
-// Initialize with external offer (alternative only)
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
-    new InitConnectionConfig
-    {
-        EnableBillingProgramAndroid = BillingProgramAndroid.ExternalOffer,
-    });
-
-// Initialize with external payments (Japan only, 8.3.0+)
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
-    new InitConnectionConfig
-    {
-        EnableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments,
-    });
-
-// Developer-rendered Billing Choice (must match Play Console, 9.1.0+)
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(
-    new InitConnectionConfig
-    {
-        EnableBillingProgramAndroid = BillingProgramAndroid.BillingChoice,
-        BillingChoiceScreenTypeAndroid = BillingChoiceScreenTypeAndroid.DeveloperRendered,
-    });
-
-// Standard billing (default)
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync();`}</CodeBlock>
+// Pass no config instead for standard billing.
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(config);
+if (!connected) throw new InvalidOperationException("Store connection failed");`}</CodeBlock>
             ),
             gdscript: (
               <CodeBlock language="gdscript">{`# Choose one configuration. End the current connection before changing programs.
 
-# Initialize with user choice billing (7.0+)
 var config = InitConnectionConfig.new()
-config.enable_billing_program_android = BillingProgramAndroid.USER_CHOICE_BILLING
-await iap.init_connection(config)
-
-# Initialize with external offer (alternative only)
+# Also supported: USER_CHOICE_BILLING, EXTERNAL_PAYMENTS, or BILLING_CHOICE.
 config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_OFFER
-await iap.init_connection(config)
+# For developer-rendered Billing Choice, also set billing_choice_screen_type_android.
 
-# Initialize with external payments (Japan only, 8.3.0+)
-config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_PAYMENTS
-await iap.init_connection(config)
-
-# Developer-rendered Billing Choice (must match Play Console, 9.1.0+)
-config.enable_billing_program_android = BillingProgramAndroid.BILLING_CHOICE
-config.billing_choice_screen_type_android = BillingChoiceScreenTypeAndroid.DEVELOPER_RENDERED
-await iap.init_connection(config)
-
-# Standard billing (default)
-await iap.init_connection()`}</CodeBlock>
+# Pass no config instead for standard billing.
+var success = await iap.init_connection(config)
+if not success:
+    push_error("Store connection failed")`}</CodeBlock>
             ),
           }}
         </LanguageTabs>

--- a/packages/docs/src/pages/docs/types/billing-programs.tsx
+++ b/packages/docs/src/pages/docs/types/billing-programs.tsx
@@ -1063,9 +1063,10 @@ function BillingPrograms() {
 } from 'expo-iap';
 
 // Enable External Payments via InitConnectionConfig
-await initConnection({
+const connected = await initConnection({
   enableBillingProgramAndroid: 'external-payments',
 });
+if (!connected) throw new Error('Store connection failed');
 
 // Listen for developer billing selection
 developerProvidedBillingListenerAndroid((details) => {
@@ -1099,11 +1100,11 @@ import dev.hyo.openiap.*
 val iapStore = OpenIapStore(context)
 
 // Enable External Payments via InitConnectionConfig
-iapStore.initConnection(
+check(iapStore.initConnection(
     InitConnectionConfig(
         enableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments
     )
-)
+)) { "Store connection failed" }
 
 // Listen for developer billing selection
 iapStore.addDeveloperProvidedBillingListener { details ->
@@ -1139,9 +1140,10 @@ if (result.isAvailable) {
               <CodeBlock language="dart">{`import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 
 // Enable External Payments via InitConnectionConfig
-await FlutterInappPurchase.instance.initConnection(
+final connected = await FlutterInappPurchase.instance.initConnection(
   enableBillingProgramAndroid: BillingProgramAndroid.ExternalPayments,
 );
+if (!connected) throw StateError('Store connection failed');
 
 // Listen for developer billing selection
 final developerBillingSubscription = FlutterInappPurchase.instance
@@ -1179,10 +1181,11 @@ using OpenIap.Maui;
 using System;
 
 // Enable External Payments via InitConnectionConfig.
-await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig
+var connected = await ((MutationResolver)OpenIapClient.Instance).InitConnectionAsync(new InitConnectionConfig
 {
     EnableBillingProgramAndroid = BillingProgramAndroid.ExternalPayments,
 });
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 // Listen for developer billing selection.
 using var subscription = OpenIapClient.Instance.DeveloperProvidedBillingAndroid.Subscribe(details =>
@@ -1221,7 +1224,10 @@ if (result.IsAvailable)
               <CodeBlock language="gdscript">{`# Enable External Payments via InitConnectionConfig
 var config = InitConnectionConfig.new()
 config.enable_billing_program_android = BillingProgramAndroid.EXTERNAL_PAYMENTS
-await iap.init_connection(config)
+var connected = await iap.init_connection(config)
+if not connected:
+    push_error("Store connection failed")
+    return
 
 # Listen for developer billing selection
 func _on_developer_provided_billing(details: DeveloperProvidedBillingDetailsAndroid):

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -506,8 +506,10 @@ import { useIAP } from 'expo-iap'; // or 'react-native-iap'
 
 function PremiumButton() {
   const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP({
-    onPurchaseSuccess: async (purchase) => {
-      await finishTransaction({ purchase, isConsumable: true });
+    onPurchaseSuccess: (purchase) => {
+      void finishTransaction({ purchase, isConsumable: true }).catch((error) => {
+        console.warn('Transaction finalization failed:', error);
+      });
     },
   });
 

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -708,13 +708,13 @@ ${deprecationMigrationReference}
 
 ### Connection
 \`\`\`typescript
-// Initialize (required before any operation)
-await initConnection();
+// Choose one call: remove the config for a standard connection.
+const connected = await initConnection({
+  enableBillingProgramAndroid: 'user-choice-billing',
+});
+if (!connected) throw new Error('Store connection failed');
 
-// With a billing program (Android)
-await initConnection({ enableBillingProgramAndroid: 'user-choice-billing' });
-
-// Cleanup on unmount
+// Cleanup at the connection owner's teardown boundary.
 await endConnection();
 \`\`\`
 

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -540,20 +540,26 @@ function PremiumButton() {
 ### Flutter
 \`\`\`dart
 final iap = FlutterInappPurchase.instance;
-await iap.initConnection();
+final connected = await iap.initConnection();
+if (!connected) throw StateError('Store connection failed');
 final products = await iap.fetchProducts<Product>(
   skus: ['premium'],
   type: ProductQueryType.InApp,
 );
-iap.purchaseUpdatedListener.listen((purchase) async {
-  await iap.finishTransaction(purchase: purchase, isConsumable: true);
+iap.purchaseUpdatedListener.listen((purchase) {
+  iap
+      .finishTransaction(purchase: purchase, isConsumable: true)
+      .catchError((Object error) => print('Transaction finalization failed: $error'));
 });
 \`\`\`
 
 ### Godot
 \`\`\`gdscript
 GodotIapPlugin.purchase_updated.connect(_on_purchase_updated)
-GodotIapPlugin.init_connection()
+var connected = await GodotIapPlugin.init_connection()
+if not connected:
+    push_error("Store connection failed")
+    return
 await GodotIapPlugin.fetch_products(request)
 GodotIapPlugin.request_purchase(props)
 \`\`\`
@@ -561,7 +567,8 @@ GodotIapPlugin.request_purchase(props)
 ### Kotlin Multiplatform
 \`\`\`kotlin
 val iap = KmpIAP()
-iap.initConnection()
+val connected = iap.initConnection()
+check(connected) { "Store connection failed" }
 val products = iap.fetchProducts {
     skus = listOf("premium")
     type = ProductQueryType.InApp
@@ -577,7 +584,8 @@ using OpenIap;
 using OpenIap.Maui;
 
 var iap = OpenIapClient.Instance;
-await ((MutationResolver)iap).InitConnectionAsync();
+var connected = await ((MutationResolver)iap).InitConnectionAsync();
+if (!connected) throw new InvalidOperationException("Store connection failed");
 
 await ((QueryResolver)iap).FetchProductsAsync(new ProductRequest
 {
@@ -585,13 +593,23 @@ await ((QueryResolver)iap).FetchProductsAsync(new ProductRequest
     Type = ProductQueryType.InApp,
 });
 
-((IOpenIap)iap).PurchaseUpdated.Subscribe(async purchase =>
+async Task FinishPurchaseSafelyAsync(Purchase purchase)
 {
-    await ((MutationResolver)iap).FinishTransactionAsync(
-        new PurchaseInput(purchase),
-        isConsumable: true
-    );
-});
+    try
+    {
+        await ((MutationResolver)iap).FinishTransactionAsync(
+            new PurchaseInput(purchase),
+            isConsumable: true
+        );
+    }
+    catch (Exception error)
+    {
+        Console.WriteLine($"Transaction finalization failed: {error.Message}");
+    }
+}
+
+((IOpenIap)iap).PurchaseUpdated.Subscribe(
+    purchase => _ = FinishPurchaseSafelyAsync(purchase));
 \`\`\`
 
 ---

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -522,12 +522,12 @@ function PremiumButton() {
     <Button
       title="Buy premium"
       disabled={!connected}
-      onPress={() =>
-        requestPurchase({
+      onPress={() => {
+        void requestPurchase({
           request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
           type: 'in-app',
-        })
-      }
+        });
+      }}
     />
   );
 }

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -513,7 +513,9 @@ function PremiumButton() {
 
   useEffect(() => {
     if (!connected) return;
-    void fetchProducts({ skus: ['premium'], type: 'in-app' });
+    void fetchProducts({ skus: ['premium'], type: 'in-app' }).catch((error) =>
+      console.warn('Product fetch failed:', error),
+    );
   }, [connected, fetchProducts]);
 
   return (

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -780,11 +780,11 @@ import {
 } from 'expo-iap';
 
 // Set up before any purchase request
-const purchaseUpdateSubscription = purchaseUpdatedListener(async (purchase) => {
-  // 1. Verify purchase on server
-  // 2. Grant entitlement
-  // 3. Finish transaction
-  await finishTransaction({ purchase, isConsumable: false });
+const purchaseUpdateSubscription = purchaseUpdatedListener((purchase) => {
+  // After server verification and entitlement grant, finish the transaction.
+  void finishTransaction({ purchase, isConsumable: false }).catch((error) => {
+    console.warn('Transaction finalization failed:', error);
+  });
 });
 
 const purchaseErrorSubscription = purchaseErrorListener((error) => {

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -500,22 +500,34 @@ is selected at the runtime integration layer.
 
 ### React Native / Expo
 \`\`\`typescript
+import { useEffect } from 'react';
+import { Button } from 'react-native';
 import { useIAP } from 'expo-iap'; // or 'react-native-iap'
 
-const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP({
-  onPurchaseSuccess: async (purchase) => {
-    await finishTransaction({ purchase, isConsumable: true });
-  },
-});
-
-// useIAP opens the connection for you; wait for it before calling the store.
-// Android rejects store calls with \`not-prepared\` until it is open.
-if (connected) {
-  await fetchProducts({ skus: ['premium'], type: 'in-app' });
-  await requestPurchase({
-    request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
-    type: 'in-app',
+function PremiumButton() {
+  const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP({
+    onPurchaseSuccess: async (purchase) => {
+      await finishTransaction({ purchase, isConsumable: true });
+    },
   });
+
+  useEffect(() => {
+    if (!connected) return;
+    void fetchProducts({ skus: ['premium'], type: 'in-app' });
+  }, [connected, fetchProducts]);
+
+  return (
+    <Button
+      title="Buy premium"
+      disabled={!connected}
+      onPress={() =>
+        requestPurchase({
+          request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
+          type: 'in-app',
+        })
+      }
+    />
+  );
 }
 \`\`\`
 

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -540,17 +540,17 @@ function PremiumButton() {
 ### Flutter
 \`\`\`dart
 final iap = FlutterInappPurchase.instance;
+iap.purchaseUpdatedListener.listen((purchase) {
+  iap
+      .finishTransaction(purchase: purchase, isConsumable: true)
+      .catchError((Object error) => print('Transaction finalization failed: $error'));
+});
 final connected = await iap.initConnection();
 if (!connected) throw StateError('Store connection failed');
 final products = await iap.fetchProducts<Product>(
   skus: ['premium'],
   type: ProductQueryType.InApp,
 );
-iap.purchaseUpdatedListener.listen((purchase) {
-  iap
-      .finishTransaction(purchase: purchase, isConsumable: true)
-      .catchError((Object error) => print('Transaction finalization failed: $error'));
-});
 \`\`\`
 
 ### Godot
@@ -567,15 +567,20 @@ GodotIapPlugin.request_purchase(props)
 ### Kotlin Multiplatform
 \`\`\`kotlin
 val iap = KmpIAP()
+val purchaseJob = appScope.launch(
+    start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+) {
+    iap.purchaseUpdatedListener.collect { purchase ->
+        iap.finishTransaction(purchase = purchase, isConsumable = true)
+    }
+}
 val connected = iap.initConnection()
 check(connected) { "Store connection failed" }
 val products = iap.fetchProducts {
     skus = listOf("premium")
     type = ProductQueryType.InApp
 }
-iap.purchaseUpdatedListener.collect { purchase ->
-    iap.finishTransaction(purchase = purchase, isConsumable = true)
-}
+// purchaseJob.cancel() at the connection owner's teardown boundary.
 \`\`\`
 
 ### .NET MAUI
@@ -733,7 +738,8 @@ const connected = await initConnection({
 if (!connected) throw new Error('Store connection failed');
 
 // Cleanup at the connection owner's teardown boundary.
-await endConnection();
+const ended = await endConnection();
+if (!ended) console.warn('Store teardown did not complete');
 \`\`\`
 
 ### Fetch Products
@@ -898,9 +904,9 @@ interface PurchaseError {
 
 ## Purchase Flow Summary
 
-1. initConnection()
-2. fetchProducts({ skus: [...], type: 'in-app' })
-3. Set up purchaseUpdatedListener
+1. Set up purchaseUpdatedListener and purchaseErrorListener
+2. initConnection()
+3. fetchProducts({ skus: [...], type: 'in-app' })
 4. requestPurchase({ request: { apple: { sku }, google: { skus: [sku] } }, type: 'in-app' })
 5. In listener: verify -> grant -> finishTransaction()
 6. endConnection() on cleanup

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -526,6 +526,8 @@ function PremiumButton() {
         void requestPurchase({
           request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
           type: 'in-app',
+        }).catch((error) => {
+          console.warn('Purchase dispatch failed:', error);
         });
       }}
     />

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -508,11 +508,15 @@ const { connected, fetchProducts, requestPurchase, finishTransaction } = useIAP(
   },
 });
 
-await fetchProducts({ skus: ['premium'], type: 'in-app' });
-await requestPurchase({
-  request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
-  type: 'in-app',
-});
+// useIAP opens the connection for you; wait for it before calling the store.
+// Android rejects store calls with \`not-prepared\` until it is open.
+if (connected) {
+  await fetchProducts({ skus: ['premium'], type: 'in-app' });
+  await requestPurchase({
+    request: { apple: { sku: 'premium' }, google: { skus: ['premium'] } },
+    type: 'in-app',
+  });
+}
 \`\`\`
 
 ### Flutter

--- a/scripts/agent/tests/llms-content.test.ts
+++ b/scripts/agent/tests/llms-content.test.ts
@@ -95,13 +95,13 @@ describe("generated LLM references", () => {
       /useEffect\(\(\) => \{([\s\S]*?)\n  \}, \[connected, fetchProducts\]\);/,
     )?.[1];
     const onPressBody = reactNativeExpo?.match(
-      /onPress=\{\(\) =>\n([\s\S]*?)\n      \}/,
+      /onPress=\{\(\) => \{\n([\s\S]*?)\n      \}\}/,
     )?.[1];
 
     expect(effectBody).toContain("void fetchProducts");
     expect(reactNativeExpo?.match(/\bfetchProducts\s*\(/g)).toHaveLength(1);
     expect(reactNativeExpo).toContain("disabled={!connected}");
-    expect(onPressBody).toContain("requestPurchase({");
+    expect(onPressBody).toContain("void requestPurchase({");
   });
 
   test("documents every Android production source set", () => {

--- a/scripts/agent/tests/llms-content.test.ts
+++ b/scripts/agent/tests/llms-content.test.ts
@@ -102,6 +102,8 @@ describe("generated LLM references", () => {
     expect(reactNativeExpo?.match(/\bfetchProducts\s*\(/g)).toHaveLength(1);
     expect(reactNativeExpo).toContain("disabled={!connected}");
     expect(onPressBody).toContain("void requestPurchase({");
+    expect(onPressBody).toContain("}).catch((error) => {");
+    expect(onPressBody).toContain("Purchase dispatch failed:");
   });
 
   test("documents every Android production source set", () => {

--- a/scripts/agent/tests/llms-content.test.ts
+++ b/scripts/agent/tests/llms-content.test.ts
@@ -56,9 +56,7 @@ describe("generated LLM references", () => {
     expect(quickReference).not.toContain(
       "openRedeemOfferCodeAndroid() - Open Play offer-code redemption page",
     );
-    expect(fullReference).toContain(
-      "cross-platform `openRedeemOfferCode`",
-    );
+    expect(fullReference).toContain("cross-platform `openRedeemOfferCode`");
   });
 
   test("uses canonical platform keys and excludes legacy API references", () => {
@@ -86,6 +84,19 @@ describe("generated LLM references", () => {
       "await GodotIapPlugin.fetch_products(request)",
     );
     expect(fullReference).toContain("val products = iap.fetchProducts {");
+  });
+
+  test("keeps hook store calls in lifecycle and user-event boundaries", () => {
+    const reactNativeExpo = fullReference
+      .split("### React Native / Expo")[2]
+      ?.split("### Flutter")[0];
+
+    expect(reactNativeExpo).toContain("useEffect(() => {");
+    expect(reactNativeExpo).toContain("disabled={!connected}");
+    expect(reactNativeExpo).toContain("onPress={() =>");
+    expect(reactNativeExpo).not.toContain(
+      "if (connected) {\n  await fetchProducts",
+    );
   });
 
   test("documents every Android production source set", () => {

--- a/scripts/agent/tests/llms-content.test.ts
+++ b/scripts/agent/tests/llms-content.test.ts
@@ -91,9 +91,16 @@ describe("generated LLM references", () => {
       .split("### React Native / Expo")[2]
       ?.split("### Flutter")[0];
 
-    expect(reactNativeExpo).toContain("useEffect(() => {");
+    const effectBody = reactNativeExpo?.match(
+      /useEffect\(\(\) => \{([\s\S]*?)\n  \}, \[connected, fetchProducts\]\);/,
+    )?.[1];
+    const onPressBody = reactNativeExpo?.match(
+      /onPress=\{\(\) =>\n([\s\S]*?)\n      \}/,
+    )?.[1];
+
+    expect(effectBody).toContain("void fetchProducts");
     expect(reactNativeExpo).toContain("disabled={!connected}");
-    expect(reactNativeExpo).toContain("onPress={() =>");
+    expect(onPressBody).toContain("requestPurchase({");
     expect(reactNativeExpo).not.toContain(
       "if (connected) {\n  await fetchProducts",
     );

--- a/scripts/agent/tests/llms-content.test.ts
+++ b/scripts/agent/tests/llms-content.test.ts
@@ -78,7 +78,7 @@ describe("generated LLM references", () => {
     expect(fullReference).toContain("type: ProductQueryType.InApp");
     expect(fullReference).toContain("iap.purchaseUpdatedListener.listen");
     expect(fullReference).toContain(
-      "iap.finishTransaction(purchase: purchase, isConsumable: true)",
+      ".finishTransaction(purchase: purchase, isConsumable: true)",
     );
     expect(fullReference).toContain(
       "await GodotIapPlugin.fetch_products(request)",

--- a/scripts/agent/tests/llms-content.test.ts
+++ b/scripts/agent/tests/llms-content.test.ts
@@ -99,11 +99,9 @@ describe("generated LLM references", () => {
     )?.[1];
 
     expect(effectBody).toContain("void fetchProducts");
+    expect(reactNativeExpo?.match(/\bfetchProducts\s*\(/g)).toHaveLength(1);
     expect(reactNativeExpo).toContain("disabled={!connected}");
     expect(onPressBody).toContain("requestPurchase({");
-    expect(reactNativeExpo).not.toContain(
-      "if (connected) {\n  await fetchProducts",
-    );
   });
 
   test("documents every Android production source set", () => {

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -286,6 +286,44 @@ describe("active docs code-example audit", () => {
     expect(auditActiveCodeExampleSource("/tmp/active.tsx", source)).toEqual([]);
   });
 
+  test("flags unchecked connections and unobserved async listeners", () => {
+    const source = [
+      '<CodeBlock language="typescript">{`await initConnection(); purchaseUpdatedListener(async (purchase) => finish(purchase)); useIAP({ onPurchaseSuccess: async (purchase) => finish(purchase) });`}</CodeBlock>',
+      '<CodeBlock language="dart">{`await iap.initConnection(); iap.purchaseUpdatedListener.listen((purchase) async { await finish(purchase); });`}</CodeBlock>',
+      '<CodeBlock language="kotlin">{`store.initConnection(null)`}</CodeBlock>',
+      '<CodeBlock language="csharp">{`await mutation.InitConnectionAsync(); stream.Subscribe(async purchase => await FinishAsync(purchase));`}</CodeBlock>',
+      '<CodeBlock language="gdscript">{`await iap.init_connection()`}</CodeBlock>',
+    ].join("\n");
+
+    expect(
+      auditActiveCodeExampleSource("/tmp/active.tsx", source).map(
+        (drift) => drift.message,
+      ),
+    ).toEqual([
+      expect.stringContaining("TypeScript examples must check"),
+      expect.stringContaining("TypeScript event listeners"),
+      expect.stringContaining("TypeScript hook callbacks"),
+      expect.stringContaining("Flutter examples must check"),
+      expect.stringContaining("Flutter stream listeners"),
+      expect.stringContaining("Kotlin and KMP examples must check"),
+      expect.stringContaining("MAUI examples must check"),
+      expect.stringContaining("MAUI observable listeners"),
+      expect.stringContaining("Godot examples must check"),
+    ]);
+  });
+
+  test("accepts checked connections and failure-handling listeners", () => {
+    const source = [
+      '<CodeBlock language="typescript">{`const connected = await initConnection(); purchaseUpdatedListener((purchase) => { void finish(purchase).catch(onError); }); useIAP({ onPurchaseSuccess: (purchase) => { void finish(purchase).catch(onError); } });`}</CodeBlock>',
+      '<CodeBlock language="dart">{`final connected = await iap.initConnection(); iap.purchaseUpdatedListener.listen((purchase) { unawaited(finish(purchase).catchError(onError)); });`}</CodeBlock>',
+      '<CodeBlock language="kotlin">{`check(store.initConnection(null))`}</CodeBlock>',
+      '<CodeBlock language="csharp">{`var connected = await mutation.InitConnectionAsync(); stream.Subscribe(purchase => _ = FinishSafelyAsync(purchase));`}</CodeBlock>',
+      '<CodeBlock language="gdscript">{`if not await iap.init_connection(): return`}</CodeBlock>',
+    ].join("\n");
+
+    expect(auditActiveCodeExampleSource("/tmp/active.tsx", source)).toEqual([]);
+  });
+
   test("audits formatted multiline CodeBlock children", () => {
     const source = `<CodeBlock language="dart">
       {\`iap.purchaseUpdatedStream.listen(onPurchase);\`}

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -8,11 +8,17 @@ import {
 } from "./audit-docs";
 
 describe("subscription failure docs", () => {
-  const valid = `
+  const validClaims = `
     React Native, Expo, and native promise APIs reject on failure.
     React Native and Expo hooks call <code>onError</code> before rethrowing.
     Godot's compatibility boolean helper still maps failure to{' '}<code>false</code>.
   `;
+  const renderPage = (body: string) => `
+    export default function Page() {
+      return <main>${body}</main>;
+    }
+  `;
+  const valid = renderPage(validClaims);
 
   test("rejects obsolete React Native false-fallback guidance", () => {
     const source = `${valid}
@@ -49,6 +55,29 @@ describe("subscription failure docs", () => {
           valid.replace(claim, ""),
         ),
       ).toEqual([expect.objectContaining({ rule: "R15" })]);
+    });
+  }
+
+  test("rejects the wrong false-fallback owner", () => {
+    expect(
+      auditSubscriptionFailureDocs(
+        "has-active.tsx",
+        valid.replace("Godot's compatibility", "React Native compatibility"),
+      ),
+    ).toEqual([expect.objectContaining({ rule: "R15" })]);
+  });
+
+  for (const [name, source] of [
+    ["JSX comments", renderPage(`{/* ${validClaims} */}`)],
+    [
+      "code blocks",
+      renderPage(`<CodeBlock language="text">{\`${validClaims}\`}</CodeBlock>`),
+    ],
+  ] as const) {
+    test(`${name} do not satisfy rendered guidance`, () => {
+      expect(
+        auditSubscriptionFailureDocs("has-active.tsx", source),
+      ).toHaveLength(3);
     });
   }
 });

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -21,13 +21,20 @@ describe("subscription failure docs", () => {
   const valid = renderPage(validClaims);
 
   test("rejects obsolete React Native false-fallback guidance", () => {
-    const source = `${valid}
+    const source = renderPage(`${validClaims}
       React Native's root helper
-      and hook map failures to{' '}<code>false</code>`;
+      and hook map failures to{' '}<code>false</code>`);
 
     expect(auditSubscriptionFailureDocs("has-active.tsx", source)).toEqual([
       expect.objectContaining({ rule: "R15" }),
     ]);
+  });
+
+  test("ignores obsolete guidance in JSX comments", () => {
+    const source = renderPage(`${validClaims}
+      {/* React Native's root helper and hook map failures to <code>false</code> */}`);
+
+    expect(auditSubscriptionFailureDocs("has-active.tsx", source)).toEqual([]);
   });
 
   test("accepts rejection guidance", () => {

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -2,9 +2,28 @@ import { describe, expect, test } from "bun:test";
 import {
   auditActiveCodeExampleSource,
   auditCanonicalOfferDocs,
+  auditSubscriptionFailureDocs,
   auditVerifyPurchaseDocs,
   type CanonicalOfferDocsSources,
 } from "./audit-docs";
+
+describe("subscription failure docs", () => {
+  test("rejects obsolete React Native false-fallback guidance", () => {
+    const source = `React Native's root helper
+      and hook map failures to{' '}<code>false</code>`;
+
+    expect(auditSubscriptionFailureDocs("has-active.tsx", source)).toEqual([
+      expect.objectContaining({ rule: "R15" }),
+    ]);
+  });
+
+  test("accepts rejection guidance", () => {
+    const source =
+      "React Native and Expo hooks call <code>onError</code> before rethrowing.";
+
+    expect(auditSubscriptionFailureDocs("has-active.tsx", source)).toEqual([]);
+  });
+});
 
 describe("verify purchase type docs", () => {
   const valid = `

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -8,8 +8,15 @@ import {
 } from "./audit-docs";
 
 describe("subscription failure docs", () => {
+  const valid = `
+    React Native, Expo, and native promise APIs reject on failure.
+    React Native and Expo hooks call <code>onError</code> before rethrowing.
+    Godot's compatibility boolean helper still maps failure to{' '}<code>false</code>.
+  `;
+
   test("rejects obsolete React Native false-fallback guidance", () => {
-    const source = `React Native's root helper
+    const source = `${valid}
+      React Native's root helper
       and hook map failures to{' '}<code>false</code>`;
 
     expect(auditSubscriptionFailureDocs("has-active.tsx", source)).toEqual([
@@ -18,11 +25,32 @@ describe("subscription failure docs", () => {
   });
 
   test("accepts rejection guidance", () => {
-    const source =
-      "React Native and Expo hooks call <code>onError</code> before rethrowing.";
-
-    expect(auditSubscriptionFailureDocs("has-active.tsx", source)).toEqual([]);
+    expect(auditSubscriptionFailureDocs("has-active.tsx", valid)).toEqual([]);
   });
+
+  for (const [name, claim] of [
+    [
+      "promise rejection guidance",
+      "React Native, Expo, and native promise APIs reject on failure.",
+    ],
+    [
+      "hook rejection guidance",
+      "React Native and Expo hooks call <code>onError</code> before rethrowing.",
+    ],
+    [
+      "Godot false-fallback guidance",
+      "Godot's compatibility boolean helper still maps failure to{' '}<code>false</code>.",
+    ],
+  ] as const) {
+    test(`requires ${name}`, () => {
+      expect(
+        auditSubscriptionFailureDocs(
+          "has-active.tsx",
+          valid.replace(claim, ""),
+        ),
+      ).toEqual([expect.objectContaining({ rule: "R15" })]);
+    });
+  }
 });
 
 describe("verify purchase type docs", () => {

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -307,6 +307,62 @@ const CODE_EXAMPLE_RULES: CodeExampleRule[] = [
       "Flutter `finishTransaction` requires the named `purchase:` argument.",
   },
   {
+    language: "typescript",
+    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_$][\w$]*\.)*initConnection\s*\(/m,
+    message:
+      "TypeScript examples must check the boolean returned by `initConnection` before store calls.",
+  },
+  {
+    language: "dart",
+    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_$][\w$]*\.)*initConnection\s*\(/m,
+    message:
+      "Flutter examples must check the boolean returned by `initConnection` before store calls.",
+  },
+  {
+    language: "kotlin",
+    pattern: /(?:^|\n)\s*(?:[A-Za-z_]\w*\.)+initConnection\s*\(/m,
+    message:
+      "Kotlin and KMP examples must check the boolean returned by `initConnection` before store calls.",
+  },
+  {
+    language: "csharp",
+    pattern: /(?:^|\n)\s*await\s+[^;\n]*\.InitConnectionAsync\s*\(/m,
+    message:
+      "MAUI examples must check the boolean returned by `InitConnectionAsync` before store calls.",
+  },
+  {
+    language: "gdscript",
+    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_]\w*\.)*init_connection\s*\(/m,
+    message:
+      "Godot examples must check the boolean returned by `init_connection` before store calls.",
+  },
+  {
+    language: "typescript",
+    pattern:
+      /\b(?:purchaseUpdatedListener|purchaseErrorListener|userChoiceBillingListenerAndroid|developerProvidedBillingListenerAndroid|subscriptionBillingIssueListener)\s*\(\s*async\b/,
+    message:
+      "TypeScript event listeners must handle asynchronous work explicitly because listener return promises are not observed.",
+  },
+  {
+    language: "typescript",
+    pattern:
+      /\b(?:onPurchaseSuccess|onPurchaseError|onError|onPromotedProductIOS|onUserChoiceBillingAndroid|onDeveloperProvidedBillingAndroid|onSubscriptionBillingIssue)\s*:\s*async\b/,
+    message:
+      "TypeScript hook callbacks must delegate asynchronous work to an explicitly handled promise.",
+  },
+  {
+    language: "dart",
+    pattern: /\.listen\s*\(\s*\([^)]*\)\s*async\b/,
+    message:
+      "Flutter stream listeners must handle asynchronous work explicitly because callback futures are not observed.",
+  },
+  {
+    language: "csharp",
+    pattern: /\.Subscribe\s*\(\s*async\b/,
+    message:
+      "MAUI observable listeners must delegate asynchronous work to a failure-handling task instead of using `async void`.",
+  },
+  {
     pattern: /OpenIapStore\.shared/,
     message:
       "Apple/native store examples must construct or inject `OpenIapStore`; no `shared` singleton exists.",

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -81,6 +81,10 @@ const VERIFY_PURCHASE_DOC_FILE = resolve(
   REPO_ROOT,
   "packages/docs/src/pages/docs/types/verify-purchase.tsx",
 );
+const HAS_ACTIVE_SUBSCRIPTIONS_DOC_FILE = resolve(
+  REPO_ROOT,
+  "packages/docs/src/pages/docs/apis/has-active-subscriptions.tsx",
+);
 const GENERATED_OFFER_TYPE_FILES = {
   typescript: TYPES_FILE,
   swift: resolve(REPO_ROOT, GENERATED_SYNC_MANIFEST.swift.source),
@@ -222,6 +226,26 @@ export function auditVerifyPurchaseDocs(
     });
   }
   return drifts;
+}
+
+export function auditSubscriptionFailureDocs(
+  file: string,
+  source: string,
+): Drift[] {
+  const obsoleteClaim =
+    /React Native's root helper\s+and hook map failures to(?:\{' '\})?\s*<code>false<\/code>/;
+  const match = obsoleteClaim.exec(source);
+  if (!match) return [];
+
+  return [
+    {
+      file,
+      line: source.slice(0, match.index).split("\n").length,
+      rule: "R15",
+      message:
+        "React Native subscription queries reject; the hook calls onError before rethrowing.",
+    },
+  ];
 }
 
 const CODE_EXAMPLE_RULES: CodeExampleRule[] = [
@@ -1866,6 +1890,12 @@ async function main() {
       VERIFY_PURCHASE_DOC_FILE,
       readFileSync(VERIFY_PURCHASE_DOC_FILE, "utf8"),
       readFileSync(TYPES_FILE, "utf8"),
+    ),
+  );
+  drifts.push(
+    ...auditSubscriptionFailureDocs(
+      HAS_ACTIVE_SUBSCRIPTIONS_DOC_FILE,
+      readFileSync(HAS_ACTIVE_SUBSCRIPTIONS_DOC_FILE, "utf8"),
     ),
   );
   drifts.push(

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -233,20 +233,23 @@ export function auditSubscriptionFailureDocs(
   source: string,
 ): Drift[] {
   const drifts: Drift[] = [];
+  const renderedProse = collectRenderedProse(source);
   const obsoleteClaim =
-    /React Native's root helper\s+and hook map failures to(?:\{' '\})?\s*<code>false<\/code>/;
-  const match = obsoleteClaim.exec(source);
+    /React\s+Native's\s+root\s+helper\s+and\s+hook\s+map\s+failures\s+to\s+false/;
+  const match = obsoleteClaim.exec(renderedProse.text);
   if (match) {
     drifts.push({
       file,
-      line: source.slice(0, match.index).split("\n").length,
+      line: lineNumberAt(
+        source,
+        renderedSourceOffset(renderedProse, match.index),
+      ),
       rule: "R15",
       message:
         "React Native subscription queries reject; the hook calls onError before rethrowing.",
     });
   }
 
-  const renderedProse = collectRenderedProse(source).text;
   const requiredClaims = [
     {
       pattern:
@@ -269,7 +272,7 @@ export function auditSubscriptionFailureDocs(
   ];
 
   for (const claim of requiredClaims) {
-    if (!claim.pattern.test(renderedProse)) {
+    if (!claim.pattern.test(renderedProse.text)) {
       drifts.push({ file, line: 1, rule: "R15", message: claim.message });
     }
   }

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -232,20 +232,48 @@ export function auditSubscriptionFailureDocs(
   file: string,
   source: string,
 ): Drift[] {
+  const drifts: Drift[] = [];
   const obsoleteClaim =
     /React Native's root helper\s+and hook map failures to(?:\{' '\})?\s*<code>false<\/code>/;
   const match = obsoleteClaim.exec(source);
-  if (!match) return [];
-
-  return [
-    {
+  if (match) {
+    drifts.push({
       file,
       line: source.slice(0, match.index).split("\n").length,
       rule: "R15",
       message:
         "React Native subscription queries reject; the hook calls onError before rethrowing.",
+    });
+  }
+
+  const requiredClaims = [
+    {
+      pattern:
+        /React Native,\s*Expo,\s*and native promise APIs reject on failure/,
+      message:
+        "Subscription docs must state that React Native, Expo, and native promise APIs reject on failure.",
+    },
+    {
+      pattern:
+        /React\s+Native\s+and\s+Expo\s+hooks\s+call\s*<code>onError<\/code>\s*before\s+rethrowing/,
+      message:
+        "Subscription docs must state that React Native and Expo hooks call onError before rethrowing.",
+    },
+    {
+      pattern:
+        /compatibility boolean helper still maps failure to(?:\s|\{' '\})*<code>false<\/code>/,
+      message:
+        "Subscription docs must identify Godot's compatibility boolean helper as the false fallback.",
     },
   ];
+
+  for (const claim of requiredClaims) {
+    if (!claim.pattern.test(source)) {
+      drifts.push({ file, line: 1, rule: "R15", message: claim.message });
+    }
+  }
+
+  return drifts;
 }
 
 const CODE_EXAMPLE_RULES: CodeExampleRule[] = [

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -246,29 +246,30 @@ export function auditSubscriptionFailureDocs(
     });
   }
 
+  const renderedProse = collectRenderedProse(source).text;
   const requiredClaims = [
     {
       pattern:
-        /React Native,\s*Expo,\s*and native promise APIs reject on failure/,
+        /React\s+Native,\s*Expo,\s*and\s+native\s+promise\s+APIs\s+reject\s+on\s+failure/,
       message:
         "Subscription docs must state that React Native, Expo, and native promise APIs reject on failure.",
     },
     {
       pattern:
-        /React\s+Native\s+and\s+Expo\s+hooks\s+call\s*<code>onError<\/code>\s*before\s+rethrowing/,
+        /React\s+Native\s+and\s+Expo\s+hooks\s+call\s+onError\s+before\s+rethrowing/,
       message:
         "Subscription docs must state that React Native and Expo hooks call onError before rethrowing.",
     },
     {
       pattern:
-        /compatibility boolean helper still maps failure to(?:\s|\{' '\})*<code>false<\/code>/,
+        /Godot(?:'s)?\s+compatibility\s+boolean\s+helper\s+still\s+maps\s+failure\s+to\s+false/,
       message:
         "Subscription docs must identify Godot's compatibility boolean helper as the false fallback.",
     },
   ];
 
   for (const claim of requiredClaims) {
-    if (!claim.pattern.test(source)) {
+    if (!claim.pattern.test(renderedProse)) {
       drifts.push({ file, line: 1, rule: "R15", message: claim.message });
     }
   }


### PR DESCRIPTION
## Outcome

React Native now follows each native store's connection contract without losing purchase events:

| Platform | Before | After |
| --- | --- | --- |
| Android | Store calls silently opened Play Billing | Apps connect explicitly; disconnected calls preserve the native error |
| iOS | The bridge rejected calls before `initConnection()` and could miss startup events | StoreKit calls connect on demand through the serialized listener lifecycle, with bounded startup-event replay |

## What changed

### Android

- Removed bridge-level implicit connection from store operations.
- Preserved native `OpenIapError` codes and coroutine cancellation.
- Allowed an explicit later `initConnection()` to rebuild a disconnected native service.
- Preserved connection and listener state when native teardown throws.

### iOS

- Routed implicit connection through the same serialized lifecycle as explicit initialization.
- Serialized connection-bound operations with teardown.
- Attached core listeners before initialization and replayed startup purchase updates/errors through bounded FIFO buffers.
- Delivered direct purchase results without duplicating later native callbacks.
- Preserved state when teardown throws and prevented on-demand initialization failures from leaking duplicate errors.

### JavaScript and hooks

- Retried deferred listener attachment when Nitro becomes available.
- Replaced stale hook-owned subscriptions during reconnect while retaining generation ownership.
- Preserved query and product-fetch rejection semantics after invoking `onError`.

### Documentation and guards

- Documented the Android explicit-connection and iOS on-demand contracts in active API/setup guides.
- Registered purchase listeners before initialization can replay unfinished purchases.
- Checked connection and teardown boolean results across TypeScript, Swift, Kotlin/KMP, Flutter, MAUI, and Godot examples.
- Replaced unobserved async listener/hook callbacks with explicit failure-handling helpers.
- Added documentation audit fixtures that reject ignored connection results and unobserved async callbacks.
- Kept release-note publication deferred until an actual package release.

## Verification

Exact head: `58deb8b8b84b510a1aaa36915f6a7f821cda1fc9`

- React Native: 632 Jest tests; typecheck and lint pass (0 errors, 5 existing warnings)
- Android: full `:react-native-iap:testDebugUnitTest` passes
- iOS example scheme: 17/17 focused simulator lifecycle tests pass
- Docs: typecheck, production build, formatting, 62 documentation/reference tests, and `audit:docs` with zero drift
- Agent context: 70/70 tests and TypeScript pass
- Repository parity, layout, sponsor, IAPKit contract, release-state, and diff audits pass

Every actionable review finding has a direct maintainer response and verified fix. Per the maintainer's one-time consolidation decision for this PR batch, the physical-device matrix will run once from the final merged `main`, without recording, rather than block each individual PR.

## Compatibility

Android apps that relied on implicit connection must call `initConnection()` or wait for the hook's `connected` state before store operations. iOS remains connection-on-demand through the bridge lifecycle.

Related: #407, #408.
