### PR TITLE
fix(google): restore listeners after reconnect

### DIFF
--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -310,9 +310,9 @@ class OpenIapStore(private val module: OpenIapProtocol) {
      * @see <a href="https://openiap.dev/docs/apis/end-connection">https://openiap.dev/docs/apis/end-connection</a>
      */
     val endConnection: MutationEndConnectionHandler = {
-        detachPurchaseListeners()
         try {
             val ok = module.endConnection()
+            detachPurchaseListeners()
             _isConnected.value = false
             pendingRequestProductId = null
             ok

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -131,6 +131,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
 
     // Keep listener references to support proper removal
     private var pendingRequestProductId: String? = null
+    private var purchaseListenersAttached = false
 
     private val purchaseUpdateListener = OpenIapPurchaseUpdateListener { purchase ->
         _currentPurchase.value = purchase
@@ -221,17 +222,29 @@ class OpenIapStore(private val module: OpenIapProtocol) {
         activityBindings.set(owner, null)
     }
 
-    init {
+    private fun attachPurchaseListeners() {
+        if (purchaseListenersAttached) return
         module.addPurchaseUpdateListener(purchaseUpdateListener)
         module.addPurchaseErrorListener(purchaseErrorListener)
+        purchaseListenersAttached = true
+    }
+
+    private fun detachPurchaseListeners() {
+        if (!purchaseListenersAttached) return
+        module.removePurchaseUpdateListener(purchaseUpdateListener)
+        module.removePurchaseErrorListener(purchaseErrorListener)
+        purchaseListenersAttached = false
+    }
+
+    init {
+        attachPurchaseListeners()
     }
 
     /**
      * Clear listeners and transient state. Call when the screen is disposed.
      */
     fun clear() {
-        module.removePurchaseUpdateListener(purchaseUpdateListener)
-        module.removePurchaseErrorListener(purchaseErrorListener)
+        detachPurchaseListeners()
         activityBindings.clear()
         processedPurchaseTokens.clear()
         pendingRequestProductId = null
@@ -262,6 +275,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
             val ok = module.initConnection(config)
             OpenIapLog.info("OpenIapStore.initConnection: module.initConnection returned: $ok", "OpenIapStore")
             _isConnected.value = ok
+            attachPurchaseListeners()
             ok
         } catch (e: Exception) {
             OpenIapLog.error("OpenIapStore.initConnection: Exception", e, "OpenIapStore")
@@ -296,12 +310,11 @@ class OpenIapStore(private val module: OpenIapProtocol) {
      * @see <a href="https://openiap.dev/docs/apis/end-connection">https://openiap.dev/docs/apis/end-connection</a>
      */
     val endConnection: MutationEndConnectionHandler = {
-        removePurchaseUpdateListener(purchaseUpdateListener)
-        removePurchaseErrorListener(purchaseErrorListener)
+        detachPurchaseListeners()
         try {
             val ok = module.endConnection()
             _isConnected.value = false
-            clear()
+            pendingRequestProductId = null
             ok
         } catch (e: Exception) {
             setError(e.message)

--- a/packages/google/openiap/src/test/java/dev/hyo/openiap/store/OpenIapStoreConnectionLifecycleTest.kt
+++ b/packages/google/openiap/src/test/java/dev/hyo/openiap/store/OpenIapStoreConnectionLifecycleTest.kt
@@ -1,0 +1,142 @@
+package dev.hyo.openiap.store
+
+import dev.hyo.openiap.IapStore
+import dev.hyo.openiap.MutationEndConnectionHandler
+import dev.hyo.openiap.MutationInitConnectionHandler
+import dev.hyo.openiap.OpenIapProtocol
+import dev.hyo.openiap.Purchase
+import dev.hyo.openiap.PurchaseAndroid
+import dev.hyo.openiap.PurchaseState
+import dev.hyo.openiap.QueryGetAvailablePurchasesHandler
+import dev.hyo.openiap.listener.OpenIapPurchaseErrorListener
+import dev.hyo.openiap.listener.OpenIapPurchaseUpdateListener
+import java.lang.reflect.Proxy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OpenIapStoreConnectionLifecycleTest {
+    @Test
+    fun `purchase updates survive a connection cycle`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val module = FakeOpenIapProtocol()
+        val store = OpenIapStore(module.protocol)
+        val purchase = PurchaseAndroid(
+            id = "transaction-id",
+            isAutoRenewing = false,
+            productId = "premium",
+            purchaseState = PurchaseState.Purchased,
+            purchaseToken = "purchase-token",
+            quantity = 1,
+            store = IapStore.Google,
+            transactionDate = 1.0,
+        )
+        module.availablePurchases = listOf(purchase)
+
+        try {
+            assertEquals(1, module.purchaseUpdateListeners.size)
+            assertEquals(1, module.purchaseErrorListeners.size)
+            assertTrue(store.initConnection())
+            assertEquals(1, module.purchaseUpdateListeners.size)
+            assertEquals(1, module.purchaseErrorListeners.size)
+            assertTrue(store.endConnection())
+            assertEquals(0, module.purchaseUpdateListeners.size)
+            assertEquals(0, module.purchaseErrorListeners.size)
+            assertTrue(store.initConnection())
+            assertEquals(1, module.purchaseUpdateListeners.size)
+            assertEquals(1, module.purchaseErrorListeners.size)
+
+            module.emitPurchase(purchase)
+            assertEquals(purchase, store.currentPurchase.value)
+
+            advanceUntilIdle()
+            assertEquals(1, module.availablePurchaseRequests)
+            assertEquals(listOf(purchase), store.availablePurchases.value)
+        } finally {
+            store.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `listeners return after a failed reconnect`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val module = FakeOpenIapProtocol()
+        val store = OpenIapStore(module.protocol)
+
+        try {
+            assertTrue(store.initConnection())
+            assertTrue(store.endConnection())
+            module.connectionResult = false
+
+            assertFalse(store.initConnection())
+            assertEquals(1, module.purchaseUpdateListeners.size)
+            assertEquals(1, module.purchaseErrorListeners.size)
+        } finally {
+            store.clear()
+            Dispatchers.resetMain()
+        }
+    }
+}
+
+private class FakeOpenIapProtocol {
+    val purchaseUpdateListeners = linkedSetOf<OpenIapPurchaseUpdateListener>()
+    val purchaseErrorListeners = linkedSetOf<OpenIapPurchaseErrorListener>()
+    var availablePurchases: List<Purchase> = emptyList()
+    var availablePurchaseRequests = 0
+    var connectionResult = true
+
+    private val initConnection: MutationInitConnectionHandler = { connectionResult }
+    private val endConnection: MutationEndConnectionHandler = { true }
+    private val getAvailablePurchases: QueryGetAvailablePurchasesHandler = {
+        availablePurchaseRequests += 1
+        availablePurchases
+    }
+
+    val protocol: OpenIapProtocol = Proxy.newProxyInstance(
+        OpenIapProtocol::class.java.classLoader,
+        arrayOf(OpenIapProtocol::class.java),
+    ) { proxy, method, args ->
+        when (method.name) {
+            "getInitConnection" -> initConnection
+            "getEndConnection" -> endConnection
+            "getGetAvailablePurchases" -> getAvailablePurchases
+            "addPurchaseUpdateListener" -> {
+                purchaseUpdateListeners += args.single() as OpenIapPurchaseUpdateListener
+                Unit
+            }
+            "removePurchaseUpdateListener" -> {
+                purchaseUpdateListeners -= args.single() as OpenIapPurchaseUpdateListener
+                Unit
+            }
+            "addPurchaseErrorListener" -> {
+                purchaseErrorListeners += args.single() as OpenIapPurchaseErrorListener
+                Unit
+            }
+            "removePurchaseErrorListener" -> {
+                purchaseErrorListeners -= args.single() as OpenIapPurchaseErrorListener
+                Unit
+            }
+            "setActivity" -> Unit
+            "equals" -> proxy === args.single()
+            "hashCode" -> System.identityHashCode(proxy)
+            "toString" -> "FakeOpenIapProtocol"
+            else -> error("Unexpected OpenIapProtocol call: ${method.name}")
+        }
+    } as OpenIapProtocol
+
+    fun emitPurchase(purchase: Purchase) {
+        for (listener in purchaseUpdateListeners) {
+            listener.onPurchaseUpdated(purchase)
+        }
+    }
+}

--- a/packages/google/openiap/src/test/java/dev/hyo/openiap/store/OpenIapStoreConnectionLifecycleTest.kt
+++ b/packages/google/openiap/src/test/java/dev/hyo/openiap/store/OpenIapStoreConnectionLifecycleTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -86,6 +87,32 @@ class OpenIapStoreConnectionLifecycleTest {
             Dispatchers.resetMain()
         }
     }
+
+    @Test
+    fun `failed disconnect keeps connection listeners`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val module = FakeOpenIapProtocol()
+        val store = OpenIapStore(module.protocol)
+
+        try {
+            assertTrue(store.initConnection())
+            module.endConnectionError = IllegalStateException("disconnect failed")
+
+            try {
+                store.endConnection()
+                fail("Expected endConnection to throw")
+            } catch (error: IllegalStateException) {
+                assertEquals("disconnect failed", error.message)
+            }
+
+            assertTrue(store.isConnected.value)
+            assertEquals(1, module.purchaseUpdateListeners.size)
+            assertEquals(1, module.purchaseErrorListeners.size)
+        } finally {
+            store.clear()
+            Dispatchers.resetMain()
+        }
+    }
 }
 
 private class FakeOpenIapProtocol {
@@ -94,9 +121,13 @@ private class FakeOpenIapProtocol {
     var availablePurchases: List<Purchase> = emptyList()
     var availablePurchaseRequests = 0
     var connectionResult = true
+    var endConnectionError: Exception? = null
 
     private val initConnection: MutationInitConnectionHandler = { connectionResult }
-    private val endConnection: MutationEndConnectionHandler = { true }
+    private val endConnection: MutationEndConnectionHandler = {
+        endConnectionError?.let { throw it }
+        true
+    }
     private val getAvailablePurchases: QueryGetAvailablePurchasesHandler = {
         availablePurchaseRequests += 1
         availablePurchases


### PR DESCRIPTION
## Summary

- Restore purchase update and error listeners after an OpenIapStore connection cycle.
- Keep endConnection reusable by reserving clear for terminal screen disposal.
- Cover successful and failed reconnects, including the post-purchase refresh scope.

Closes #407

## Test plan

- [x] Play, Horizon, and Amazon library compilation
- [x] Play, Horizon, and Amazon example compilation
- [x] All openiap unit tests
- [x] Kotlin 2.1.20 consumer verification for all three AAR variants
- [x] SDK parity and repository pre-commit audits
- [x] Two clean review-self snapshots five minutes apart

## Preview

Not applicable: this fixes internal Android connection lifecycle behavior and has no visual surface. The regression test exercises initConnection, endConnection, and initConnection on one store instance and verifies that purchase delivery and refresh still work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved purchase handling across connection interruptions and reconnections.
  * Purchase updates now continue to be received after reconnecting.
  * Purchase listeners are restored following an unsuccessful reconnection attempt.
  * Ending a connection no longer clears active purchase state or activity bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->