### PR TITLE
fix(iapkit): support Horizon entitlement verification

### DIFF
--- a/libraries/expo-iap/example/__tests__/vega-runtime.test.ts
+++ b/libraries/expo-iap/example/__tests__/vega-runtime.test.ts
@@ -66,6 +66,26 @@ describe('Vega runtime example helpers', () => {
     });
   });
 
+  it('uses Horizon verification without treating the purchase ID as a user ID', () => {
+    const payload = createIapkitVerificationPayload(
+      {
+        id: 'purchase-id-1',
+        productId: 'dev.hyo.martie.premium',
+        purchaseToken: 'purchase-id-1',
+        store: 'horizon',
+      } as Purchase,
+      'purchase-id-1',
+      'http://localhost:3100',
+    );
+
+    expect(payload).toMatchObject({
+      apiKey: 'test-api-key',
+      baseUrl: 'http://localhost:3100',
+      horizon: {sku: 'dev.hyo.martie.premium'},
+    });
+    expect(payload).not.toHaveProperty('google');
+  });
+
   it('defaults to local IAPKit when a key and local URL are configured', () => {
     expect(getDefaultVerificationMethod()).toBe('iapkit-localhost');
   });

--- a/libraries/expo-iap/example/src/utils/vegaRuntime.ts
+++ b/libraries/expo-iap/example/src/utils/vegaRuntime.ts
@@ -125,6 +125,8 @@ function isIapkitStateReadyForFulfillment(
         verified.state === 'pending-acknowledgment' ||
         (isConsumable && verified.state === 'ready-to-consume')
       );
+    case 'horizon':
+      return verified.state === 'entitled';
     default:
       return false;
   }
@@ -228,6 +230,15 @@ export function createIapkitVerificationPayload(
           receiptId: purchaseToken,
           sandbox: isAmazonRvsSandboxEnabled(),
         },
+      },
+      baseUrl,
+    );
+  }
+  if (purchaseStore === 'horizon') {
+    return withIapkitEndpoint(
+      {
+        apiKey,
+        horizon: {sku: purchase.productId},
       },
       baseUrl,
     );

--- a/libraries/expo-iap/src/types.ts
+++ b/libraries/expo-iap/src/types.ts
@@ -1828,11 +1828,19 @@ export interface RequestVerifyPurchaseWithIapkitGoogleProps {
   purchaseToken: string;
 }
 
+export interface RequestVerifyPurchaseWithIapkitHorizonProps {
+  /** Meta Horizon product or subscription SKU. */
+  sku: string;
+  /** Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted. */
+  userId?: (string | null);
+}
+
 /**
  * Platform-specific verification parameters for IAPKit.
  *
  * - apple: Verifies via App Store (JWS token)
  * - google: Verifies via Play Store (purchase token)
+ * - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
  * - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
  */
 export interface RequestVerifyPurchaseWithIapkitProps {
@@ -1851,10 +1859,12 @@ export interface RequestVerifyPurchaseWithIapkitProps {
   baseUrl?: (string | null);
   /** Google Play Store verification parameters. */
   google?: (RequestVerifyPurchaseWithIapkitGoogleProps | null);
+  /** Meta Horizon verification parameters. */
+  horizon?: (RequestVerifyPurchaseWithIapkitHorizonProps | null);
   /**
    * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-   * Include the product's public IAPKit client payload in a valid Apple or
-   * Google verification response. Defaults to false so existing response
+   * Include the product's public IAPKit client payload in a valid verification
+   * response. Defaults to false so existing response
    * shapes and bandwidth remain unchanged.
    */
   includeClientPayload?: (boolean | null);

--- a/libraries/flutter_inapp_purchase/example/lib/src/screens/purchase_flow_screen.dart
+++ b/libraries/flutter_inapp_purchase/example/lib/src/screens/purchase_flow_screen.dart
@@ -242,11 +242,6 @@ Has token: ${purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpt
     debugPrint('ID: ${purchase.id}'); // OpenIAP standard
     debugPrint('Transaction ID: ${transactionId ?? 'N/A'}');
 
-    // Mark this transaction as processed
-    if (transactionId != null) {
-      _processedTransactionIds.add(transactionId);
-    }
-
     if (!mounted) return;
     setState(() {
       _isProcessing = false;
@@ -266,7 +261,12 @@ Purchase credential: ${purchase.purchaseToken?.isNotEmpty == true ? 'Present' : 
 
     // Perform verification based on selected method
     if (_verificationMethod == VerificationMethod.iapkit) {
-      await _verifyPurchaseWithIAPKit(purchase);
+      final verificationOk = await _verifyPurchaseWithIAPKit(purchase);
+      if (!verificationOk) {
+        debugPrint(
+            '⚠️ Skipping finishTransaction because IAPKit verification did not return isValid=true');
+        return;
+      }
     } else if (_verificationMethod == VerificationMethod.local) {
       await _verifyPurchaseLocally(purchase);
     }
@@ -278,6 +278,9 @@ Purchase credential: ${purchase.purchaseToken?.isNotEmpty == true ? 'Present' : 
         purchase: purchase,
         isConsumable: true,
       );
+      if (transactionId != null) {
+        _processedTransactionIds.add(transactionId);
+      }
       debugPrint('Transaction finished successfully');
       if (!mounted) return;
       setState(() {
@@ -417,7 +420,7 @@ Auto Renewing: ${androidResult.autoRenewing}
   }
 
   /// Verify purchase with IAPKit provider
-  Future<void> _verifyPurchaseWithIAPKit(Purchase purchase) async {
+  Future<bool> _verifyPurchaseWithIAPKit(Purchase purchase) async {
     final apiKey = IapConstants.iapkitApiKey;
     debugPrint('IAPKit API key configured: ${apiKey.isNotEmpty}');
 
@@ -449,14 +452,14 @@ Auto Renewing: ${androidResult.autoRenewing}
       debugPrint(
           'IAPKit verification completed: hasIapkit=${result.iapkit != null}');
 
-      if (result.iapkit != null) {
-        final iapkitResult = result.iapkit!;
+      final iapkitResult = result.iapkit;
+      if (iapkitResult != null) {
         final statusEmoji = iapkitResult.isValid ? '✅' : '⚠️';
         final stateText = iapkitResult.state.value;
 
-        if (!mounted) return;
-        setState(() {
-          _purchaseResult = '''
+        if (mounted) {
+          setState(() {
+            _purchaseResult = '''
 $_purchaseResult
 
 $statusEmoji IAPKit Verification
@@ -464,16 +467,20 @@ Valid: ${iapkitResult.isValid}
 State: $stateText
 Store: ${iapkitResult.store.value}
           '''
-              .trim();
-        });
+                .trim();
+          });
+        }
       }
+      return iapkitResult?.isValid == true;
     } catch (e) {
       debugPrint('IAPKit verification failed: $e');
-      if (!mounted) return;
-      setState(() {
-        _purchaseResult =
-            '$_purchaseResult\n\n❌ IAPKit verification failed: $e';
-      });
+      if (mounted) {
+        setState(() {
+          _purchaseResult =
+              '$_purchaseResult\n\n❌ IAPKit verification failed: $e';
+        });
+      }
+      return false;
     }
   }
 

--- a/libraries/flutter_inapp_purchase/example/lib/src/screens/purchase_flow_screen.dart
+++ b/libraries/flutter_inapp_purchase/example/lib/src/screens/purchase_flow_screen.dart
@@ -430,9 +430,19 @@ Auto Renewing: ${androidResult.autoRenewing}
         provider: PurchaseVerificationProvider.Iapkit,
         iapkit: RequestVerifyPurchaseWithIapkitProps(
           apiKey: apiKey.isNotEmpty ? apiKey : null,
-          apple: RequestVerifyPurchaseWithIapkitAppleProps(jws: jwsOrToken),
-          google: RequestVerifyPurchaseWithIapkitGoogleProps(
-              purchaseToken: jwsOrToken),
+          apple: purchase.store == IapStore.Apple
+              ? RequestVerifyPurchaseWithIapkitAppleProps(jws: jwsOrToken)
+              : null,
+          google: purchase.store == IapStore.Google
+              ? RequestVerifyPurchaseWithIapkitGoogleProps(
+                  purchaseToken: jwsOrToken,
+                )
+              : null,
+          horizon: purchase.store == IapStore.Horizon
+              ? RequestVerifyPurchaseWithIapkitHorizonProps(
+                  sku: purchase.productId,
+                )
+              : null,
         ),
       );
 

--- a/libraries/flutter_inapp_purchase/example/lib/src/screens/subscription_flow_screen.dart
+++ b/libraries/flutter_inapp_purchase/example/lib/src/screens/subscription_flow_screen.dart
@@ -325,9 +325,19 @@ Has token: ${purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpt
         provider: PurchaseVerificationProvider.Iapkit,
         iapkit: RequestVerifyPurchaseWithIapkitProps(
           apiKey: apiKey.isNotEmpty ? apiKey : null,
-          apple: RequestVerifyPurchaseWithIapkitAppleProps(jws: jwsOrToken),
-          google: RequestVerifyPurchaseWithIapkitGoogleProps(
-              purchaseToken: jwsOrToken),
+          apple: purchase.store == IapStore.Apple
+              ? RequestVerifyPurchaseWithIapkitAppleProps(jws: jwsOrToken)
+              : null,
+          google: purchase.store == IapStore.Google
+              ? RequestVerifyPurchaseWithIapkitGoogleProps(
+                  purchaseToken: jwsOrToken,
+                )
+              : null,
+          horizon: purchase.store == IapStore.Horizon
+              ? RequestVerifyPurchaseWithIapkitHorizonProps(
+                  sku: purchase.productId,
+                )
+              : null,
         ),
       );
 

--- a/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
+++ b/libraries/flutter_inapp_purchase/lib/flutter_inapp_purchase.dart
@@ -1846,6 +1846,12 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
                   if (iapkit.baseUrl != null) 'baseUrl': iapkit.baseUrl,
                   if (iapkit.google != null)
                     'google': {'purchaseToken': iapkit.google!.purchaseToken},
+                  if (iapkit.horizon != null)
+                    'horizon': {
+                      'sku': iapkit.horizon!.sku,
+                      if (iapkit.horizon!.userId != null)
+                        'userId': iapkit.horizon!.userId,
+                    },
                   if (iapkit.includeClientPayload != null)
                     'includeClientPayload': iapkit.includeClientPayload,
                   if (iapkit.amazon != null)

--- a/libraries/flutter_inapp_purchase/lib/types.dart
+++ b/libraries/flutter_inapp_purchase/lib/types.dart
@@ -5299,10 +5299,37 @@ class RequestVerifyPurchaseWithIapkitGoogleProps {
   }
 }
 
+class RequestVerifyPurchaseWithIapkitHorizonProps {
+  const RequestVerifyPurchaseWithIapkitHorizonProps({
+    required this.sku,
+    this.userId,
+  });
+
+  /// Meta Horizon product or subscription SKU.
+  final String sku;
+  /// Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+  final String? userId;
+
+  factory RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(Map<String, dynamic> json) {
+    return RequestVerifyPurchaseWithIapkitHorizonProps(
+      sku: json['sku'] as String,
+      userId: json['userId'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'sku': sku,
+      'userId': userId,
+    };
+  }
+}
+
 /// Platform-specific verification parameters for IAPKit.
 ///
 /// - apple: Verifies via App Store (JWS token)
 /// - google: Verifies via Play Store (purchase token)
+/// - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 /// - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 class RequestVerifyPurchaseWithIapkitProps {
   const RequestVerifyPurchaseWithIapkitProps({
@@ -5311,6 +5338,7 @@ class RequestVerifyPurchaseWithIapkitProps {
     this.apple,
     this.baseUrl,
     this.google,
+    this.horizon,
     this.includeClientPayload,
   });
 
@@ -5327,9 +5355,11 @@ class RequestVerifyPurchaseWithIapkitProps {
   final String? baseUrl;
   /// Google Play Store verification parameters.
   final RequestVerifyPurchaseWithIapkitGoogleProps? google;
+  /// Meta Horizon verification parameters.
+  final RequestVerifyPurchaseWithIapkitHorizonProps? horizon;
   /// Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-  /// Include the product's public IAPKit client payload in a valid Apple or
-  /// Google verification response. Defaults to false so existing response
+  /// Include the product's public IAPKit client payload in a valid verification
+  /// response. Defaults to false so existing response
   /// shapes and bandwidth remain unchanged.
   final bool? includeClientPayload;
 
@@ -5340,6 +5370,7 @@ class RequestVerifyPurchaseWithIapkitProps {
       apple: json['apple'] != null ? RequestVerifyPurchaseWithIapkitAppleProps.fromJson(json['apple'] as Map<String, dynamic>) : null,
       baseUrl: json['baseUrl'] as String?,
       google: json['google'] != null ? RequestVerifyPurchaseWithIapkitGoogleProps.fromJson(json['google'] as Map<String, dynamic>) : null,
+      horizon: json['horizon'] != null ? RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(json['horizon'] as Map<String, dynamic>) : null,
       includeClientPayload: json['includeClientPayload'] as bool?,
     );
   }
@@ -5351,6 +5382,7 @@ class RequestVerifyPurchaseWithIapkitProps {
       'apple': apple?.toJson(),
       'baseUrl': baseUrl,
       'google': google?.toJson(),
+      'horizon': horizon?.toJson(),
       'includeClientPayload': includeClientPayload,
     };
   }

--- a/libraries/flutter_inapp_purchase/test/flutter_inapp_purchase_channel_test.dart
+++ b/libraries/flutter_inapp_purchase/test/flutter_inapp_purchase_channel_test.dart
@@ -2922,6 +2922,57 @@ void main() {
       expect(iapkitPayload['baseUrl'], 'http://127.0.0.1:4174');
     });
 
+    test('sends Horizon SKU without a Google purchase token', () async {
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        calls.add(call);
+        if (call.method == 'initConnection') return true;
+        if (call.method == 'verifyPurchaseWithProvider') {
+          return {
+            'provider': 'iapkit',
+            'iapkit': {
+              'isValid': true,
+              'productId': 'premium.monthly',
+              'state': 'entitled',
+              'store': 'horizon',
+            },
+          };
+        }
+        return null;
+      });
+
+      final iap = FlutterInappPurchase.private(
+        FakePlatform(operatingSystem: 'android'),
+      );
+      await iap.initConnection();
+      await iap.verifyPurchaseWithProvider(
+        provider: types.PurchaseVerificationProvider.Iapkit,
+        iapkit: const types.RequestVerifyPurchaseWithIapkitProps(
+          apiKey: 'test-api-key',
+          horizon: types.RequestVerifyPurchaseWithIapkitHorizonProps(
+            sku: 'premium.monthly',
+          ),
+        ),
+      );
+
+      final verifyCall = calls.singleWhere(
+        (MethodCall call) => call.method == 'verifyPurchaseWithProvider',
+      );
+      final payload = Map<String, dynamic>.from(
+        verifyCall.arguments as Map<dynamic, dynamic>,
+      );
+      final iapkitPayload = Map<String, dynamic>.from(
+        payload['iapkit'] as Map<dynamic, dynamic>,
+      );
+      final horizonPayload = Map<String, dynamic>.from(
+        iapkitPayload['horizon'] as Map<dynamic, dynamic>,
+      );
+
+      expect(horizonPayload['sku'], 'premium.monthly');
+      expect(iapkitPayload, isNot(contains('google')));
+    });
+
     test('sends correct payload for Android verification', () async {
       final calls = <MethodCall>[];
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/libraries/flutter_inapp_purchase/test/flutter_inapp_purchase_channel_test.dart
+++ b/libraries/flutter_inapp_purchase/test/flutter_inapp_purchase_channel_test.dart
@@ -2952,6 +2952,7 @@ void main() {
           apiKey: 'test-api-key',
           horizon: types.RequestVerifyPurchaseWithIapkitHorizonProps(
             sku: 'premium.monthly',
+            userId: 'horizon-user-123',
           ),
         ),
       );
@@ -2970,6 +2971,7 @@ void main() {
       );
 
       expect(horizonPayload['sku'], 'premium.monthly');
+      expect(horizonPayload['userId'], 'horizon-user-123');
       expect(iapkitPayload, isNot(contains('google')));
     });
 

--- a/libraries/godot-iap/addons/godot-iap/types.gd
+++ b/libraries/godot-iap/addons/godot-iap/types.gd
@@ -5091,18 +5091,48 @@ class RequestVerifyPurchaseWithIapkitGoogleProps:
 			dict["purchaseToken"] = purchase_token
 		return dict
 
-## Platform-specific verification parameters for IAPKit. - apple: Verifies via App Store (JWS token) - google: Verifies via Play Store (purchase token) - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
+class RequestVerifyPurchaseWithIapkitHorizonProps:
+	## Meta Horizon product or subscription SKU.
+	var sku: String = ""
+	## Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+	var user_id: Variant = null
+
+	static func from_dict(data: Dictionary) -> RequestVerifyPurchaseWithIapkitHorizonProps:
+		if not data.has("sku") or not data["sku"] is String:
+			push_error("Invalid required RequestVerifyPurchaseWithIapkitHorizonProps.sku value")
+			return null
+		if data.has("userId") and data["userId"] != null and not data["userId"] is String:
+			push_error("Invalid RequestVerifyPurchaseWithIapkitHorizonProps.userId value")
+			return null
+		var obj = RequestVerifyPurchaseWithIapkitHorizonProps.new()
+		if data.has("sku") and data["sku"] != null:
+			obj.sku = data["sku"]
+		if data.has("userId") and data["userId"] != null:
+			obj.user_id = data["userId"]
+		return obj
+
+	func to_dict() -> Dictionary:
+		var dict = {}
+		if sku != null:
+			dict["sku"] = sku
+		if user_id != null:
+			dict["userId"] = user_id
+		return dict
+
+## Platform-specific verification parameters for IAPKit. - apple: Verifies via App Store (JWS token) - google: Verifies via Play Store (purchase token) - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU) - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 class RequestVerifyPurchaseWithIapkitProps:
 	## API key used for the Authorization header (Bearer {apiKey}).
 	var api_key: Variant = null
 	## Available in OpenIAP Spec 2.3.1 / openiap-apple 2.4.0 / openiap-google 2.4.0. Base URL for the IAPKit server. Defaults to https://kit.openiap.dev. Set this to a reachable HTTP(S) origin when self-hosting or testing a local IAPKit server. The apiKey must be issued by the same IAPKit/Convex deployment as this server.
 	var base_url: Variant = null
-	## Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1. Include the product's public IAPKit client payload in a valid Apple or Google verification response. Defaults to false so existing response shapes and bandwidth remain unchanged.
+	## Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1. Include the product's public IAPKit client payload in a valid verification response. Defaults to false so existing response shapes and bandwidth remain unchanged.
 	var include_client_payload: Variant = null
 	## Apple App Store verification parameters.
 	var apple: RequestVerifyPurchaseWithIapkitAppleProps
 	## Google Play Store verification parameters.
 	var google: RequestVerifyPurchaseWithIapkitGoogleProps
+	## Meta Horizon verification parameters.
+	var horizon: RequestVerifyPurchaseWithIapkitHorizonProps
 	## Amazon Appstore verification parameters.
 	var amazon: RequestVerifyPurchaseWithIapkitAmazonProps
 
@@ -5143,6 +5173,16 @@ class RequestVerifyPurchaseWithIapkitProps:
 			else:
 				push_error("Expected google to be a RequestVerifyPurchaseWithIapkitGoogleProps dictionary")
 				return null
+		if data.has("horizon") and data["horizon"] != null:
+			if data["horizon"] is Dictionary:
+				var decoded_horizon = RequestVerifyPurchaseWithIapkitHorizonProps.from_dict(data["horizon"])
+				if decoded_horizon == null:
+					push_error("Invalid input RequestVerifyPurchaseWithIapkitHorizonProps value for horizon")
+					return null
+				obj.horizon = decoded_horizon
+			else:
+				push_error("Expected horizon to be a RequestVerifyPurchaseWithIapkitHorizonProps dictionary")
+				return null
 		if data.has("amazon") and data["amazon"] != null:
 			if data["amazon"] is Dictionary:
 				var decoded_amazon = RequestVerifyPurchaseWithIapkitAmazonProps.from_dict(data["amazon"])
@@ -5173,6 +5213,11 @@ class RequestVerifyPurchaseWithIapkitProps:
 				dict["google"] = google.to_dict()
 			else:
 				dict["google"] = google
+		if horizon != null:
+			if horizon.has_method("to_dict"):
+				dict["horizon"] = horizon.to_dict()
+			else:
+				dict["horizon"] = horizon
 		if amazon != null:
 			if amazon.has_method("to_dict"):
 				dict["amazon"] = amazon.to_dict()

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -114,6 +114,7 @@ fun PurchaseFlowScreen(navController: NavController) {
                 """.trimIndent()
 
                         scope.launch {
+                            var iapkitVerificationOk = true
                             // Verify purchase based on selected method
                             if (verificationMethod != VerificationMethod.None) {
                                 verificationResult = "🔄 Verifying purchase..."
@@ -148,11 +149,13 @@ fun PurchaseFlowScreen(navController: NavController) {
                                         VerificationMethod.IAPKit -> {
                                             val apiKey = AppConfig.iapkitApiKey
                                             if (apiKey.isEmpty()) {
+                                                iapkitVerificationOk = false
                                                 verificationResult = "❌ IAPKit API key not configured.\n" +
                                                     "Set IAPKIT_API_KEY in .env file."
                                             } else {
                                                 val jwsOrToken = purchase.purchaseToken ?: ""
-                                                if (jwsOrToken.isEmpty()) {
+                                                if (jwsOrToken.isEmpty() && purchase.store != IapStore.Horizon) {
+                                                    iapkitVerificationOk = false
                                                     verificationResult = "❌ No purchase token available for verification"
                                                 } else {
                                                     val isIos = getCurrentPlatform() == IapPlatform.Ios
@@ -168,6 +171,7 @@ fun PurchaseFlowScreen(navController: NavController) {
                                                         )
                                                     )
                                                     val iapkitResult = result.iapkit
+                                                    iapkitVerificationOk = iapkitResult?.isValid == true
                                                     val statusEmoji = if (iapkitResult?.isValid == true) "✅" else "⚠️"
                                                     verificationResult = "$statusEmoji IAPKit Verification:\n" +
                                                         "Valid: ${iapkitResult?.isValid ?: false}\n" +
@@ -179,8 +183,16 @@ fun PurchaseFlowScreen(navController: NavController) {
                                         else -> {}
                                     }
                                 } catch (e: Exception) {
+                                    if (verificationMethod == VerificationMethod.IAPKit) {
+                                        iapkitVerificationOk = false
+                                    }
                                     verificationResult = "❌ Verification failed: ${e.message}"
                                 }
+                            }
+
+                            if (verificationMethod == VerificationMethod.IAPKit && !iapkitVerificationOk) {
+                                purchaseResult = "$purchaseResult\n\n⚠️ Transaction left unfinished because IAPKit verification failed"
+                                return@launch
                             }
 
                             // Finish the transaction

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -40,6 +40,8 @@ import io.github.hyochan.kmpiap.openiap.PurchaseVerificationProvider
 import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitProps
 import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitAppleProps
 import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitGoogleProps
+import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitHorizonProps
+import io.github.hyochan.kmpiap.openiap.IapStore
 import io.github.hyochan.kmpiap.openiap.IapPlatform
 import io.github.hyochan.kmpiap.openiap.VerifyPurchaseResultIOS
 import io.github.hyochan.kmpiap.openiap.VerifyPurchaseResultAndroid
@@ -160,7 +162,8 @@ fun PurchaseFlowScreen(navController: NavController) {
                                                             iapkit = RequestVerifyPurchaseWithIapkitProps(
                                                                 apiKey = apiKey,
                                                                 apple = if (isIos) RequestVerifyPurchaseWithIapkitAppleProps(jws = jwsOrToken) else null,
-                                                                google = if (!isIos) RequestVerifyPurchaseWithIapkitGoogleProps(purchaseToken = jwsOrToken) else null
+                                                                google = if (!isIos && purchase.store == IapStore.Google) RequestVerifyPurchaseWithIapkitGoogleProps(purchaseToken = jwsOrToken) else null,
+                                                                horizon = if (purchase.store == IapStore.Horizon) RequestVerifyPurchaseWithIapkitHorizonProps(sku = purchase.productId) else null,
                                                             )
                                                         )
                                                     )

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -114,12 +114,13 @@ fun PurchaseFlowScreen(navController: NavController) {
                 """.trimIndent()
 
                         scope.launch {
+                            val verificationMethodAtStart = verificationMethod
                             var iapkitVerificationOk = true
                             // Verify purchase based on selected method
-                            if (verificationMethod != VerificationMethod.None) {
+                            if (verificationMethodAtStart != VerificationMethod.None) {
                                 verificationResult = "🔄 Verifying purchase..."
                                 try {
-                                    when (verificationMethod) {
+                                    when (verificationMethodAtStart) {
                                         VerificationMethod.Local -> {
                                             val isIos = getCurrentPlatform() == IapPlatform.Ios
                                             val result = kmpIapInstance.verifyPurchase(
@@ -183,14 +184,14 @@ fun PurchaseFlowScreen(navController: NavController) {
                                         else -> {}
                                     }
                                 } catch (e: Exception) {
-                                    if (verificationMethod == VerificationMethod.IAPKit) {
+                                    if (verificationMethodAtStart == VerificationMethod.IAPKit) {
                                         iapkitVerificationOk = false
                                     }
                                     verificationResult = "❌ Verification failed: ${e.message}"
                                 }
                             }
 
-                            if (verificationMethod == VerificationMethod.IAPKit && !iapkitVerificationOk) {
+                            if (verificationMethodAtStart == VerificationMethod.IAPKit && !iapkitVerificationOk) {
                                 purchaseResult = "$purchaseResult\n\n⚠️ Transaction left unfinished because IAPKit verification failed"
                                 return@launch
                             }

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -120,6 +120,7 @@ fun SubscriptionFlowScreen(navController: NavController) {
                 """.trimIndent()
 
                         scope.launch {
+                            var iapkitVerificationOk = true
                             // Verify purchase based on selected method
                             if (verificationMethod != VerificationMethod.None) {
                                 verificationResult = "🔄 Verifying subscription..."
@@ -154,11 +155,13 @@ fun SubscriptionFlowScreen(navController: NavController) {
                                         VerificationMethod.IAPKit -> {
                                             val apiKey = AppConfig.iapkitApiKey
                                             if (apiKey.isEmpty()) {
+                                                iapkitVerificationOk = false
                                                 verificationResult = "❌ IAPKit API key not configured.\n" +
                                                     "Set IAPKIT_API_KEY in .env file."
                                             } else {
                                                 val jwsOrToken = purchase.purchaseToken ?: ""
-                                                if (jwsOrToken.isEmpty()) {
+                                                if (jwsOrToken.isEmpty() && purchase.store != IapStore.Horizon) {
+                                                    iapkitVerificationOk = false
                                                     verificationResult = "❌ No purchase token available for verification"
                                                 } else {
                                                     val isIos = getCurrentPlatform() == IapPlatform.Ios
@@ -174,6 +177,7 @@ fun SubscriptionFlowScreen(navController: NavController) {
                                                         )
                                                     )
                                                     val iapkitResult = result.iapkit
+                                                    iapkitVerificationOk = iapkitResult?.isValid == true
                                                     val statusEmoji = if (iapkitResult?.isValid == true) "✅" else "⚠️"
                                                     verificationResult = "$statusEmoji IAPKit Verification:\n" +
                                                         "Valid: ${iapkitResult?.isValid ?: false}\n" +
@@ -185,8 +189,16 @@ fun SubscriptionFlowScreen(navController: NavController) {
                                         else -> {}
                                     }
                                 } catch (e: Exception) {
+                                    if (verificationMethod == VerificationMethod.IAPKit) {
+                                        iapkitVerificationOk = false
+                                    }
                                     verificationResult = "❌ Verification failed: ${e.message}"
                                 }
+                            }
+
+                            if (verificationMethod == VerificationMethod.IAPKit && !iapkitVerificationOk) {
+                                purchaseResult = "$purchaseResult\n\n⚠️ Transaction left unfinished because IAPKit verification failed"
+                                return@launch
                             }
 
                             // Finish the transaction

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -120,12 +120,13 @@ fun SubscriptionFlowScreen(navController: NavController) {
                 """.trimIndent()
 
                         scope.launch {
+                            val verificationMethodAtStart = verificationMethod
                             var iapkitVerificationOk = true
                             // Verify purchase based on selected method
-                            if (verificationMethod != VerificationMethod.None) {
+                            if (verificationMethodAtStart != VerificationMethod.None) {
                                 verificationResult = "🔄 Verifying subscription..."
                                 try {
-                                    when (verificationMethod) {
+                                    when (verificationMethodAtStart) {
                                         VerificationMethod.Local -> {
                                             val isIos = getCurrentPlatform() == IapPlatform.Ios
                                             val result = kmpIAP.verifyPurchase(
@@ -189,14 +190,14 @@ fun SubscriptionFlowScreen(navController: NavController) {
                                         else -> {}
                                     }
                                 } catch (e: Exception) {
-                                    if (verificationMethod == VerificationMethod.IAPKit) {
+                                    if (verificationMethodAtStart == VerificationMethod.IAPKit) {
                                         iapkitVerificationOk = false
                                     }
                                     verificationResult = "❌ Verification failed: ${e.message}"
                                 }
                             }
 
-                            if (verificationMethod == VerificationMethod.IAPKit && !iapkitVerificationOk) {
+                            if (verificationMethodAtStart == VerificationMethod.IAPKit && !iapkitVerificationOk) {
                                 purchaseResult = "$purchaseResult\n\n⚠️ Transaction left unfinished because IAPKit verification failed"
                                 return@launch
                             }

--- a/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/libraries/kmp-iap/example/composeApp/src/commonMain/kotlin/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -48,6 +48,8 @@ import io.github.hyochan.kmpiap.openiap.PurchaseVerificationProvider
 import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitProps
 import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitAppleProps
 import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitGoogleProps
+import io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitHorizonProps
+import io.github.hyochan.kmpiap.openiap.IapStore
 import io.github.hyochan.kmpiap.openiap.VerifyPurchaseResultIOS
 import io.github.hyochan.kmpiap.openiap.VerifyPurchaseResultAndroid
 import io.github.hyochan.kmpiap.openiap.VerifyPurchaseResultHorizon
@@ -166,7 +168,8 @@ fun SubscriptionFlowScreen(navController: NavController) {
                                                             iapkit = RequestVerifyPurchaseWithIapkitProps(
                                                                 apiKey = apiKey,
                                                                 apple = if (isIos) RequestVerifyPurchaseWithIapkitAppleProps(jws = jwsOrToken) else null,
-                                                                google = if (!isIos) RequestVerifyPurchaseWithIapkitGoogleProps(purchaseToken = jwsOrToken) else null
+                                                                google = if (!isIos && purchase.store == IapStore.Google) RequestVerifyPurchaseWithIapkitGoogleProps(purchaseToken = jwsOrToken) else null,
+                                                                horizon = if (purchase.store == IapStore.Horizon) RequestVerifyPurchaseWithIapkitHorizonProps(sku = purchase.productId) else null,
                                                             )
                                                         )
                                                     )

--- a/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
+++ b/libraries/kmp-iap/library/src/androidMain/kotlin/io/github/hyochan/kmpiap/InAppPurchaseAndroid.kt
@@ -116,6 +116,7 @@ import io.github.hyochan.kmpiap.openiap.SubscriptionProductReplacementParamsAndr
 import io.github.hyochan.kmpiap.openiap.SubscriptionReplacementModeAndroid
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitAmazonProps as AndroidVerifyPurchaseWithIapkitAmazonProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitGoogleProps as AndroidVerifyPurchaseWithIapkitGoogleProps
+import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitHorizonProps as AndroidVerifyPurchaseWithIapkitHorizonProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitProps as AndroidVerifyPurchaseWithIapkitProps
 import dev.hyo.openiap.VerifyPurchaseGoogleOptions as AndroidVerifyPurchaseGoogleOptions
 import dev.hyo.openiap.VerifyPurchaseProps as AndroidVerifyPurchaseProps
@@ -2242,15 +2243,17 @@ internal class InAppPurchaseAndroid(
         val payloadCount = listOfNotNull(
             iapkitOptions.apple,
             iapkitOptions.google,
+            iapkitOptions.horizon,
             iapkitOptions.amazon
         ).size
         val googleOptions = iapkitOptions.google
+        val horizonOptions = iapkitOptions.horizon
         val amazonOptions = iapkitOptions.amazon
-        if (payloadCount != 1 || (googleOptions == null && amazonOptions == null)) {
+        if (payloadCount != 1 || (googleOptions == null && horizonOptions == null && amazonOptions == null)) {
             failWith(
                 PurchaseError(
                     code = ErrorCode.PurchaseVerificationFailed,
-                    message = "IAPKit verification on KMP Android requires exactly one google or amazon payload"
+                    message = "IAPKit verification on KMP Android requires exactly one google, horizon, or amazon payload"
                 )
             )
         }
@@ -2273,7 +2276,13 @@ internal class InAppPurchaseAndroid(
                         purchaseToken = google.purchaseToken
                     )
                 },
-                includeClientPayload = iapkitOptions.includeClientPayload
+                includeClientPayload = iapkitOptions.includeClientPayload,
+                horizon = horizonOptions?.let { horizon ->
+                    AndroidVerifyPurchaseWithIapkitHorizonProps(
+                        sku = horizon.sku,
+                        userId = horizon.userId,
+                    )
+                },
             )
 
             val androidResult = verifyPurchaseWithIapkitAndroid(openIapProps, "kmp-iap-android")

--- a/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/KmpIap.kt
+++ b/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/KmpIap.kt
@@ -77,6 +77,7 @@ typealias RequestVerifyPurchaseWithIapkitProps = io.github.hyochan.kmpiap.openia
 typealias RequestVerifyPurchaseWithIapkitAmazonProps = io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitAmazonProps
 typealias RequestVerifyPurchaseWithIapkitAppleProps = io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitAppleProps
 typealias RequestVerifyPurchaseWithIapkitGoogleProps = io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitGoogleProps
+typealias RequestVerifyPurchaseWithIapkitHorizonProps = io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitHorizonProps
 typealias RequestVerifyPurchaseWithIapkitResult = io.github.hyochan.kmpiap.openiap.RequestVerifyPurchaseWithIapkitResult
 typealias IapkitPurchaseState = io.github.hyochan.kmpiap.openiap.IapkitPurchaseState
 typealias IapStore = io.github.hyochan.kmpiap.openiap.IapStore

--- a/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
+++ b/libraries/kmp-iap/library/src/commonMain/kotlin/io/github/hyochan/kmpiap/openiap/Types.kt
@@ -5267,11 +5267,40 @@ public data class RequestVerifyPurchaseWithIapkitGoogleProps(
     )
 }
 
+public data class RequestVerifyPurchaseWithIapkitHorizonProps(
+    /**
+     * Meta Horizon product or subscription SKU.
+     */
+    val sku: String,
+    /**
+     * Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+     */
+    val userId: String? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestVerifyPurchaseWithIapkitHorizonProps? {
+            val sku = json["sku"] as? String
+            val userId = json["userId"]?.let { raw -> (raw as? String) ?: throw IllegalArgumentException("Invalid String input value") }
+            if (sku == null) return null
+            return RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = sku,
+                userId = userId,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "sku" to sku,
+        "userId" to userId,
+    )
+}
+
 /**
  * Platform-specific verification parameters for IAPKit.
  *
  * - apple: Verifies via App Store (JWS token)
  * - google: Verifies via Play Store (purchase token)
+ * - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
  * - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
  */
 public data class RequestVerifyPurchaseWithIapkitProps(
@@ -5302,11 +5331,17 @@ public data class RequestVerifyPurchaseWithIapkitProps(
 
     /**
      * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-     * Include the product's public IAPKit client payload in a valid Apple or
-     * Google verification response. Defaults to false so existing response
+     * Include the product's public IAPKit client payload in a valid verification
+     * response. Defaults to false so existing response
      * shapes and bandwidth remain unchanged.
      */
     var includeClientPayload: Boolean? = null
+        private set
+
+    /**
+     * Meta Horizon verification parameters.
+     */
+    var horizon: RequestVerifyPurchaseWithIapkitHorizonProps? = null
         private set
 
     constructor(
@@ -5326,6 +5361,25 @@ public data class RequestVerifyPurchaseWithIapkitProps(
         this.includeClientPayload = includeClientPayload
     }
 
+    constructor(
+        amazon: RequestVerifyPurchaseWithIapkitAmazonProps? = null,
+        apiKey: String? = null,
+        apple: RequestVerifyPurchaseWithIapkitAppleProps? = null,
+        baseUrl: String? = null,
+        google: RequestVerifyPurchaseWithIapkitGoogleProps? = null,
+        includeClientPayload: Boolean? = null,
+        horizon: RequestVerifyPurchaseWithIapkitHorizonProps?,
+    ) : this(
+        amazon = amazon,
+        apiKey = apiKey,
+        apple = apple,
+        baseUrl = baseUrl,
+        google = google,
+    ) {
+        this.includeClientPayload = includeClientPayload
+        this.horizon = horizon
+    }
+
     companion object {
         fun fromJson(json: Map<String, Any?>): RequestVerifyPurchaseWithIapkitProps {
             return RequestVerifyPurchaseWithIapkitProps(
@@ -5335,6 +5389,7 @@ public data class RequestVerifyPurchaseWithIapkitProps(
                 baseUrl = json["baseUrl"]?.let { raw -> (raw as? String) ?: throw IllegalArgumentException("Invalid String input value") },
                 google = json["google"]?.let { value -> (value as? Map<String, Any?>)?.let { RequestVerifyPurchaseWithIapkitGoogleProps.fromJson(it) } ?: throw IllegalArgumentException("Invalid input object for RequestVerifyPurchaseWithIapkitGoogleProps") },
                 includeClientPayload = json["includeClientPayload"]?.let { raw -> (raw as? Boolean) ?: throw IllegalArgumentException("Invalid Boolean input value") },
+                horizon = json["horizon"]?.let { value -> (value as? Map<String, Any?>)?.let { RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(it) } ?: throw IllegalArgumentException("Invalid input object for RequestVerifyPurchaseWithIapkitHorizonProps") },
             )
         }
     }
@@ -5345,6 +5400,7 @@ public data class RequestVerifyPurchaseWithIapkitProps(
         "includeClientPayload" to includeClientPayload,
         "apple" to apple?.toJson(),
         "google" to google?.toJson(),
+        "horizon" to horizon?.toJson(),
         "amazon" to amazon?.toJson(),
     )
 }

--- a/libraries/kmp-iap/library/src/commonTest/kotlin/io/github/hyochan/kmpiap/VerificationTest.kt
+++ b/libraries/kmp-iap/library/src/commonTest/kotlin/io/github/hyochan/kmpiap/VerificationTest.kt
@@ -447,6 +447,21 @@ class VerificationTest {
     }
 
     @Test
+    fun testRequestVerifyPurchaseWithIapkitPropsHorizon() {
+        val props = RequestVerifyPurchaseWithIapkitProps(
+            apiKey = "test-api-key",
+            horizon = RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = "premium.monthly"
+            )
+        )
+
+        assertEquals("premium.monthly", props.horizon?.sku)
+        assertNull(props.horizon?.userId)
+        val restored = RequestVerifyPurchaseWithIapkitProps.fromJson(props.toJson())
+        assertEquals("premium.monthly", restored.horizon?.sku)
+    }
+
+    @Test
     fun testRequestVerifyPurchaseWithIapkitPropsToJson() {
         val props = RequestVerifyPurchaseWithIapkitProps(
             apiKey = "key123",

--- a/libraries/maui-iap/example/OpenIap.Maui.Example/Utils/IapKitSettings.cs
+++ b/libraries/maui-iap/example/OpenIap.Maui.Example/Utils/IapKitSettings.cs
@@ -53,6 +53,15 @@ internal static class IapKitSettings
                 BaseUrl = BaseUrl,
                 Google = new RequestVerifyPurchaseWithIapkitGoogleProps { PurchaseToken = token },
             },
+            IapStore.Horizon => new RequestVerifyPurchaseWithIapkitProps
+            {
+                ApiKey = ApiKey,
+                BaseUrl = BaseUrl,
+                Horizon = new RequestVerifyPurchaseWithIapkitHorizonProps
+                {
+                    Sku = common.ProductId,
+                },
+            },
             IapStore.Amazon => new RequestVerifyPurchaseWithIapkitProps
             {
                 ApiKey = ApiKey,

--- a/libraries/maui-iap/src/OpenIap.Maui/Types.cs
+++ b/libraries/maui-iap/src/OpenIap.Maui/Types.cs
@@ -4707,11 +4707,22 @@ public sealed record RequestVerifyPurchaseWithIapkitGoogleProps
     public required string PurchaseToken { get; init; }
 }
 
+public sealed record RequestVerifyPurchaseWithIapkitHorizonProps
+{
+    /// <summary>Meta Horizon product or subscription SKU.</summary>
+    [JsonPropertyName("sku")]
+    public required string Sku { get; init; }
+    /// <summary>Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.</summary>
+    [JsonPropertyName("userId")]
+    public string? UserId { get; init; }
+}
+
 /// <summary>
 /// Platform-specific verification parameters for IAPKit.
 ///
 /// - apple: Verifies via App Store (JWS token)
 /// - google: Verifies via Play Store (purchase token)
+/// - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 /// - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 /// </summary>
 public sealed record RequestVerifyPurchaseWithIapkitProps
@@ -4729,8 +4740,8 @@ public sealed record RequestVerifyPurchaseWithIapkitProps
     public string? BaseUrl { get; init; }
     /// <summary>
     /// Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-    /// Include the product&apos;s public IAPKit client payload in a valid Apple or
-    /// Google verification response. Defaults to false so existing response
+    /// Include the product&apos;s public IAPKit client payload in a valid verification
+    /// response. Defaults to false so existing response
     /// shapes and bandwidth remain unchanged.
     /// </summary>
     [JsonPropertyName("includeClientPayload")]
@@ -4741,6 +4752,9 @@ public sealed record RequestVerifyPurchaseWithIapkitProps
     /// <summary>Google Play Store verification parameters.</summary>
     [JsonPropertyName("google")]
     public RequestVerifyPurchaseWithIapkitGoogleProps? Google { get; init; }
+    /// <summary>Meta Horizon verification parameters.</summary>
+    [JsonPropertyName("horizon")]
+    public RequestVerifyPurchaseWithIapkitHorizonProps? Horizon { get; init; }
     /// <summary>Amazon Appstore verification parameters.</summary>
     [JsonPropertyName("amazon")]
     public RequestVerifyPurchaseWithIapkitAmazonProps? Amazon { get; init; }

--- a/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/libraries/react-native-iap/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -1678,6 +1678,11 @@ class HybridRnIap : HybridRnIapSpec() {
                     (iapkit.google as? Variant_NullType_NitroVerifyPurchaseWithIapkitGoogleProps.Second)?.value?.let { google ->
                         iapkitMap["google"] = mapOf("purchaseToken" to google.purchaseToken)
                     }
+                    (iapkit.horizon as? Variant_NullType_NitroVerifyPurchaseWithIapkitHorizonProps.Second)?.value?.let { horizon ->
+                        val horizonMap = mutableMapOf<String, Any?>("sku" to horizon.sku)
+                        horizon.userId.unwrapString()?.let { horizonMap["userId"] = it }
+                        iapkitMap["horizon"] = horizonMap
+                    }
                     (iapkit.amazon as? Variant_NullType_NitroVerifyPurchaseWithIapkitAmazonProps.Second)?.value?.let { amazon ->
                         val amazonMap = mutableMapOf<String, Any?>(
                             "receiptId" to amazon.receiptId

--- a/libraries/react-native-iap/example/__tests__/utils/vegaRuntime.test.ts
+++ b/libraries/react-native-iap/example/__tests__/utils/vegaRuntime.test.ts
@@ -55,6 +55,28 @@ describe('Vega runtime example helpers', () => {
     });
   });
 
+  it('uses Horizon verification without treating the purchase ID as a user ID', () => {
+    const payload = createIapkitVerificationPayload(
+      {
+        id: 'purchase-id-1',
+        productId: 'dev.hyo.martie.premium',
+        purchaseToken: 'purchase-id-1',
+        store: 'horizon',
+      } as unknown as Purchase,
+      'purchase-id-1',
+      'test-api-key',
+      false,
+      'http://localhost:3100',
+    );
+
+    expect(payload).toMatchObject({
+      apiKey: 'test-api-key',
+      baseUrl: 'http://localhost:3100',
+      horizon: {sku: 'dev.hyo.martie.premium'},
+    });
+    expect(payload).not.toHaveProperty('google');
+  });
+
   it('uses Apple verification when purchase store is Apple', () => {
     const payload = createIapkitVerificationPayload(
       {

--- a/libraries/react-native-iap/example/src/utils/vegaRuntime.ts
+++ b/libraries/react-native-iap/example/src/utils/vegaRuntime.ts
@@ -68,6 +68,8 @@ function isIapkitStateReadyForFulfillment(
         verified.state === 'pending-acknowledgment' ||
         (isConsumable && verified.state === 'ready-to-consume')
       );
+    case 'horizon':
+      return verified.state === 'entitled';
     default:
       return false;
   }
@@ -169,6 +171,15 @@ export function createIapkitVerificationPayload(
           receiptId: purchaseToken,
           sandbox: amazonRvsSandbox,
         },
+      },
+      baseUrl,
+    );
+  }
+  if (purchaseStore === 'horizon') {
+    return withIapkitEndpoint(
+      {
+        apiKey: trimmedApiKey,
+        horizon: {sku: purchase.productId},
       },
       baseUrl,
     );

--- a/libraries/react-native-iap/ios/HybridRnIap.swift
+++ b/libraries/react-native-iap/ios/HybridRnIap.swift
@@ -619,6 +619,13 @@ class HybridRnIap: HybridRnIapSpec {
                     if case .second(let google) = iapkit.google {
                         iapkitDict["google"] = ["purchaseToken": google.purchaseToken]
                     }
+                    if case .second(let horizon) = iapkit.horizon {
+                        var horizonDict: [String: Any] = ["sku": horizon.sku]
+                        if case .second(let userId) = horizon.userId {
+                            horizonDict["userId"] = userId
+                        }
+                        iapkitDict["horizon"] = horizonDict
+                    }
                     if case .second(let amazon) = iapkit.amazon {
                         var amazonDict: [String: Any] = [
                             "receiptId": amazon.receiptId

--- a/libraries/react-native-iap/src/__tests__/iapkit-base-url-bridge.test.js
+++ b/libraries/react-native-iap/src/__tests__/iapkit-base-url-bridge.test.js
@@ -57,4 +57,22 @@ describe('IAPKit native bridge parity', () => {
       'environment = item.environment?.let { Variant_NullType_String.Second(it) }',
     );
   });
+
+  it('forwards Horizon SKU and optional user ID through both native maps', () => {
+    const spec = readSource('src/specs/RnIap.nitro.ts');
+    const ios = readSource('ios/HybridRnIap.swift');
+    const android = readSource(
+      'android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt',
+    );
+
+    expect(spec).toMatch(
+      /interface NitroVerifyPurchaseWithIapkitHorizonProps[\s\S]*?sku: string;[\s\S]*?userId\?: string \| null;/,
+    );
+    expect(ios).toContain('if case .second(let horizon) = iapkit.horizon');
+    expect(ios).toContain('iapkitDict["horizon"] = horizonDict');
+    expect(android).toContain(
+      '(iapkit.horizon as? Variant_NullType_NitroVerifyPurchaseWithIapkitHorizonProps.Second)',
+    );
+    expect(android).toContain('iapkitMap["horizon"] = horizonMap');
+  });
 });

--- a/libraries/react-native-iap/src/specs/RnIap.nitro.ts
+++ b/libraries/react-native-iap/src/specs/RnIap.nitro.ts
@@ -452,6 +452,13 @@ export interface NitroVerifyPurchaseWithIapkitGoogleProps {
   purchaseToken: string;
 }
 
+export interface NitroVerifyPurchaseWithIapkitHorizonProps {
+  /** Meta Horizon product or subscription SKU. */
+  sku: string;
+  /** Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted. */
+  userId?: string | null;
+}
+
 export interface NitroVerifyPurchaseWithIapkitAmazonProps {
   /** Available in OpenIAP Spec 3.2.0 / openiap-apple 3.2.0 / openiap-google 3.3.0. Optional Amazon product id that must match the product id verified by RVS. */
   expectedProductId?: string | null;
@@ -474,6 +481,7 @@ export interface NitroVerifyPurchaseWithIapkitProps {
    */
   baseUrl?: string | null;
   google?: NitroVerifyPurchaseWithIapkitGoogleProps | null;
+  horizon?: NitroVerifyPurchaseWithIapkitHorizonProps | null;
   /**
    * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
    * Include the product's public IAPKit client payload when available.

--- a/libraries/react-native-iap/src/types.ts
+++ b/libraries/react-native-iap/src/types.ts
@@ -1828,11 +1828,19 @@ export interface RequestVerifyPurchaseWithIapkitGoogleProps {
   purchaseToken: string;
 }
 
+export interface RequestVerifyPurchaseWithIapkitHorizonProps {
+  /** Meta Horizon product or subscription SKU. */
+  sku: string;
+  /** Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted. */
+  userId?: (string | null);
+}
+
 /**
  * Platform-specific verification parameters for IAPKit.
  *
  * - apple: Verifies via App Store (JWS token)
  * - google: Verifies via Play Store (purchase token)
+ * - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
  * - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
  */
 export interface RequestVerifyPurchaseWithIapkitProps {
@@ -1851,10 +1859,12 @@ export interface RequestVerifyPurchaseWithIapkitProps {
   baseUrl?: (string | null);
   /** Google Play Store verification parameters. */
   google?: (RequestVerifyPurchaseWithIapkitGoogleProps | null);
+  /** Meta Horizon verification parameters. */
+  horizon?: (RequestVerifyPurchaseWithIapkitHorizonProps | null);
   /**
    * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-   * Include the product's public IAPKit client payload in a valid Apple or
-   * Google verification response. Defaults to false so existing response
+   * Include the product's public IAPKit client payload in a valid verification
+   * response. Defaults to false so existing response
    * shapes and bandwidth remain unchanged.
    */
   includeClientPayload?: (boolean | null);

--- a/packages/apple/Sources/Models/Types.swift
+++ b/packages/apple/Sources/Models/Types.swift
@@ -2096,10 +2096,26 @@ public struct RequestVerifyPurchaseWithIapkitGoogleProps: Codable {
     }
 }
 
+public struct RequestVerifyPurchaseWithIapkitHorizonProps: Codable {
+    /// Meta Horizon product or subscription SKU.
+    public var sku: String
+    /// Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+    public var userId: String?
+
+    public init(
+        sku: String,
+        userId: String? = nil
+    ) {
+        self.sku = sku
+        self.userId = userId
+    }
+}
+
 /// Platform-specific verification parameters for IAPKit.
 ///
 /// - apple: Verifies via App Store (JWS token)
 /// - google: Verifies via Play Store (purchase token)
+/// - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 /// - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 public struct RequestVerifyPurchaseWithIapkitProps: Codable {
     /// Amazon Appstore verification parameters.
@@ -2115,9 +2131,11 @@ public struct RequestVerifyPurchaseWithIapkitProps: Codable {
     public var baseUrl: String?
     /// Google Play Store verification parameters.
     public var google: RequestVerifyPurchaseWithIapkitGoogleProps?
+    /// Meta Horizon verification parameters.
+    public var horizon: RequestVerifyPurchaseWithIapkitHorizonProps?
     /// Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-    /// Include the product's public IAPKit client payload in a valid Apple or
-    /// Google verification response. Defaults to false so existing response
+    /// Include the product's public IAPKit client payload in a valid verification
+    /// response. Defaults to false so existing response
     /// shapes and bandwidth remain unchanged.
     public var includeClientPayload: Bool?
 
@@ -2127,6 +2145,7 @@ public struct RequestVerifyPurchaseWithIapkitProps: Codable {
         apple: RequestVerifyPurchaseWithIapkitAppleProps? = nil,
         baseUrl: String? = nil,
         google: RequestVerifyPurchaseWithIapkitGoogleProps? = nil,
+        horizon: RequestVerifyPurchaseWithIapkitHorizonProps? = nil,
         includeClientPayload: Bool? = nil
     ) {
         self.amazon = amazon
@@ -2134,6 +2153,7 @@ public struct RequestVerifyPurchaseWithIapkitProps: Codable {
         self.apple = apple
         self.baseUrl = baseUrl
         self.google = google
+        self.horizon = horizon
         self.includeClientPayload = includeClientPayload
     }
 }

--- a/packages/apple/Sources/OpenIapModule.swift
+++ b/packages/apple/Sources/OpenIapModule.swift
@@ -16,6 +16,13 @@ struct IapkitAmazonVerificationPayload: Codable {
     let includeClientPayload: Bool?
 }
 
+struct IapkitHorizonVerificationPayload: Codable {
+    let store: IapStore
+    let sku: String
+    let userId: String
+    let includeClientPayload: Bool?
+}
+
 struct EntitlementSelectionKey: Comparable {
     let purchaseDate: Date
     let transactionId: UInt64
@@ -165,6 +172,26 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
             receiptId: receiptId,
             sandbox: amazon.sandbox,
             userId: userId?.isEmpty == true ? nil : userId,
+            includeClientPayload: includeClientPayload
+        )
+    }
+
+    static func iapkitHorizonPayload(
+        from horizon: RequestVerifyPurchaseWithIapkitHorizonProps,
+        includeClientPayload: Bool?
+    ) throws -> IapkitHorizonVerificationPayload {
+        let sku = horizon.sku.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userId = horizon.userId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard sku.isEmpty == false, userId.isEmpty == false else {
+            throw PurchaseError.make(
+                code: .developerError,
+                message: "Horizon sku and userId are required"
+            )
+        }
+        return IapkitHorizonVerificationPayload(
+            store: .horizon,
+            sku: sku,
+            userId: userId,
             includeClientPayload: includeClientPayload
         )
     }
@@ -927,7 +954,12 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
         func buildIapkitPayload(props: RequestVerifyPurchaseWithIapkitProps) throws -> (store: IapStore, body: Data) {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.withoutEscapingSlashes]
-            let payloadCount = [props.apple != nil, props.google != nil, props.amazon != nil].filter { $0 }.count
+            let payloadCount = [
+                props.apple != nil,
+                props.google != nil,
+                props.horizon != nil,
+                props.amazon != nil,
+            ].filter { $0 }.count
             guard payloadCount == 1 else {
                 throw makePurchaseError(code: .developerError, message: "IAPKit verification requires exactly one store payload")
             }
@@ -956,6 +988,14 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
                     includeClientPayload: props.includeClientPayload
                 )
                 return (.google, try encoder.encode(payload))
+            }
+
+            if let horizon = props.horizon {
+                let payload = try Self.iapkitHorizonPayload(
+                    from: horizon,
+                    includeClientPayload: props.includeClientPayload
+                )
+                return (.horizon, try encoder.encode(payload))
             }
 
             if let amazon = props.amazon {

--- a/packages/apple/Tests/OpenIapTests/VerifyPurchaseWithProviderTests.swift
+++ b/packages/apple/Tests/OpenIapTests/VerifyPurchaseWithProviderTests.swift
@@ -220,6 +220,21 @@ final class VerifyPurchaseWithProviderTests: XCTestCase {
         XCTAssertEqual("premium.monthly", body["expectedProductId"] as? String)
     }
 
+    func testIapkitHorizonPayloadForwardsUserAndSku() throws {
+        let payload = try OpenIapModule.iapkitHorizonPayload(
+            from: RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku: "  premium.monthly  ",
+                userId: "  123456789  "
+            ),
+            includeClientPayload: true
+        )
+
+        XCTAssertEqual(.horizon, payload.store)
+        XCTAssertEqual("premium.monthly", payload.sku)
+        XCTAssertEqual("123456789", payload.userId)
+        XCTAssertEqual(true, payload.includeClientPayload)
+    }
+
     @MainActor
     func testStoreReturnsIapkitResult() async throws {
         let iapkitResult = RequestVerifyPurchaseWithIapkitResult(

--- a/packages/google/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/packages/google/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -38,9 +38,12 @@ import dev.hyo.openiap.RequestSubscriptionAndroidProps
 import dev.hyo.openiap.RequestSubscriptionPropsByPlatforms
 import dev.hyo.openiap.utils.toPurchaseInput
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitGoogleProps
+import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitHorizonProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitResult
-import dev.hyo.openiap.utils.verifyPurchaseWithIapkit
+import dev.hyo.openiap.IapStore
+import dev.hyo.openiap.PurchaseVerificationProvider
+import dev.hyo.openiap.VerifyPurchaseWithProviderProps
 import dev.hyo.martie.BuildConfig
 
 enum class VerificationMethod(val displayName: String) {
@@ -531,14 +534,23 @@ fun PurchaseFlowScreen(
 
         val props = RequestVerifyPurchaseWithIapkitProps(
             apiKey = apiKey,
-            apple = null,
-            google = RequestVerifyPurchaseWithIapkitGoogleProps(
-                purchaseToken = token
-            ),
+            google = if (purchase.store == IapStore.Google) {
+                RequestVerifyPurchaseWithIapkitGoogleProps(purchaseToken = token)
+            } else null,
+            horizon = if (purchase.store == IapStore.Horizon) {
+                RequestVerifyPurchaseWithIapkitHorizonProps(sku = purchase.productId)
+            } else null,
             // Client payload is public configuration, never entitlement authority or secrets.
             includeClientPayload = true
         )
-        return verifyPurchaseWithIapkit(props, "PurchaseFlowScreen")
+        return requireNotNull(
+            iapStore.verifyPurchaseWithProvider(
+                VerifyPurchaseWithProviderProps(
+                    iapkit = props,
+                    provider = PurchaseVerificationProvider.Iapkit,
+                )
+            ).iapkit
+        ) { "IAPKit returned no verification result" }
     }
 
     // Local verification: For Android, we just check if the purchase state is authentic

--- a/packages/google/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/packages/google/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -39,10 +39,13 @@ import dev.hyo.openiap.RequestSubscriptionAndroidProps
 import dev.hyo.openiap.RequestSubscriptionPropsByPlatforms
 import dev.hyo.openiap.AndroidSubscriptionOfferInput
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitGoogleProps
+import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitHorizonProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitProps
+import dev.hyo.openiap.IapStore
+import dev.hyo.openiap.PurchaseVerificationProvider
+import dev.hyo.openiap.VerifyPurchaseWithProviderProps
 import dev.hyo.openiap.SubscriptionProductReplacementParamsAndroid
 import dev.hyo.openiap.SubscriptionReplacementModeAndroid
-import dev.hyo.openiap.utils.verifyPurchaseWithIapkit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -1340,13 +1343,20 @@ fun SubscriptionFlowScreen(
 
         val props = RequestVerifyPurchaseWithIapkitProps(
             apiKey = apiKey,
-            apple = null,
-            google = RequestVerifyPurchaseWithIapkitGoogleProps(
-                purchaseToken = token
+            google = if (purchase.store == IapStore.Google) {
+                RequestVerifyPurchaseWithIapkitGoogleProps(purchaseToken = token)
+            } else null,
+            horizon = if (purchase.store == IapStore.Horizon) {
+                RequestVerifyPurchaseWithIapkitHorizonProps(sku = purchase.productId)
+            } else null,
+        )
+        val result = iapStore.verifyPurchaseWithProvider(
+            VerifyPurchaseWithProviderProps(
+                iapkit = props,
+                provider = PurchaseVerificationProvider.Iapkit,
             )
         )
-        val result = verifyPurchaseWithIapkit(props, "SubscriptionFlowScreen")
-        return result.isValid
+        return result.iapkit?.isValid == true
     }
 
     // Local verification: For Android, we just check if the purchase state is authentic

--- a/packages/google/openiap/build.gradle.kts
+++ b/packages/google/openiap/build.gradle.kts
@@ -213,7 +213,7 @@ dependencies {
     // platform SDK modules transitively; do not also ship the legacy OVR SDK.
     add("horizonCompileOnly", "com.meta.horizon.billingclient.api:horizon-billing-compatibility:$horizonBillingCompatibilityVersion")
     add("horizonApi", "com.meta.horizon.billingclient.api:horizon-billing-compatibility:$horizonBillingCompatibilityVersion")
-    for (module in listOf("core-kotlin", "user-age-category-kotlin", "iap-kotlin")) {
+    for (module in listOf("core-kotlin", "user-age-category-kotlin", "iap-kotlin", "users-kotlin")) {
         add("horizonApi", "com.meta.horizon.platform.sdk:$module:$horizonPlatformKotlinVersion")
     }
     add("horizonApi", "org.jetbrains.kotlinx:kotlinx-serialization-json:$horizonSerializationVersion")

--- a/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/packages/google/openiap/src/horizon/java/dev/hyo/openiap/OpenIapModule.kt
@@ -15,6 +15,7 @@ import com.meta.horizon.billingclient.api.Purchase as HorizonPurchase
 import com.meta.horizon.billingclient.api.PurchasesUpdatedListener
 import com.meta.horizon.billingclient.api.QueryProductDetailsParams
 import com.meta.horizon.billingclient.api.QueryPurchasesParams
+import horizon.platform.users.Users
 import dev.hyo.openiap.listener.OpenIapDeveloperProvidedBillingListener
 import dev.hyo.openiap.listener.OpenIapPurchaseErrorListener
 import dev.hyo.openiap.listener.OpenIapPurchaseUpdateListener
@@ -68,6 +69,26 @@ private const val PURCHASE_QUERY_INTERVAL_MS = 1_000L
 private const val PURCHASE_QUERY_MAX_ATTEMPTS = 300
 internal fun resolveHorizonAppId(metaData: android.os.Bundle?): String? =
     metaData?.getString(HORIZON_APP_ID_META_DATA)?.takeIf { it.isNotBlank() }
+
+internal fun withResolvedHorizonUserId(
+    options: RequestVerifyPurchaseWithIapkitProps,
+    userId: String,
+): RequestVerifyPurchaseWithIapkitProps {
+    val horizon = requireNotNull(options.horizon)
+    return RequestVerifyPurchaseWithIapkitProps(
+        amazon = options.amazon,
+        apiKey = options.apiKey,
+        apple = options.apple,
+        baseUrl = options.baseUrl,
+        google = options.google,
+        includeClientPayload = options.includeClientPayload,
+        horizon = RequestVerifyPurchaseWithIapkitHorizonProps(
+            sku = horizon.sku,
+            userId = userId.trim().takeIf { it.isNotEmpty() }
+                ?: throw IllegalArgumentException("Horizon user ID must not be blank"),
+        ),
+    )
+}
 
 internal data class HorizonAllQueryResults<T : Any>(
     val inApp: T?,
@@ -1411,8 +1432,22 @@ class OpenIapModule(
         val options = props.iapkit ?: throw OpenIapError.DeveloperError(
             "Missing IAPKit verification parameters"
         )
+        val horizonOptions = options.horizon
+        val resolvedOptions = if (horizonOptions != null && horizonOptions.userId.isNullOrBlank()) {
+            try {
+                withResolvedHorizonUserId(options, Users().getLoggedInUser().id)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                throw OpenIapError.PurchaseVerificationFailed(
+                    "Unable to resolve the logged-in Horizon user"
+                )
+            }
+        } else {
+            options
+        }
         VerifyPurchaseWithProviderResult(
-            iapkit = verifyPurchaseWithIapkit(options, TAG),
+            iapkit = verifyPurchaseWithIapkit(resolvedOptions, TAG),
             provider = props.provider
         )
     }

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/Types.kt
@@ -5319,11 +5319,40 @@ public data class RequestVerifyPurchaseWithIapkitGoogleProps(
     )
 }
 
+public data class RequestVerifyPurchaseWithIapkitHorizonProps(
+    /**
+     * Meta Horizon product or subscription SKU.
+     */
+    val sku: String,
+    /**
+     * Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+     */
+    val userId: String? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestVerifyPurchaseWithIapkitHorizonProps? {
+            val sku = json["sku"] as? String
+            val userId = json["userId"]?.let { raw -> (raw as? String) ?: throw IllegalArgumentException("Invalid String input value") }
+            if (sku == null) return null
+            return RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = sku,
+                userId = userId,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "sku" to sku,
+        "userId" to userId,
+    )
+}
+
 /**
  * Platform-specific verification parameters for IAPKit.
  *
  * - apple: Verifies via App Store (JWS token)
  * - google: Verifies via Play Store (purchase token)
+ * - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
  * - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
  */
 public data class RequestVerifyPurchaseWithIapkitProps(
@@ -5354,11 +5383,17 @@ public data class RequestVerifyPurchaseWithIapkitProps(
 
     /**
      * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-     * Include the product's public IAPKit client payload in a valid Apple or
-     * Google verification response. Defaults to false so existing response
+     * Include the product's public IAPKit client payload in a valid verification
+     * response. Defaults to false so existing response
      * shapes and bandwidth remain unchanged.
      */
     var includeClientPayload: Boolean? = null
+        private set
+
+    /**
+     * Meta Horizon verification parameters.
+     */
+    var horizon: RequestVerifyPurchaseWithIapkitHorizonProps? = null
         private set
 
     constructor(
@@ -5378,6 +5413,25 @@ public data class RequestVerifyPurchaseWithIapkitProps(
         this.includeClientPayload = includeClientPayload
     }
 
+    constructor(
+        amazon: RequestVerifyPurchaseWithIapkitAmazonProps? = null,
+        apiKey: String? = null,
+        apple: RequestVerifyPurchaseWithIapkitAppleProps? = null,
+        baseUrl: String? = null,
+        google: RequestVerifyPurchaseWithIapkitGoogleProps? = null,
+        includeClientPayload: Boolean? = null,
+        horizon: RequestVerifyPurchaseWithIapkitHorizonProps?,
+    ) : this(
+        amazon = amazon,
+        apiKey = apiKey,
+        apple = apple,
+        baseUrl = baseUrl,
+        google = google,
+    ) {
+        this.includeClientPayload = includeClientPayload
+        this.horizon = horizon
+    }
+
     companion object {
         fun fromJson(json: Map<String, Any?>): RequestVerifyPurchaseWithIapkitProps {
             return RequestVerifyPurchaseWithIapkitProps(
@@ -5387,6 +5441,7 @@ public data class RequestVerifyPurchaseWithIapkitProps(
                 baseUrl = json["baseUrl"]?.let { raw -> (raw as? String) ?: throw IllegalArgumentException("Invalid String input value") },
                 google = json["google"]?.let { value -> (value as? Map<String, Any?>)?.let { RequestVerifyPurchaseWithIapkitGoogleProps.fromJson(it) } ?: throw IllegalArgumentException("Invalid input object for RequestVerifyPurchaseWithIapkitGoogleProps") },
                 includeClientPayload = json["includeClientPayload"]?.let { raw -> (raw as? Boolean) ?: throw IllegalArgumentException("Invalid Boolean input value") },
+                horizon = json["horizon"]?.let { value -> (value as? Map<String, Any?>)?.let { RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(it) } ?: throw IllegalArgumentException("Invalid input object for RequestVerifyPurchaseWithIapkitHorizonProps") },
             )
         }
     }
@@ -5397,6 +5452,7 @@ public data class RequestVerifyPurchaseWithIapkitProps(
         "includeClientPayload" to includeClientPayload,
         "apple" to apple?.toJson(),
         "google" to google?.toJson(),
+        "horizon" to horizon?.toJson(),
         "amazon" to amazon?.toJson(),
     )
 }

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -51,6 +51,8 @@ import dev.hyo.openiap.OpenIapError
 import dev.hyo.openiap.OpenIapLog
 // OpenIapModule is loaded via reflection to support both Play and Horizon flavors
 import dev.hyo.openiap.OpenIapProtocol
+import dev.hyo.openiap.VerifyPurchaseWithProviderProps
+import dev.hyo.openiap.VerifyPurchaseWithProviderResult
 import dev.hyo.openiap.listener.OpenIapPurchaseErrorListener
 import dev.hyo.openiap.listener.OpenIapPurchaseUpdateListener
 import dev.hyo.openiap.utils.toProduct
@@ -524,6 +526,11 @@ class OpenIapStore(private val module: OpenIapProtocol) {
      */
     suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription> =
         module.queryHandlers.getActiveSubscriptions?.invoke(subscriptionIds) ?: emptyList()
+
+    /** Verify a purchase with the configured provider. */
+    suspend fun verifyPurchaseWithProvider(
+        options: VerifyPurchaseWithProviderProps
+    ): VerifyPurchaseWithProviderResult = module.verifyPurchaseWithProvider(options)
 
     /**
      * Check whether the user has any active subscription.

--- a/packages/google/openiap/src/main/java/dev/hyo/openiap/utils/PurchaseVerificationValidator.kt
+++ b/packages/google/openiap/src/main/java/dev/hyo/openiap/utils/PurchaseVerificationValidator.kt
@@ -253,10 +253,11 @@ suspend fun verifyPurchaseWithIapkit(
 
     val hasApple = props.apple != null
     val hasGoogle = props.google != null
+    val hasHorizon = props.horizon != null
     val hasAmazon = props.amazon != null
-    if (listOf(hasApple, hasGoogle, hasAmazon).count { it } != 1 || hasApple) {
+    if (listOf(hasApple, hasGoogle, hasHorizon, hasAmazon).count { it } != 1 || hasApple) {
         throw IllegalArgumentException(
-            "IAPKit verification on Android requires exactly one google or amazon payload"
+            "IAPKit verification on Android requires exactly one google, horizon, or amazon payload"
         )
     }
 
@@ -288,6 +289,21 @@ suspend fun verifyPurchaseWithIapkit(
             amazon.sandbox?.let { put("sandbox", it) }
             amazon.expectedProductId?.let { put("expectedProductId", it) }
         }
+    }
+
+    fun buildHorizonPayload(): Map<String, Any?> {
+        val horizon = props.horizon
+            ?: throw IllegalArgumentException("IAPKit Horizon verification requires horizon options")
+        val sku = horizon.sku.trim()
+        val userId = horizon.userId?.trim().orEmpty()
+        if (sku.isBlank() || userId.isBlank()) {
+            throw IllegalArgumentException("IAPKit Horizon verification requires sku and userId")
+        }
+        return mutableMapOf(
+            "store" to IapStore.Horizon.rawValue,
+            "sku" to sku,
+            "userId" to userId
+        )
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -335,10 +351,15 @@ suspend fun verifyPurchaseWithIapkit(
         return null
     }
 
-    val store = if (hasAmazon) IapStore.Amazon else IapStore.Google
+    val store = when {
+        hasAmazon -> IapStore.Amazon
+        hasHorizon -> IapStore.Horizon
+        else -> IapStore.Google
+    }
     val payload = when (store) {
         IapStore.Amazon -> buildAmazonPayload()
         IapStore.Google -> buildGooglePayload()
+        IapStore.Horizon -> buildHorizonPayload()
         else -> throw IllegalArgumentException("IAPKit verification on Android does not support ${store.rawValue}")
     }.toMutableMap().apply {
         if (props.includeClientPayload == true) {

--- a/packages/google/openiap/src/test/java/dev/hyo/openiap/PurchaseVerificationValidatorTest.kt
+++ b/packages/google/openiap/src/test/java/dev/hyo/openiap/PurchaseVerificationValidatorTest.kt
@@ -9,6 +9,7 @@ import dev.hyo.openiap.IapkitPurchaseState
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitAmazonProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitAppleProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitGoogleProps
+import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitHorizonProps
 import dev.hyo.openiap.RequestVerifyPurchaseWithIapkitProps
 import dev.hyo.openiap.VerifyPurchaseGoogleOptions
 import dev.hyo.openiap.VerifyPurchaseHorizonOptions
@@ -530,6 +531,55 @@ class PurchaseVerificationValidatorTest {
     }
 
     @Test
+    fun `verifyPurchaseWithIapkit posts horizon entitlement details`() = runTest {
+        val props = RequestVerifyPurchaseWithIapkitProps(
+            apiKey = "secret",
+            horizon = RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = "premium.monthly",
+                userId = "123456789"
+            ),
+            includeClientPayload = true
+        )
+        val connection = FakeHttpURLConnection(
+            200,
+            """{"store":"horizon","isValid":true,"state":"ENTITLED","productId":"premium.monthly"}"""
+        )
+
+        val result = verifyPurchaseWithIapkit(props, "TEST") { _ -> connection }
+
+        assertEquals(IapStore.Horizon, result.store)
+        assertTrue(result.isValid)
+        assertEquals("premium.monthly", result.productId)
+        val bodyMap = Gson().fromJson(requireNotNull(connection.writtenBody), Map::class.java) as Map<*, *>
+        assertEquals("horizon", bodyMap["store"])
+        assertEquals("premium.monthly", bodyMap["sku"])
+        assertEquals("123456789", bodyMap["userId"])
+        assertEquals(true, bodyMap["includeClientPayload"])
+    }
+
+    @Test
+    fun `verifyPurchaseWithIapkit throws when horizon payload is incomplete`() = runTest {
+        for (horizon in listOf(
+            RequestVerifyPurchaseWithIapkitHorizonProps(sku = "", userId = "123456789"),
+            RequestVerifyPurchaseWithIapkitHorizonProps(sku = "premium.monthly", userId = " ")
+        )) {
+            try {
+                verifyPurchaseWithIapkit(
+                    RequestVerifyPurchaseWithIapkitProps(
+                        horizon = horizon
+                    ),
+                    "TEST"
+                ) { _ ->
+                    throw AssertionError("Connection should not be created when Horizon payload is invalid")
+                }
+                throw AssertionError("Expected IllegalArgumentException for invalid Horizon payload")
+            } catch (expected: IllegalArgumentException) {
+                assertTrue(expected.message?.contains("sku and userId") == true)
+            }
+        }
+    }
+
+    @Test
     fun `verifyPurchaseWithIapkit accepts absent null and production environments`() = runTest {
         val props = RequestVerifyPurchaseWithIapkitProps(
             amazon = RequestVerifyPurchaseWithIapkitAmazonProps(
@@ -672,7 +722,7 @@ class PurchaseVerificationValidatorTest {
             }
             throw AssertionError("Expected IllegalArgumentException for apple payload on Android")
         } catch (expected: IllegalArgumentException) {
-            assertTrue(expected.message?.contains("exactly one google or amazon") == true)
+            assertTrue(expected.message?.contains("exactly one google, horizon, or amazon") == true)
         }
     }
 
@@ -695,7 +745,7 @@ class PurchaseVerificationValidatorTest {
             }
             throw AssertionError("Expected IllegalArgumentException for mixed apple payload")
         } catch (expected: IllegalArgumentException) {
-            assertTrue(expected.message?.contains("exactly one google or amazon") == true)
+            assertTrue(expected.message?.contains("exactly one google, horizon, or amazon") == true)
         }
     }
 

--- a/packages/google/openiap/src/testHorizon/java/dev/hyo/openiap/HorizonIapkitOptionsTest.kt
+++ b/packages/google/openiap/src/testHorizon/java/dev/hyo/openiap/HorizonIapkitOptionsTest.kt
@@ -1,0 +1,40 @@
+package dev.hyo.openiap
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class HorizonIapkitOptionsTest {
+    @Test
+    fun resolvedUserIdPreservesSkuAndOptions() {
+        val options = RequestVerifyPurchaseWithIapkitProps(
+            apiKey = "openiap-kit_pk_test",
+            baseUrl = "https://kit.openiap.dev",
+            includeClientPayload = true,
+            horizon = RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = "dev.hyo.martie.premium",
+            ),
+        )
+
+        val resolved = withResolvedHorizonUserId(options, " 123456789 ")
+
+        assertEquals("dev.hyo.martie.premium", resolved.horizon?.sku)
+        assertEquals("123456789", resolved.horizon?.userId)
+        assertEquals("openiap-kit_pk_test", resolved.apiKey)
+        assertEquals("https://kit.openiap.dev", resolved.baseUrl)
+        assertEquals(true, resolved.includeClientPayload)
+    }
+
+    @Test
+    fun blankResolvedUserIdIsRejected() {
+        val options = RequestVerifyPurchaseWithIapkitProps(
+            horizon = RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = "dev.hyo.martie.premium",
+            ),
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            withResolvedHorizonUserId(options, " ")
+        }
+    }
+}

--- a/packages/gql/codegen/plugins/kotlin.ts
+++ b/packages/gql/codegen/plugins/kotlin.ts
@@ -56,7 +56,8 @@ const COMPATIBLE_INPUT_DATA_CLASS_SHAPES: Record<string, CompatibleDataClassShap
   },
   RequestVerifyPurchaseWithIapkitProps: {
     primaryFields: ['amazon', 'apiKey', 'apple', 'baseUrl', 'google'],
-    extraFields: ['includeClientPayload'],
+    extraFields: ['includeClientPayload', 'horizon'],
+    legacyExtraFieldCounts: [1],
   },
 };
 
@@ -645,24 +646,39 @@ export class KotlinPlugin extends CodegenPlugin {
       this.emit('');
     }
 
-    this.emit('    constructor(');
-    for (const value of primaryFields) {
-      this.emit(`        ${value.name}: ${this.getPropertyType(value.type)}${defaultValue(value)},`);
+    const constructorExtraFieldCounts = [
+      ...new Set([...(shape.legacyExtraFieldCounts ?? []), extraFields.length]),
+    ];
+    for (const extraFieldCount of constructorExtraFieldCounts) {
+      if (extraFieldCount < 1 || extraFieldCount > extraFields.length) {
+        throw new Error(`${irInput.name} has an invalid compatibility constructor size`);
+      }
+      const constructorExtraFields = extraFields.slice(0, extraFieldCount);
+      const isCurrentConstructor = extraFieldCount === extraFields.length;
+      const hasLegacyConstructor = (shape.legacyExtraFieldCounts?.length ?? 0) > 0;
+      this.emit('    constructor(');
+      for (const value of primaryFields) {
+        this.emit(`        ${value.name}: ${this.getPropertyType(value.type)}${defaultValue(value)},`);
+      }
+      constructorExtraFields.forEach((value, index) => {
+        const isNewestField = index === constructorExtraFields.length - 1;
+        let extraDefault = index === 0 ? '' : ' = null';
+        if (isCurrentConstructor && hasLegacyConstructor) {
+          extraDefault = isNewestField ? '' : ' = null';
+        }
+        this.emit(`        ${value.name}: ${this.getPropertyType(value.type)}${extraDefault},`);
+      });
+      this.emit('    ) : this(');
+      for (const value of primaryFields) {
+        this.emit(`        ${value.name} = ${value.name},`);
+      }
+      this.emit('    ) {');
+      for (const value of constructorExtraFields) {
+        this.emit(`        this.${value.name} = ${value.name}`);
+      }
+      this.emit('    }');
+      this.emit('');
     }
-    extraFields.forEach((value, index) => {
-      const extraDefault = index === 0 ? '' : ' = null';
-      this.emit(`        ${value.name}: ${this.getPropertyType(value.type)}${extraDefault},`);
-    });
-    this.emit('    ) : this(');
-    for (const value of primaryFields) {
-      this.emit(`        ${value.name} = ${value.name},`);
-    }
-    this.emit('    ) {');
-    for (const value of extraFields) {
-      this.emit(`        this.${value.name} = ${value.name}`);
-    }
-    this.emit('    }');
-    this.emit('');
 
     const allFields = [...primaryFields, ...extraFields];
     const requiredFields = allFields.filter(

--- a/packages/gql/src/generated-compatibility.test.ts
+++ b/packages/gql/src/generated-compatibility.test.ts
@@ -525,10 +525,17 @@ export interface WrongOwner {
       'public data class RequestVerifyPurchaseWithIapkitProps( val amazon: RequestVerifyPurchaseWithIapkitAmazonProps? = null, val apiKey: String? = null, val apple: RequestVerifyPurchaseWithIapkitAppleProps? = null, val baseUrl: String? = null, val google: RequestVerifyPurchaseWithIapkitGoogleProps? = null ) {',
     );
     expect(iapkitProps).toContain('var includeClientPayload: Boolean? = null');
+    expect(iapkitProps).toContain('var horizon: RequestVerifyPurchaseWithIapkitHorizonProps? = null');
+    expect(iapkitProps).toContain(`        includeClientPayload: Boolean?,
+    ) : this(`);
+    expect(iapkitProps).toContain(`        includeClientPayload: Boolean? = null,
+        horizon: RequestVerifyPurchaseWithIapkitHorizonProps?,
+    ) : this(`);
     expect(iapkitResult).toContain('private set');
     expect(iapkitAmazonProps).toContain('private set');
     expect(iapkitProps).toContain('private set');
     expect(iapkitPropsPrimary).not.toContain('includeClientPayload');
+    expect(iapkitPropsPrimary).not.toContain('horizon');
   });
 
   it('preserves schema prose in custom purchase and discount generators', () => {

--- a/packages/gql/src/generated/Types.cs
+++ b/packages/gql/src/generated/Types.cs
@@ -4707,11 +4707,22 @@ public sealed record RequestVerifyPurchaseWithIapkitGoogleProps
     public required string PurchaseToken { get; init; }
 }
 
+public sealed record RequestVerifyPurchaseWithIapkitHorizonProps
+{
+    /// <summary>Meta Horizon product or subscription SKU.</summary>
+    [JsonPropertyName("sku")]
+    public required string Sku { get; init; }
+    /// <summary>Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.</summary>
+    [JsonPropertyName("userId")]
+    public string? UserId { get; init; }
+}
+
 /// <summary>
 /// Platform-specific verification parameters for IAPKit.
 ///
 /// - apple: Verifies via App Store (JWS token)
 /// - google: Verifies via Play Store (purchase token)
+/// - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 /// - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 /// </summary>
 public sealed record RequestVerifyPurchaseWithIapkitProps
@@ -4729,8 +4740,8 @@ public sealed record RequestVerifyPurchaseWithIapkitProps
     public string? BaseUrl { get; init; }
     /// <summary>
     /// Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-    /// Include the product&apos;s public IAPKit client payload in a valid Apple or
-    /// Google verification response. Defaults to false so existing response
+    /// Include the product&apos;s public IAPKit client payload in a valid verification
+    /// response. Defaults to false so existing response
     /// shapes and bandwidth remain unchanged.
     /// </summary>
     [JsonPropertyName("includeClientPayload")]
@@ -4741,6 +4752,9 @@ public sealed record RequestVerifyPurchaseWithIapkitProps
     /// <summary>Google Play Store verification parameters.</summary>
     [JsonPropertyName("google")]
     public RequestVerifyPurchaseWithIapkitGoogleProps? Google { get; init; }
+    /// <summary>Meta Horizon verification parameters.</summary>
+    [JsonPropertyName("horizon")]
+    public RequestVerifyPurchaseWithIapkitHorizonProps? Horizon { get; init; }
     /// <summary>Amazon Appstore verification parameters.</summary>
     [JsonPropertyName("amazon")]
     public RequestVerifyPurchaseWithIapkitAmazonProps? Amazon { get; init; }

--- a/packages/gql/src/generated/Types.kt
+++ b/packages/gql/src/generated/Types.kt
@@ -5265,11 +5265,40 @@ public data class RequestVerifyPurchaseWithIapkitGoogleProps(
     )
 }
 
+public data class RequestVerifyPurchaseWithIapkitHorizonProps(
+    /**
+     * Meta Horizon product or subscription SKU.
+     */
+    val sku: String,
+    /**
+     * Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+     */
+    val userId: String? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestVerifyPurchaseWithIapkitHorizonProps? {
+            val sku = json["sku"] as? String
+            val userId = json["userId"]?.let { raw -> (raw as? String) ?: throw IllegalArgumentException("Invalid String input value") }
+            if (sku == null) return null
+            return RequestVerifyPurchaseWithIapkitHorizonProps(
+                sku = sku,
+                userId = userId,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "sku" to sku,
+        "userId" to userId,
+    )
+}
+
 /**
  * Platform-specific verification parameters for IAPKit.
  *
  * - apple: Verifies via App Store (JWS token)
  * - google: Verifies via Play Store (purchase token)
+ * - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
  * - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
  */
 public data class RequestVerifyPurchaseWithIapkitProps(
@@ -5300,11 +5329,17 @@ public data class RequestVerifyPurchaseWithIapkitProps(
 
     /**
      * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-     * Include the product's public IAPKit client payload in a valid Apple or
-     * Google verification response. Defaults to false so existing response
+     * Include the product's public IAPKit client payload in a valid verification
+     * response. Defaults to false so existing response
      * shapes and bandwidth remain unchanged.
      */
     var includeClientPayload: Boolean? = null
+        private set
+
+    /**
+     * Meta Horizon verification parameters.
+     */
+    var horizon: RequestVerifyPurchaseWithIapkitHorizonProps? = null
         private set
 
     constructor(
@@ -5324,6 +5359,25 @@ public data class RequestVerifyPurchaseWithIapkitProps(
         this.includeClientPayload = includeClientPayload
     }
 
+    constructor(
+        amazon: RequestVerifyPurchaseWithIapkitAmazonProps? = null,
+        apiKey: String? = null,
+        apple: RequestVerifyPurchaseWithIapkitAppleProps? = null,
+        baseUrl: String? = null,
+        google: RequestVerifyPurchaseWithIapkitGoogleProps? = null,
+        includeClientPayload: Boolean? = null,
+        horizon: RequestVerifyPurchaseWithIapkitHorizonProps?,
+    ) : this(
+        amazon = amazon,
+        apiKey = apiKey,
+        apple = apple,
+        baseUrl = baseUrl,
+        google = google,
+    ) {
+        this.includeClientPayload = includeClientPayload
+        this.horizon = horizon
+    }
+
     companion object {
         fun fromJson(json: Map<String, Any?>): RequestVerifyPurchaseWithIapkitProps {
             return RequestVerifyPurchaseWithIapkitProps(
@@ -5333,6 +5387,7 @@ public data class RequestVerifyPurchaseWithIapkitProps(
                 baseUrl = json["baseUrl"]?.let { raw -> (raw as? String) ?: throw IllegalArgumentException("Invalid String input value") },
                 google = json["google"]?.let { value -> (value as? Map<String, Any?>)?.let { RequestVerifyPurchaseWithIapkitGoogleProps.fromJson(it) } ?: throw IllegalArgumentException("Invalid input object for RequestVerifyPurchaseWithIapkitGoogleProps") },
                 includeClientPayload = json["includeClientPayload"]?.let { raw -> (raw as? Boolean) ?: throw IllegalArgumentException("Invalid Boolean input value") },
+                horizon = json["horizon"]?.let { value -> (value as? Map<String, Any?>)?.let { RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(it) } ?: throw IllegalArgumentException("Invalid input object for RequestVerifyPurchaseWithIapkitHorizonProps") },
             )
         }
     }
@@ -5343,6 +5398,7 @@ public data class RequestVerifyPurchaseWithIapkitProps(
         "includeClientPayload" to includeClientPayload,
         "apple" to apple?.toJson(),
         "google" to google?.toJson(),
+        "horizon" to horizon?.toJson(),
         "amazon" to amazon?.toJson(),
     )
 }

--- a/packages/gql/src/generated/Types.swift
+++ b/packages/gql/src/generated/Types.swift
@@ -2096,10 +2096,26 @@ public struct RequestVerifyPurchaseWithIapkitGoogleProps: Codable {
     }
 }
 
+public struct RequestVerifyPurchaseWithIapkitHorizonProps: Codable {
+    /// Meta Horizon product or subscription SKU.
+    public var sku: String
+    /// Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+    public var userId: String?
+
+    public init(
+        sku: String,
+        userId: String? = nil
+    ) {
+        self.sku = sku
+        self.userId = userId
+    }
+}
+
 /// Platform-specific verification parameters for IAPKit.
 ///
 /// - apple: Verifies via App Store (JWS token)
 /// - google: Verifies via Play Store (purchase token)
+/// - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 /// - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 public struct RequestVerifyPurchaseWithIapkitProps: Codable {
     /// Amazon Appstore verification parameters.
@@ -2115,9 +2131,11 @@ public struct RequestVerifyPurchaseWithIapkitProps: Codable {
     public var baseUrl: String?
     /// Google Play Store verification parameters.
     public var google: RequestVerifyPurchaseWithIapkitGoogleProps?
+    /// Meta Horizon verification parameters.
+    public var horizon: RequestVerifyPurchaseWithIapkitHorizonProps?
     /// Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-    /// Include the product's public IAPKit client payload in a valid Apple or
-    /// Google verification response. Defaults to false so existing response
+    /// Include the product's public IAPKit client payload in a valid verification
+    /// response. Defaults to false so existing response
     /// shapes and bandwidth remain unchanged.
     public var includeClientPayload: Bool?
 
@@ -2127,6 +2145,7 @@ public struct RequestVerifyPurchaseWithIapkitProps: Codable {
         apple: RequestVerifyPurchaseWithIapkitAppleProps? = nil,
         baseUrl: String? = nil,
         google: RequestVerifyPurchaseWithIapkitGoogleProps? = nil,
+        horizon: RequestVerifyPurchaseWithIapkitHorizonProps? = nil,
         includeClientPayload: Bool? = nil
     ) {
         self.amazon = amazon
@@ -2134,6 +2153,7 @@ public struct RequestVerifyPurchaseWithIapkitProps: Codable {
         self.apple = apple
         self.baseUrl = baseUrl
         self.google = google
+        self.horizon = horizon
         self.includeClientPayload = includeClientPayload
     }
 }

--- a/packages/gql/src/generated/types.dart
+++ b/packages/gql/src/generated/types.dart
@@ -5299,10 +5299,37 @@ class RequestVerifyPurchaseWithIapkitGoogleProps {
   }
 }
 
+class RequestVerifyPurchaseWithIapkitHorizonProps {
+  const RequestVerifyPurchaseWithIapkitHorizonProps({
+    required this.sku,
+    this.userId,
+  });
+
+  /// Meta Horizon product or subscription SKU.
+  final String sku;
+  /// Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+  final String? userId;
+
+  factory RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(Map<String, dynamic> json) {
+    return RequestVerifyPurchaseWithIapkitHorizonProps(
+      sku: json['sku'] as String,
+      userId: json['userId'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'sku': sku,
+      'userId': userId,
+    };
+  }
+}
+
 /// Platform-specific verification parameters for IAPKit.
 ///
 /// - apple: Verifies via App Store (JWS token)
 /// - google: Verifies via Play Store (purchase token)
+/// - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 /// - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 class RequestVerifyPurchaseWithIapkitProps {
   const RequestVerifyPurchaseWithIapkitProps({
@@ -5311,6 +5338,7 @@ class RequestVerifyPurchaseWithIapkitProps {
     this.apple,
     this.baseUrl,
     this.google,
+    this.horizon,
     this.includeClientPayload,
   });
 
@@ -5327,9 +5355,11 @@ class RequestVerifyPurchaseWithIapkitProps {
   final String? baseUrl;
   /// Google Play Store verification parameters.
   final RequestVerifyPurchaseWithIapkitGoogleProps? google;
+  /// Meta Horizon verification parameters.
+  final RequestVerifyPurchaseWithIapkitHorizonProps? horizon;
   /// Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-  /// Include the product's public IAPKit client payload in a valid Apple or
-  /// Google verification response. Defaults to false so existing response
+  /// Include the product's public IAPKit client payload in a valid verification
+  /// response. Defaults to false so existing response
   /// shapes and bandwidth remain unchanged.
   final bool? includeClientPayload;
 
@@ -5340,6 +5370,7 @@ class RequestVerifyPurchaseWithIapkitProps {
       apple: json['apple'] != null ? RequestVerifyPurchaseWithIapkitAppleProps.fromJson(json['apple'] as Map<String, dynamic>) : null,
       baseUrl: json['baseUrl'] as String?,
       google: json['google'] != null ? RequestVerifyPurchaseWithIapkitGoogleProps.fromJson(json['google'] as Map<String, dynamic>) : null,
+      horizon: json['horizon'] != null ? RequestVerifyPurchaseWithIapkitHorizonProps.fromJson(json['horizon'] as Map<String, dynamic>) : null,
       includeClientPayload: json['includeClientPayload'] as bool?,
     );
   }
@@ -5351,6 +5382,7 @@ class RequestVerifyPurchaseWithIapkitProps {
       'apple': apple?.toJson(),
       'baseUrl': baseUrl,
       'google': google?.toJson(),
+      'horizon': horizon?.toJson(),
       'includeClientPayload': includeClientPayload,
     };
   }

--- a/packages/gql/src/generated/types.gd
+++ b/packages/gql/src/generated/types.gd
@@ -5091,18 +5091,48 @@ class RequestVerifyPurchaseWithIapkitGoogleProps:
 			dict["purchaseToken"] = purchase_token
 		return dict
 
-## Platform-specific verification parameters for IAPKit. - apple: Verifies via App Store (JWS token) - google: Verifies via Play Store (purchase token) - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
+class RequestVerifyPurchaseWithIapkitHorizonProps:
+	## Meta Horizon product or subscription SKU.
+	var sku: String = ""
+	## Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+	var user_id: Variant = null
+
+	static func from_dict(data: Dictionary) -> RequestVerifyPurchaseWithIapkitHorizonProps:
+		if not data.has("sku") or not data["sku"] is String:
+			push_error("Invalid required RequestVerifyPurchaseWithIapkitHorizonProps.sku value")
+			return null
+		if data.has("userId") and data["userId"] != null and not data["userId"] is String:
+			push_error("Invalid RequestVerifyPurchaseWithIapkitHorizonProps.userId value")
+			return null
+		var obj = RequestVerifyPurchaseWithIapkitHorizonProps.new()
+		if data.has("sku") and data["sku"] != null:
+			obj.sku = data["sku"]
+		if data.has("userId") and data["userId"] != null:
+			obj.user_id = data["userId"]
+		return obj
+
+	func to_dict() -> Dictionary:
+		var dict = {}
+		if sku != null:
+			dict["sku"] = sku
+		if user_id != null:
+			dict["userId"] = user_id
+		return dict
+
+## Platform-specific verification parameters for IAPKit. - apple: Verifies via App Store (JWS token) - google: Verifies via Play Store (purchase token) - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU) - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 class RequestVerifyPurchaseWithIapkitProps:
 	## API key used for the Authorization header (Bearer {apiKey}).
 	var api_key: Variant = null
 	## Available in OpenIAP Spec 2.3.1 / openiap-apple 2.4.0 / openiap-google 2.4.0. Base URL for the IAPKit server. Defaults to https://kit.openiap.dev. Set this to a reachable HTTP(S) origin when self-hosting or testing a local IAPKit server. The apiKey must be issued by the same IAPKit/Convex deployment as this server.
 	var base_url: Variant = null
-	## Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1. Include the product's public IAPKit client payload in a valid Apple or Google verification response. Defaults to false so existing response shapes and bandwidth remain unchanged.
+	## Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1. Include the product's public IAPKit client payload in a valid verification response. Defaults to false so existing response shapes and bandwidth remain unchanged.
 	var include_client_payload: Variant = null
 	## Apple App Store verification parameters.
 	var apple: RequestVerifyPurchaseWithIapkitAppleProps
 	## Google Play Store verification parameters.
 	var google: RequestVerifyPurchaseWithIapkitGoogleProps
+	## Meta Horizon verification parameters.
+	var horizon: RequestVerifyPurchaseWithIapkitHorizonProps
 	## Amazon Appstore verification parameters.
 	var amazon: RequestVerifyPurchaseWithIapkitAmazonProps
 
@@ -5143,6 +5173,16 @@ class RequestVerifyPurchaseWithIapkitProps:
 			else:
 				push_error("Expected google to be a RequestVerifyPurchaseWithIapkitGoogleProps dictionary")
 				return null
+		if data.has("horizon") and data["horizon"] != null:
+			if data["horizon"] is Dictionary:
+				var decoded_horizon = RequestVerifyPurchaseWithIapkitHorizonProps.from_dict(data["horizon"])
+				if decoded_horizon == null:
+					push_error("Invalid input RequestVerifyPurchaseWithIapkitHorizonProps value for horizon")
+					return null
+				obj.horizon = decoded_horizon
+			else:
+				push_error("Expected horizon to be a RequestVerifyPurchaseWithIapkitHorizonProps dictionary")
+				return null
 		if data.has("amazon") and data["amazon"] != null:
 			if data["amazon"] is Dictionary:
 				var decoded_amazon = RequestVerifyPurchaseWithIapkitAmazonProps.from_dict(data["amazon"])
@@ -5173,6 +5213,11 @@ class RequestVerifyPurchaseWithIapkitProps:
 				dict["google"] = google.to_dict()
 			else:
 				dict["google"] = google
+		if horizon != null:
+			if horizon.has_method("to_dict"):
+				dict["horizon"] = horizon.to_dict()
+			else:
+				dict["horizon"] = horizon
 		if amazon != null:
 			if amazon.has_method("to_dict"):
 				dict["amazon"] = amazon.to_dict()

--- a/packages/gql/src/generated/types.ts
+++ b/packages/gql/src/generated/types.ts
@@ -1828,11 +1828,19 @@ export interface RequestVerifyPurchaseWithIapkitGoogleProps {
   purchaseToken: string;
 }
 
+export interface RequestVerifyPurchaseWithIapkitHorizonProps {
+  /** Meta Horizon product or subscription SKU. */
+  sku: string;
+  /** Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted. */
+  userId?: (string | null);
+}
+
 /**
  * Platform-specific verification parameters for IAPKit.
  *
  * - apple: Verifies via App Store (JWS token)
  * - google: Verifies via Play Store (purchase token)
+ * - horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
  * - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
  */
 export interface RequestVerifyPurchaseWithIapkitProps {
@@ -1851,10 +1859,12 @@ export interface RequestVerifyPurchaseWithIapkitProps {
   baseUrl?: (string | null);
   /** Google Play Store verification parameters. */
   google?: (RequestVerifyPurchaseWithIapkitGoogleProps | null);
+  /** Meta Horizon verification parameters. */
+  horizon?: (RequestVerifyPurchaseWithIapkitHorizonProps | null);
   /**
    * Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-   * Include the product's public IAPKit client payload in a valid Apple or
-   * Google verification response. Defaults to false so existing response
+   * Include the product's public IAPKit client payload in a valid verification
+   * response. Defaults to false so existing response
    * shapes and bandwidth remain unchanged.
    */
   includeClientPayload?: (boolean | null);

--- a/packages/gql/src/type.graphql
+++ b/packages/gql/src/type.graphql
@@ -306,6 +306,17 @@ input RequestVerifyPurchaseWithIapkitGoogleProps {
   purchaseToken: String!
 }
 
+input RequestVerifyPurchaseWithIapkitHorizonProps {
+  """
+  Meta Horizon product or subscription SKU.
+  """
+  sku: String!
+  """
+  Meta app-scoped user ID. The openiap-google Horizon module resolves the logged-in user when omitted.
+  """
+  userId: String
+}
+
 input RequestVerifyPurchaseWithIapkitAmazonProps {
   """
   Available in OpenIAP Spec 3.2.0 / openiap-apple 3.2.0 / openiap-google 3.3.0.
@@ -331,6 +342,7 @@ Platform-specific verification parameters for IAPKit.
 
 - apple: Verifies via App Store (JWS token)
 - google: Verifies via Play Store (purchase token)
+- horizon: Verifies via Meta Horizon (app-scoped user ID + SKU)
 - amazon: Verifies via Amazon Appstore RVS (userId + receiptId)
 """
 input RequestVerifyPurchaseWithIapkitProps {
@@ -347,8 +359,8 @@ input RequestVerifyPurchaseWithIapkitProps {
   baseUrl: String
   """
   Available in OpenIAP Spec 2.4.0 / openiap-apple 2.4.1 / openiap-google 2.4.1.
-  Include the product's public IAPKit client payload in a valid Apple or
-  Google verification response. Defaults to false so existing response
+  Include the product's public IAPKit client payload in a valid verification
+  response. Defaults to false so existing response
   shapes and bandwidth remain unchanged.
   """
   includeClientPayload: Boolean
@@ -360,6 +372,10 @@ input RequestVerifyPurchaseWithIapkitProps {
   Google Play Store verification parameters.
   """
   google: RequestVerifyPurchaseWithIapkitGoogleProps
+  """
+  Meta Horizon verification parameters.
+  """
+  horizon: RequestVerifyPurchaseWithIapkitHorizonProps
   """
   Amazon Appstore verification parameters.
   """


### PR DESCRIPTION
## Summary

- add an explicit Horizon IAPKit payload (`sku` plus optional app-scoped `userId`) to the OpenIAP schema and generated SDK types
- resolve the logged-in Meta user in the openiap-google Horizon module before server verification while preserving Kotlin constructor ABI compatibility
- route Horizon verification correctly through the native, React Native, Expo, Flutter, KMP, MAUI, and Godot surfaces and examples

## Verification

- GQL generation, compatibility tests, 179 tests, and schema SemVer audit
- Google Play/Amazon/Horizon unit tests and all three Example debug builds
- Apple Swift build and 164 tests
- React Native Nitrogen specs, typecheck, 19 library suites / 633 tests, 8 example suites / 144 tests, and lint
- Expo typecheck/lint, 17 library suites / 454 tests, 4 plugin suites / 82 tests, and 17 example suites / 136 tests
- Flutter analyze and 367 tests
- KMP full library build/test, podspec/dummy framework, Horizon library/example build, and iOS simulator compilation
- MAUI build, 8 contract tests, and 106 xUnit tests
- repository parity, IAPKit contract, release-state, layout, docs, facts, and secret-pattern audits

## Device E2E

- Meta Quest 3 Horizon build installed and launched without recording
- existing monthly entitlement verified through local IAPKit as `ENTITLED`, completed/acknowledged, reverified, and remained idempotent after a cold restart
- the yearly device-local record was correctly rejected as `INAUTHENTIC`; Meta's authoritative purchase list contained only the monthly SKU
- no new purchase was approved because the Meta checkout did not visibly identify itself as Sandbox or Test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Meta Horizon purchase verification through IAPKit.
  * Horizon requests use the product SKU and optional user ID.
  * Added support across React Native, Flutter, Kotlin, .NET MAUI, Godot, Expo, and GraphQL integrations.
  * Horizon user IDs can be resolved automatically when unavailable.
* **Bug Fixes**
  * Prevented Horizon purchases from being incorrectly processed as Google purchases.
  * Transactions remain unfinished when verification fails.
* **Tests**
  * Added coverage for Horizon payloads, validation, user resolution, and cross-platform forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->