### PR TITLE
docs(docs): check store teardown results

### DIFF
--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-08-30T14:55:50.344Z
+> Last updated: 2026-08-30T16:26:08.115Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -2728,8 +2728,9 @@ raw imports outside `packages/docs`.
 Fenced `CodeBlock` examples under active documentation must not reintroduce
 known cross-language mistakes such as Kotlin syntax in C#, obsolete Flutter
 listener names, legacy purchase request shapes, top-level Godot SKUs, obsolete
-Kotlin/KMP named arguments, unchecked connection results, or asynchronous
-listener callbacks whose returned promise, future, or task is not observed.
+Kotlin/KMP named arguments, unchecked connection or teardown results, or
+asynchronous listener callbacks whose returned promise, future, or task is not
+observed.
 Historical release notes are excluded because they describe APIs as shipped at
 that time.
 

--- a/knowledge/internal/07-docs-consistency.md
+++ b/knowledge/internal/07-docs-consistency.md
@@ -240,8 +240,9 @@ raw imports outside `packages/docs`.
 Fenced `CodeBlock` examples under active documentation must not reintroduce
 known cross-language mistakes such as Kotlin syntax in C#, obsolete Flutter
 listener names, legacy purchase request shapes, top-level Godot SKUs, obsolete
-Kotlin/KMP named arguments, unchecked connection results, or asynchronous
-listener callbacks whose returned promise, future, or task is not observed.
+Kotlin/KMP named arguments, unchecked connection or teardown results, or
+asynchronous listener callbacks whose returned promise, future, or task is not
+observed.
 Historical release notes are excluded because they describe APIs as shipped at
 that time.
 

--- a/packages/docs/src/pages/docs/features/offer-code-redemption.tsx
+++ b/packages/docs/src/pages/docs/features/offer-code-redemption.tsx
@@ -146,7 +146,8 @@ export async function redeemCode() {
 
 export async function stopIap() {
   subscription?.remove();
-  await endConnection();
+  const ended = await endConnection();
+  if (!ended) console.warn('Store teardown did not complete');
 }`}</CodeBlock>
                     ),
                     swift: (
@@ -173,7 +174,11 @@ final class RedemptionManager {
     }
 
     func stop() async {
-        try? await iapStore.endConnection()
+        do {
+            try await iapStore.endConnection()
+        } catch {
+            print("Store teardown failed: \(error.localizedDescription)")
+        }
     }
 }`}</CodeBlock>
                     ),
@@ -206,7 +211,8 @@ class RedemptionManager(private val scope: CoroutineScope) {
 
     suspend fun stop() {
         purchaseJob?.cancel()
-        iap.endConnection()
+        val ended = iap.endConnection()
+        if (!ended) println("Store teardown did not complete")
     }
 }`}</CodeBlock>
                     ),
@@ -230,7 +236,8 @@ class RedemptionManager {
 
   Future<void> stop() async {
     await subscription?.cancel();
-    await iap.endConnection();
+    final ended = await iap.endConnection();
+    if (!ended) print('Store teardown did not complete');
   }
 }`}</CodeBlock>
                     ),
@@ -258,7 +265,8 @@ public sealed class RedemptionManager : IDisposable
     {
         _purchaseSubscription?.Dispose();
         _purchaseSubscription = null;
-        await ((MutationResolver)_iap).EndConnectionAsync();
+        var ended = await ((MutationResolver)_iap).EndConnectionAsync();
+        if (!ended) Console.WriteLine("Store teardown did not complete");
     }
 
     public void Dispose() => _purchaseSubscription?.Dispose();
@@ -279,7 +287,9 @@ func redeem_code() -> Variant:
     return await GodotIapPlugin.open_redeem_offer_code()
 
 func _exit_tree() -> void:
-    await GodotIapPlugin.end_connection()`}</CodeBlock>
+    var ended = await GodotIapPlugin.end_connection()
+    if not ended:
+        push_warning("Store teardown did not complete")`}</CodeBlock>
                     ),
                   }}
                 </LanguageTabs>

--- a/packages/docs/src/pages/docs/features/purchase.tsx
+++ b/packages/docs/src/pages/docs/features/purchase.tsx
@@ -425,7 +425,9 @@ func _on_purchase_error(error: PurchaseError) -> void:
     handle_purchase_error(error)
 
 func _exit_tree() -> void:
-    await iap.end_connection()`}</CodeBlock>
+    var ended = await iap.end_connection()
+    if not ended:
+        push_warning("Store teardown did not complete")`}</CodeBlock>
             ),
           }}
         </LanguageTabs>
@@ -2162,7 +2164,9 @@ func _on_purchase_error(error: PurchaseError) -> void:
     is_processing = false
 
 func _exit_tree() -> void:
-    await iap.end_connection()`}</CodeBlock>
+    var ended = await iap.end_connection()
+    if not ended:
+        push_warning("Store teardown did not complete")`}</CodeBlock>
             ),
           }}
         </LanguageTabs>

--- a/packages/docs/src/pages/docs/setup/flutter.tsx
+++ b/packages/docs/src/pages/docs/setup/flutter.tsx
@@ -323,7 +323,9 @@ class _StoreScreenState extends State<StoreScreen> {
     unawaited(errorSub?.cancel().catchError(
       (Object error) => print('Listener cleanup failed: $error'),
     ));
-    unawaited(iap.endConnection().then<void>((_) {}).catchError(
+    unawaited(iap.endConnection().then<void>((ended) {
+      if (!ended) print('Store teardown did not complete');
+    }).catchError(
       (Object error) => print('Store teardown failed: $error'),
     ));
     super.dispose();

--- a/packages/docs/src/pages/docs/setup/maui.tsx
+++ b/packages/docs/src/pages/docs/setup/maui.tsx
@@ -426,7 +426,8 @@ BindUserResponse bind = await kit.BindUserAsync(purchase.PurchaseToken!, "user_1
           {`purchaseSub.Dispose();
 errorSub.Dispose();
 
-await mutate.EndConnectionAsync();`}
+var ended = await mutate.EndConnectionAsync();
+if (!ended) Console.WriteLine("Store teardown did not complete");`}
         </CodeBlock>
       </section>
 

--- a/packages/docs/src/pages/docs/setup/react-native.tsx
+++ b/packages/docs/src/pages/docs/setup/react-native.tsx
@@ -409,7 +409,8 @@ await requestPurchase({
 // Cleanup on unmount
 purchaseSub.remove();
 errorSub.remove();
-await endConnection();`}
+const ended = await endConnection();
+if (!ended) console.warn('Store teardown did not complete');`}
         </CodeBlock>
         <p>
           Each call here has a full reference — see{' '}

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -348,15 +348,45 @@ describe("active docs code-example audit", () => {
     ]);
   });
 
+  test("flags inline unchecked teardown results", () => {
+    const source = [
+      '<CodeBlock language="typescript">{`if (disposing) await endConnection();`}</CodeBlock>',
+      '<CodeBlock language="swift">{`if disposing { try? await OpenIapModule.shared.endConnection() }`}</CodeBlock>',
+      '<CodeBlock language="dart">{`if (disposing) await iap.endConnection();`}</CodeBlock>',
+      '<CodeBlock language="kotlin">{`if (disposing) store.endConnection()`}</CodeBlock>',
+      '<CodeBlock language="csharp">{`if (disposing) await mutation.EndConnectionAsync();`}</CodeBlock>',
+      '<CodeBlock language="gdscript">{`if disposing: await iap.end_connection()`}</CodeBlock>',
+    ].join("\n");
+
+    expect(
+      auditActiveCodeExampleSource("/tmp/active.tsx", source).map(
+        (drift) => drift.message,
+      ),
+    ).toEqual([
+      expect.stringContaining("TypeScript examples must check"),
+      expect.stringContaining("Swift module examples must check"),
+      expect.stringContaining("Flutter examples must check"),
+      expect.stringContaining("Kotlin and KMP examples must check"),
+      expect.stringContaining("MAUI examples must check"),
+      expect.stringContaining("Godot examples must check"),
+    ]);
+  });
+
   test("accepts checked teardown results", () => {
     const source = [
       '<CodeBlock language="typescript">{`const ended = await endConnection(); if (!ended) warn();`}</CodeBlock>',
+      '<CodeBlock language="typescript">{`if (!(await endConnection())) warn();`}</CodeBlock>',
       '<CodeBlock language="swift">{`let ended = try await OpenIapModule.shared.endConnection(); if !ended { warn() }`}</CodeBlock>',
+      '<CodeBlock language="swift">{`if !(try await OpenIapModule.shared.endConnection()) { warn() }`}</CodeBlock>',
       '<CodeBlock language="swift">{`try await store.endConnection()`}</CodeBlock>',
       '<CodeBlock language="dart">{`final ended = await iap.endConnection(); if (!ended) warn();`}</CodeBlock>',
+      '<CodeBlock language="dart">{`if (!await iap.endConnection()) warn();`}</CodeBlock>',
       '<CodeBlock language="kotlin">{`val ended = store.endConnection(); if (!ended) warn()`}</CodeBlock>',
+      '<CodeBlock language="kotlin">{`if (!store.endConnection()) warn()`}</CodeBlock>',
       '<CodeBlock language="csharp">{`var ended = await mutation.EndConnectionAsync(); if (!ended) Warn();`}</CodeBlock>',
+      '<CodeBlock language="csharp">{`if (!await mutation.EndConnectionAsync()) Warn();`}</CodeBlock>',
       '<CodeBlock language="gdscript">{`var ended = await iap.end_connection(); if not ended: warn()`}</CodeBlock>',
+      '<CodeBlock language="gdscript">{`if not await iap.end_connection(): warn()`}</CodeBlock>',
     ].join("\n");
 
     expect(auditActiveCodeExampleSource("/tmp/active.tsx", source)).toEqual([]);

--- a/scripts/audit-docs.test.ts
+++ b/scripts/audit-docs.test.ts
@@ -324,6 +324,44 @@ describe("active docs code-example audit", () => {
     expect(auditActiveCodeExampleSource("/tmp/active.tsx", source)).toEqual([]);
   });
 
+  test("flags unchecked teardown results", () => {
+    const source = [
+      '<CodeBlock language="typescript">{`await endConnection();`}</CodeBlock>',
+      '<CodeBlock language="swift">{`try? await OpenIapModule.shared.endConnection()`}</CodeBlock>',
+      '<CodeBlock language="dart">{`await iap.endConnection();`}</CodeBlock>',
+      '<CodeBlock language="kotlin">{`store.endConnection()`}</CodeBlock>',
+      '<CodeBlock language="csharp">{`await mutation.EndConnectionAsync();`}</CodeBlock>',
+      '<CodeBlock language="gdscript">{`await iap.end_connection()`}</CodeBlock>',
+    ].join("\n");
+
+    expect(
+      auditActiveCodeExampleSource("/tmp/active.tsx", source).map(
+        (drift) => drift.message,
+      ),
+    ).toEqual([
+      expect.stringContaining("TypeScript examples must check"),
+      expect.stringContaining("Swift module examples must check"),
+      expect.stringContaining("Flutter examples must check"),
+      expect.stringContaining("Kotlin and KMP examples must check"),
+      expect.stringContaining("MAUI examples must check"),
+      expect.stringContaining("Godot examples must check"),
+    ]);
+  });
+
+  test("accepts checked teardown results", () => {
+    const source = [
+      '<CodeBlock language="typescript">{`const ended = await endConnection(); if (!ended) warn();`}</CodeBlock>',
+      '<CodeBlock language="swift">{`let ended = try await OpenIapModule.shared.endConnection(); if !ended { warn() }`}</CodeBlock>',
+      '<CodeBlock language="swift">{`try await store.endConnection()`}</CodeBlock>',
+      '<CodeBlock language="dart">{`final ended = await iap.endConnection(); if (!ended) warn();`}</CodeBlock>',
+      '<CodeBlock language="kotlin">{`val ended = store.endConnection(); if (!ended) warn()`}</CodeBlock>',
+      '<CodeBlock language="csharp">{`var ended = await mutation.EndConnectionAsync(); if (!ended) Warn();`}</CodeBlock>',
+      '<CodeBlock language="gdscript">{`var ended = await iap.end_connection(); if not ended: warn()`}</CodeBlock>',
+    ].join("\n");
+
+    expect(auditActiveCodeExampleSource("/tmp/active.tsx", source)).toEqual([]);
+  });
+
   test("audits formatted multiline CodeBlock children", () => {
     const source = `<CodeBlock language="dart">
       {\`iap.purchaseUpdatedStream.listen(onPurchase);\`}

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -338,6 +338,43 @@ const CODE_EXAMPLE_RULES: CodeExampleRule[] = [
   },
   {
     language: "typescript",
+    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_$][\w$]*\.)*endConnection\s*\(/m,
+    message:
+      "TypeScript examples must check the boolean returned by `endConnection` before treating teardown as complete.",
+  },
+  {
+    language: "swift",
+    pattern:
+      /(?:^|\n)\s*(?:try[!?]?\s+)?await\s+OpenIapModule\.shared\.endConnection\s*\(/m,
+    message:
+      "Swift module examples must check the boolean returned by `endConnection` before treating teardown as complete.",
+  },
+  {
+    language: "dart",
+    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_$][\w$]*\.)+endConnection\s*\(/m,
+    message:
+      "Flutter examples must check the boolean returned by `endConnection` before treating teardown as complete.",
+  },
+  {
+    language: "kotlin",
+    pattern: /(?:^|\n)\s*(?:[A-Za-z_]\w*\.)+endConnection\s*\(/m,
+    message:
+      "Kotlin and KMP examples must check the boolean returned by `endConnection` before treating teardown as complete.",
+  },
+  {
+    language: "csharp",
+    pattern: /(?:^|\n)\s*await\s+[^;\n]*\.EndConnectionAsync\s*\(/m,
+    message:
+      "MAUI examples must check the boolean returned by `EndConnectionAsync` before treating teardown as complete.",
+  },
+  {
+    language: "gdscript",
+    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_]\w*\.)*end_connection\s*\(/m,
+    message:
+      "Godot examples must check the boolean returned by `end_connection` before treating teardown as complete.",
+  },
+  {
+    language: "typescript",
     pattern:
       /\b(?:purchaseUpdatedListener|purchaseErrorListener|userChoiceBillingListenerAndroid|developerProvidedBillingListenerAndroid|subscriptionBillingIssueListener)\s*\(\s*async\b/,
     message:

--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -338,38 +338,43 @@ const CODE_EXAMPLE_RULES: CodeExampleRule[] = [
   },
   {
     language: "typescript",
-    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_$][\w$]*\.)*endConnection\s*\(/m,
+    pattern:
+      /(?:^|[;{}]|\)\s*|\belse\s+)\s*await\s+(?:[A-Za-z_$][\w$]*\.)*endConnection\s*\(/,
     message:
       "TypeScript examples must check the boolean returned by `endConnection` before treating teardown as complete.",
   },
   {
     language: "swift",
     pattern:
-      /(?:^|\n)\s*(?:try[!?]?\s+)?await\s+OpenIapModule\.shared\.endConnection\s*\(/m,
+      /(?:^|[;{}]|\)\s*|\belse\s+)\s*(?:try[!?]?\s+)?await\s+OpenIapModule\.shared\.endConnection\s*\(/,
     message:
       "Swift module examples must check the boolean returned by `endConnection` before treating teardown as complete.",
   },
   {
     language: "dart",
-    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_$][\w$]*\.)+endConnection\s*\(/m,
+    pattern:
+      /(?:^|[;{}]|\)\s*|\belse\s+)\s*await\s+(?:[A-Za-z_$][\w$]*\.)+endConnection\s*\(/,
     message:
       "Flutter examples must check the boolean returned by `endConnection` before treating teardown as complete.",
   },
   {
     language: "kotlin",
-    pattern: /(?:^|\n)\s*(?:[A-Za-z_]\w*\.)+endConnection\s*\(/m,
+    pattern:
+      /(?:^|[;{}]|\)\s*|\belse\s+)\s*(?:[A-Za-z_]\w*\.)+endConnection\s*\(/,
     message:
       "Kotlin and KMP examples must check the boolean returned by `endConnection` before treating teardown as complete.",
   },
   {
     language: "csharp",
-    pattern: /(?:^|\n)\s*await\s+[^;\n]*\.EndConnectionAsync\s*\(/m,
+    pattern:
+      /(?:^|[;{}]|\)\s*|\belse\s+)\s*await\s+[^;\n]*\.EndConnectionAsync\s*\(/,
     message:
       "MAUI examples must check the boolean returned by `EndConnectionAsync` before treating teardown as complete.",
   },
   {
     language: "gdscript",
-    pattern: /(?:^|\n)\s*await\s+(?:[A-Za-z_]\w*\.)*end_connection\s*\(/m,
+    pattern:
+      /(?:^|[:;{}]|\)\s*|\belse\s+)\s*await\s+(?:[A-Za-z_]\w*\.)*end_connection\s*\(/,
     message:
       "Godot examples must check the boolean returned by `end_connection` before treating teardown as complete.",
   },


### PR DESCRIPTION
## Summary

- update active cleanup examples to inspect boolean teardown results across React Native, Expo, KMP, Flutter, MAUI, and Godot
- handle OpenIapStore teardown through its throwing Void contract while keeping the OpenIapModule boolean contract explicit
- add fault-tested documentation audits so unchecked teardown examples do not return
- regenerate the shared agent context from the documentation consistency source

## Verification

- 58 audit-docs tests
- audit:docs (0 drift)
- docs typecheck and production build
- docs Prettier check
- 70 agent-context tests and agent typecheck
- pre-commit SDK parity, layout, sponsor, IAPKit contract, docs, and generated-context audits
- git diff --check

## Visual proof

Recording intentionally omitted per maintainer request. This change updates code snippets and automated consistency checks; the production docs build passes.

No package release or docs deployment is part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated setup, purchase, and offer-code redemption examples across supported platforms to verify store connection teardown results.
  - Added warnings and error handling when teardown does not complete successfully.
  - Clarified guidance for checking connection and teardown outcomes.

- **Quality Improvements**
  - Improved automated checks to detect unchecked teardown calls, including inline control-flow examples.
  - Validated compliant examples across TypeScript, Swift, Dart, Kotlin, MAUI, and Godot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->