### PR TITLE
docs(workflows): align release and E2E guidance

### DIFF
--- a/.claude/commands/e2e-tests.md
+++ b/.claude/commands/e2e-tests.md
@@ -419,7 +419,7 @@ cd libraries/expo-iap/example
 : "${IOS_UDID:?Set IOS_UDID to the target iOS device UDID}"
 : "${TEAM_ID:?Set TEAM_ID to the Apple development team ID}"
 xcodebuild \
-  -workspace ios/ExpoIAPExample.xcworkspace \
+  -workspace ios/expoiapexample.xcworkspace \
   -configuration Debug \
   -scheme ExpoIAPExample \
   -destination "id=$IOS_UDID" \
@@ -442,6 +442,11 @@ FireOS/Amazon Android path:
 cd libraries/expo-iap/example
 EXPO_IAP_FIREOS=1 bunx expo prebuild --platform android --clean
 cd android
+variant_report="$(./gradlew :app:dependencyInsight \
+  --configuration debugRuntimeClasspath --dependency openiap-google)"
+printf '%s\n' "$variant_report" | grep -F 'Variant amazonDebugRuntimeElements'
+printf '%s\n' "$variant_report" | \
+  grep -E 'ProductFlavor:platform[[:space:]]+\| amazon'
 ./gradlew :app:assembleDebug
 # Build-only regression can stop here.
 : "${FIREOS_SERIAL:?Set FIREOS_SERIAL to the target FireOS device serial}"
@@ -449,13 +454,22 @@ adb -s "$FIREOS_SERIAL" install -r app/build/outputs/apk/debug/app-debug.apk
 adb -s "$FIREOS_SERIAL" shell monkey -p dev.hyo.martie 1
 ```
 
-Horizon Android build-only path:
+Horizon Android build and optional device path:
 
 ```bash
 cd libraries/expo-iap/example
 EXPO_IAP_HORIZON=1 bunx expo prebuild --platform android --clean
 cd android
+variant_report="$(./gradlew :app:dependencyInsight \
+  --configuration debugRuntimeClasspath --dependency openiap-google)"
+printf '%s\n' "$variant_report" | grep -F 'Variant horizonDebugRuntimeElements'
+printf '%s\n' "$variant_report" | \
+  grep -E 'ProductFlavor:platform[[:space:]]+\| horizon'
 ./gradlew :app:assembleDebug
+# Build-only regression can stop here.
+: "${HORIZON_SERIAL:?Set HORIZON_SERIAL to the target Horizon device serial}"
+adb -s "$HORIZON_SERIAL" install -r app/build/outputs/apk/debug/app-debug.apk
+adb -s "$HORIZON_SERIAL" shell monkey -p dev.hyo.martie 1
 ```
 
 Onside iOS build-only path:
@@ -469,7 +483,7 @@ grep -F 'OnsideKit' ios/Podfile.lock
 plutil -p ios/ExpoIAPExample/Info.plist | grep -F 'onside'
 plutil -p ios/ExpoIAPExample/Info.plist | grep -F 'dev.hyo.martie.onside-auth'
 xcodebuild \
-  -workspace ios/ExpoIAPExample.xcworkspace \
+  -workspace ios/expoiapexample.xcworkspace \
   -configuration Debug \
   -scheme ExpoIAPExample \
   -destination "generic/platform=iOS" \
@@ -886,9 +900,10 @@ Run these on each connected platform requested:
 - VegaOS / Fire TV: build and install the VPK, copy Amazon tester catalog/config
   with the project script, launch, fetch products, and run at least one purchase
   attempt when device input and tester UI are available.
-- Horizon: build-only unless a runnable Horizon device and store prerequisites
-  are explicitly available. If it is build-only, do not claim purchase flow
-  coverage.
+- Horizon: when a runnable device and store prerequisites are available, install
+  and launch the store-specific build, verify reconnect/listener behavior, and
+  run the exposed purchase/restore flow. Approve checkout only when its UI is
+  visibly marked as test or sandbox. Otherwise report build-only coverage.
 - Onside: Expo iOS build-only. Verify the generated Podfile and iOS project
   include the Onside module when `EXPO_IAP_ONSIDE=1`. Run CocoaPods explicitly
   after prebuild, require `OnsideKit` in `Podfile.lock`, require both `onside`
@@ -918,7 +933,7 @@ RN iOS                | {UDID}        | build/install/purchase | PASS | ...
 RN Vega               | {device id}   | build debug/release/run | PASS | ...
 Expo Android          | {serial}      | build/install/purchase | PASS | ...
 Expo FireOS           | {serial}      | build/install/purchase | PASS | ...
-Expo Horizon          | local Gradle  | build        | PASS   | build-only
+Expo Horizon          | {serial/local Gradle} | build[/install/store flow] | PASS | ...
 Expo iOS              | {UDID}        | build/install/purchase | PASS | ...
 Expo Onside           | generic iOS   | prebuild/build | PASS | build-only
 Expo Vega             | {device id}   | build debug/release/run | PASS | ...

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -151,7 +151,8 @@ Train rules (mistake guards):
   registry-verified, add the consolidated entry to
   `packages/docs/src/pages/docs/updates/releases.tsx` (see `generate-doc`),
   commit it directly to `main` together with any release-process doc updates,
-  then run the docs deployment. Run the Docs release workflow with
+  and do not open a PR for that post-release docs-only commit; then run the docs
+  deployment. Run the Docs release workflow with
   `version=current` only when the native-derived `spec` advanced; otherwise skip
   it so an immutable existing `docs-{spec}` tag is never reused. If a Docs
   GitHub Release is requested while `spec` is unchanged, stop and explain that

--- a/.codex/skills/loop-review/SKILL.md
+++ b/.codex/skills/loop-review/SKILL.md
@@ -186,7 +186,8 @@ Follow `.codex/skills/ship-release/SKILL.md` as the release SSOT:
    consecutive five-minute snapshots are clean. Any edit resets the count.
 5. Commit and push the reviewed release note and process-documentation changes
    directly to `main`. If review finds a product-code fix, return it to the PR
-   loop instead of committing that fix directly to `main`.
+   loop instead of committing that fix directly to `main`. Do not open a PR for
+   this post-release docs-only commit.
 6. From a clean local `main` equal to `origin/main`, run `npm run deploy`, then
    verify the production release page and generated documentation assets.
 7. If the native spec floor advanced, dispatch `.github/workflows/release.yml`

--- a/.codex/skills/ship-release/SKILL.md
+++ b/.codex/skills/ship-release/SKILL.md
@@ -96,10 +96,12 @@ change resets the clean count. Run all path-specific validation, including the
 docs build, docs and release-state audits, skill validation, and
 `git diff --check`.
 
-Commit and push through `.claude/commands/commit.md`. Direct commits to `main`
-are allowed only when the user explicitly requested them; otherwise use a PR.
-Immediately before committing, fast-forward from `origin/main` and revalidate
-that the intended files are the only changes.
+Commit and push through `.claude/commands/commit.md`. An explicit invocation of
+this full shipping workflow authorizes the release-note and release-process
+documentation commit directly on `main`; do not open a PR for that post-release
+docs-only commit. Immediately before committing, fast-forward from `origin/main`
+and revalidate that the intended files are the only changes. Product-code fixes
+still return to the normal PR loop.
 
 ## 5. Deploy and verify docs
 

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -1427,6 +1427,11 @@ function checkE2eExampleIds() {
     "Example tests, normal Android build, and launch smoke:",
     "VegaOS/Kepler path:",
   );
+  const horizonTarget = extractBetween(
+    normalTargets,
+    "Horizon Android build and optional device path:",
+    "Onside iOS build-only path:",
+  );
   const vegaTarget = extractBetween(expoSection, "VegaOS/Kepler path:", null);
 
   for (const expected of [
@@ -1461,6 +1466,38 @@ function checkE2eExampleIds() {
         )}`,
       );
     }
+  }
+  for (const expected of [
+    '"${HORIZON_SERIAL:?Set HORIZON_SERIAL to the target Horizon device serial}"',
+    'adb -s "$HORIZON_SERIAL" install -r app/build/outputs/apk/debug/app-debug.apk',
+    'adb -s "$HORIZON_SERIAL" shell monkey -p dev.hyo.martie 1',
+  ]) {
+    if (!horizonTarget.includes(expected)) {
+      fail(`Expo Horizon device flow is missing ${JSON.stringify(expected)}`);
+    }
+  }
+  const manualStoreFlows = extractBetween(
+    workflow,
+    "## Manual Store Flows",
+    "## Final Report",
+  );
+  for (const expected of [
+    "verify reconnect/listener behavior",
+    "run the exposed purchase/restore flow",
+    "visibly marked as test or sandbox",
+    "Otherwise report build-only coverage",
+  ]) {
+    if (!manualStoreFlows.includes(expected)) {
+      fail(`Expo Horizon store flow is missing ${JSON.stringify(expected)}`);
+    }
+  }
+  const finalReport = extractBetween(workflow, "## Final Report", null);
+  if (
+    !finalReport.includes(
+      "Expo Horizon          | {serial/local Gradle} | build[/install/store flow] | PASS | ...",
+    )
+  ) {
+    fail("Expo Horizon final-report coverage row is missing");
   }
   for (const expected of [
     "dev.hyo.openiap.expo.example.main",
@@ -5991,6 +6028,8 @@ function checkFrameworkDependencyHygiene() {
     [
       "currently every five minutes",
       "`npm run deploy`; run `release.yml` with `version=current` only when",
+      "add the consolidated entry to",
+      "commit it directly to `main` together with any release-process doc updates",
       "do not open a PR for that post-release docs-only commit",
       "deployment. Run the Docs release workflow with",
       "only when the native-derived `spec` advanced",
@@ -5999,6 +6038,24 @@ function checkFrameworkDependencyHygiene() {
       "stop and explain that the immutable",
     ],
     "dependency release gate must preserve review cadence and conditional Docs releases",
+  );
+  expectIncludes(
+    ".codex/skills/loop-review/SKILL.md",
+    [
+      "Commit and push the reviewed release note and process-documentation changes",
+      "directly to `main`",
+      "Do not open a PR for",
+    ],
+    "loop-review must commit and push post-release documentation directly to main",
+  );
+  expectIncludes(
+    ".codex/skills/ship-release/SKILL.md",
+    [
+      "release-note and release-process",
+      "documentation commit directly on `main`",
+      "do not open a PR for that post-release",
+    ],
+    "ship-release must commit post-release documentation directly to main without a PR",
   );
   expectNotIncludes(
     ".claude/commands/release.md",

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -1481,13 +1481,18 @@ function checkE2eExampleIds() {
     "## Manual Store Flows",
     "## Final Report",
   );
+  const horizonStoreFlow = extractBetween(
+    manualStoreFlows,
+    "- Horizon:",
+    "- Onside:",
+  );
   for (const expected of [
     "verify reconnect/listener behavior",
     "run the exposed purchase/restore flow",
     "visibly marked as test or sandbox",
     "Otherwise report build-only coverage",
   ]) {
-    if (!manualStoreFlows.includes(expected)) {
+    if (!horizonStoreFlow.includes(expected)) {
       fail(`Expo Horizon store flow is missing ${JSON.stringify(expected)}`);
     }
   }

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -1432,9 +1432,13 @@ function checkE2eExampleIds() {
   for (const expected of [
     "shell monkey -p dev.hyo.martie 1",
     "dev.hyo.martie",
-    "-workspace ios/ExpoIAPExample.xcworkspace",
+    "-workspace ios/expoiapexample.xcworkspace",
     "-scheme ExpoIAPExample",
     "Debug-iphoneos/ExpoIAPExample.app",
+    "Variant amazonDebugRuntimeElements",
+    "ProductFlavor:platform[[:space:]]+\\| amazon",
+    "Variant horizonDebugRuntimeElements",
+    "ProductFlavor:platform[[:space:]]+\\| horizon",
   ]) {
     if (!normalTargets.includes(expected)) {
       fail(`Expo E2E normal targets are missing ${JSON.stringify(expected)}`);
@@ -1446,7 +1450,7 @@ function checkE2eExampleIds() {
     );
   }
   for (const staleName of [
-    "ios/expoiapexample.xcworkspace",
+    "ios/ExpoIAPExample.xcworkspace",
     "-scheme expoiapexample",
     "Debug-iphoneos/expoiapexample.app",
   ]) {
@@ -5987,7 +5991,8 @@ function checkFrameworkDependencyHygiene() {
     [
       "currently every five minutes",
       "`npm run deploy`; run `release.yml` with `version=current` only when",
-      "then run the docs deployment. Run the Docs release workflow with",
+      "do not open a PR for that post-release docs-only commit",
+      "deployment. Run the Docs release workflow with",
       "only when the native-derived `spec` advanced",
       "immutable existing `docs-{spec}` tag is never reused",
       "If a Docs GitHub Release is requested while",


### PR DESCRIPTION
## Summary

- align Expo iOS E2E commands with the clean-prebuild workspace name while retaining the actual scheme and app product names
- verify the selected Amazon and Horizon Gradle variants and document the optional Horizon device flow
- require post-release release-note and process-documentation commits to go directly to `main` without a PR
- enforce the updated workflow contract in the parity audit

## Verification

- [x] two clean `review-self` snapshots at least five minutes apart
- [x] `bun run audit:parity`
- [x] `node --test scripts/audit-agent-surfaces.test.mjs`
- [x] `cd scripts/agent && bun test`
- [x] `bun run audit:release-state`
- [x] Expo Amazon clean prebuild, variant selection, and `:app:assembleDebug`
- [x] Expo Horizon variant selection and `:app:assembleDebug`
- [x] `git diff --check`

## Device regression

Not required: this PR changes workflow documentation and its repository audit only; it does not change product or example runtime code.

## Preview

No recording was made per maintainer instruction. The changed surface is terminal workflow guidance rather than a visual UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Expo iOS build validation across standard and Onside configurations.
  - Added Amazon FireOS checks for the expected Android runtime variant.
  - Expanded Expo Horizon validation to include device installation, launch, purchase, and restore flows.
  - Updated reporting to reflect the broader Horizon coverage.

- **Documentation**
  - Clarified post-release documentation deployment and commit procedures.
  - Distinguished documentation updates from product-code changes in release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->