### PR TITLE
fix: repair Horizon examples and release evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
       - name: Audit npm override compatibility
         run: bun run audit:overrides
 
+      # security/SBOM.md restates the releasable component list for readers.
+      # Without this the copy drifts, which is how commerce-protocol shipped an
+      # SBOM artifact while the documented matrix said it did not exist.
+      - name: Audit SBOM documentation
+        run: bun run audit:sbom-docs
+
       - name: Verify independent Bun locks
         run: |
           for directory in \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,17 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE/scripts/ci/retry-gradle.sh" ./gradlew :openiap:assembleHorizonDebug
 
+      # The audit checks that the Example declares the app id; only the merged
+      # manifest shows what the build actually resolved it to. Without this a
+      # blank or missing property merges an empty value, which compiles and
+      # installs and then throws inside startConnection on a headset.
+      - name: Verify Horizon app id resolves in the merged manifest
+        working-directory: packages/google
+        run: |
+          "$GITHUB_WORKSPACE/scripts/ci/retry-gradle.sh" ./gradlew :Example:processHorizonDebugManifest
+          node "$GITHUB_WORKSPACE/scripts/verify-horizon-merged-manifest.mjs" \
+            Example/build/intermediates/merged_manifests/horizonDebug/processHorizonDebugManifest/AndroidManifest.xml
+
       - name: Build Fire OS flavor
         working-directory: packages/google
         run: |

--- a/.github/workflows/release-godot.yml
+++ b/.github/workflows/release-godot.yml
@@ -114,6 +114,10 @@ jobs:
           fi
           bash scripts/verify-ios-toolchain.sh
 
+      - name: Verify prebuilt binary digests
+        working-directory: .
+        run: node scripts/audit-godot-binary-digests.mjs
+
       - name: Verify macOS Frameworks
         if: ${{ inputs.notarize_macos }}
         run: |
@@ -130,7 +134,9 @@ jobs:
     needs: [validate-android, validate-ios]
     permissions:
       actions: write
+      attestations: write # bind the published ZIP to this workflow run
       contents: write
+      id-token: write
     runs-on: macos-26
     defaults:
       run:
@@ -339,6 +345,13 @@ jobs:
           cp scripts/fix_ios_embed.sh dist/addons/godot-iap/scripts/
           chmod +x dist/addons/godot-iap/scripts/fix_ios_embed.sh
 
+          # The ZIP is a primary distribution channel, so the licences have to
+          # travel in it. The generator fails rather than emitting an empty
+          # notice when an embedded component has no committed licence text.
+          cp LICENSE dist/addons/godot-iap/LICENSE
+          node "$GITHUB_WORKSPACE/scripts/generate-third-party-notices.mjs" \
+            godot dist/addons/godot-iap/THIRD_PARTY_NOTICES.md
+
           cp android/build/outputs/aar/godot-iap-release.aar dist/addons/godot-iap/android/GodotIap.release.aar
           cp android/build/outputs/aar/godot-iap-release.aar dist/addons/godot-iap/android/GodotIap.debug.aar
 
@@ -405,6 +418,14 @@ jobs:
           cd dist
           zip -yr "../godot-iap-$VERSION.zip" addons
 
+      # The ZIP is a primary distribution channel. Without this the only
+      # attested artifact is the SBOM, which records no hash for the ZIP it
+      # describes, so a replaced asset would verify clean.
+      - name: Attest release zip provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        with:
+          subject-path: libraries/godot-iap/godot-iap-${{ steps.version.outputs.VERSION }}.zip
+
       - name: Notarize macOS frameworks
         if: ${{ inputs.notarize_macos }}
         env:
@@ -460,6 +481,11 @@ jobs:
           test -x "$VERIFY_DIR/addons/godot-iap/scripts/fix_ios_embed.sh"
           test -d "$VERIFY_DIR/addons/godot-iap/bin/ios/GodotIap.framework"
           test -d "$VERIFY_DIR/addons/godot-iap/bin/ios/SwiftGodotRuntime.framework"
+          # MIT requires the notice to ship with the binary it covers.
+          test -s "$VERIFY_DIR/addons/godot-iap/LICENSE"
+          test -s "$VERIFY_DIR/addons/godot-iap/THIRD_PARTY_NOTICES.md"
+          grep -q 'SwiftGodotRuntime' "$VERIFY_DIR/addons/godot-iap/THIRD_PARTY_NOTICES.md"
+          grep -q 'Permission is hereby granted' "$VERIFY_DIR/addons/godot-iap/THIRD_PARTY_NOTICES.md"
           bash scripts/verify-ios-toolchain.sh "$VERIFY_DIR/addons/godot-iap/bin/ios"
           if [ "$NOTARIZE_MACOS" = "true" ]; then
             grep -q '^include_tags = \["ios", "macos"\]' "$VERIFY_DIR/addons/godot-iap/bin/godot_iap.gdextension"
@@ -568,6 +594,30 @@ jobs:
           draft: false
           prerelease: ${{ steps.version.outputs.is_prerelease }}
           body_path: /tmp/release-notes.md
+
+      # Download what the release actually serves and check it against the
+      # bytes this run built and attested. Everything before this verifies a
+      # local file; only this verifies the artifact a user receives.
+      - name: Verify published release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: godot-iap-${{ steps.version.outputs.VERSION }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          LOCAL_ZIP="libraries/godot-iap/godot-iap-$VERSION.zip"
+          EXPECTED="$(shasum -a 256 "$LOCAL_ZIP" | cut -d' ' -f1)"
+          PUBLISHED_DIR="$(mktemp -d)"
+          gh release download "$RELEASE_TAG" \
+            --pattern "godot-iap-$VERSION.zip" \
+            --dir "$PUBLISHED_DIR"
+          PUBLISHED="$PUBLISHED_DIR/godot-iap-$VERSION.zip"
+          ACTUAL="$(shasum -a 256 "$PUBLISHED" | cut -d' ' -f1)"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::published asset digest $ACTUAL does not match the built artifact $EXPECTED"
+            exit 1
+          fi
+          gh attestation verify "$PUBLISHED" --repo "$GITHUB_REPOSITORY"
+          echo "Published godot-iap-$VERSION.zip verified: sha256:$ACTUAL"
 
       - name: Dispatch SBOM
         env:

--- a/libraries/flutter_inapp_purchase/example/android/app/build.gradle
+++ b/libraries/flutter_inapp_purchase/example/android/app/build.gradle
@@ -79,9 +79,11 @@ android {
         missingDimensionStrategy 'platform', openIapFlavor
 
         // Configure Horizon App ID if enabled
+        // Ships the shared example app id like the other OpenIAP examples; an
+        // empty value would only surface as a startConnection crash on device.
         def horizonAppId = ""
         if (horizonEnabled) {
-            horizonAppId = localProperties.getProperty("HORIZON_APP_ID") ?: ""
+            horizonAppId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"
         }
         manifestPlaceholders = [HORIZON_APP_ID: horizonAppId]
     }

--- a/libraries/flutter_inapp_purchase/example/android/app/build.gradle
+++ b/libraries/flutter_inapp_purchase/example/android/app/build.gradle
@@ -83,7 +83,9 @@ android {
         // empty value would only surface as a startConnection crash on device.
         def horizonAppId = ""
         if (horizonEnabled) {
-            horizonAppId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"
+            // Blank counts as absent: getProperty returns "" for a key present
+            // with no value, and "" is non-null, so elvis alone would keep it.
+            horizonAppId = localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "31705015229097839"
         }
         manifestPlaceholders = [HORIZON_APP_ID: horizonAppId]
     }

--- a/libraries/godot-iap/prebuilt-binaries.sha256
+++ b/libraries/godot-iap/prebuilt-binaries.sha256
@@ -1,0 +1,13 @@
+# SHA-256 of the native binaries that ship inside the godot-iap addon ZIP.
+#
+# These frameworks are committed rather than compiled by CI, so without this
+# manifest nothing records or verifies the bytes users execute. `bun run
+# audit:godot-binaries` recomputes them, and the release refuses to publish a
+# ZIP whose binaries do not match.
+#
+# Regenerate after an intentional rebuild:
+#   bun run audit:godot-binaries --write
+0e9914201189d1409ad294228986b6751e1f4cb9a2bdd2192b98da8852214dd9  addons/godot-iap/bin/ios/GodotIap.framework/GodotIap
+89a1f9306992f6b83be0432c9bdec83454d6cf1393e19b6f4c2b2422bd9253b3  addons/godot-iap/bin/ios/SwiftGodotRuntime.framework/SwiftGodotRuntime
+cfdb4e4b0ddaab250e609e29467c37b21162e5a71212f6177a8a246e9b3ceb28  addons/godot-iap/bin/macos/GodotIap.framework/GodotIap
+66585c71f205ef0b4c5b663ca9082535a42f447f0a23e033e1e0e01d2db0709a  addons/godot-iap/bin/macos/SwiftGodotRuntime.framework/SwiftGodotRuntime

--- a/libraries/godot-iap/third-party/SwiftGodot-LICENSE
+++ b/libraries/godot-iap/third-party/SwiftGodot-LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2020-2024 Miguel de Icaza (https://github.com/migueldeicaza)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/libraries/kmp-iap/example/composeApp/src/androidMain/AndroidManifest.xml
+++ b/libraries/kmp-iap/example/composeApp/src/androidMain/AndroidManifest.xml
@@ -16,5 +16,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- Horizon OS (Meta Quest): the billing client reads the app id from
+             the manifest, and startConnection throws without it. -->
+        <meta-data
+            android:name="com.meta.horizon.platform.HORIZON_APP_ID"
+            android:value="31705015229097839" />
     </application>
 </manifest>

--- a/libraries/kmp-iap/example/run-ios.sh
+++ b/libraries/kmp-iap/example/run-ios.sh
@@ -9,7 +9,7 @@ echo "Building iOS app..."
 cd "$SCRIPT_DIR"
 
 # Build the Kotlin Multiplatform part first
-./gradlew :composeApp:linkPodDebugFrameworkIosSimulatorArm64
+./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
 
 # Build and run the iOS app
 cd iosApp

--- a/libraries/maui-iap/example/OpenIap.Maui.Example/Platforms/Android/AndroidManifest.xml
+++ b/libraries/maui-iap/example/OpenIap.Maui.Example/Platforms/Android/AndroidManifest.xml
@@ -4,5 +4,11 @@
     <application
         android:allowBackup="true"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true" />
+        android:usesCleartextTraffic="true">
+        <!-- Horizon OS (Meta Quest): the billing client reads the app id from
+             the manifest, and startConnection throws without it. -->
+        <meta-data
+            android:name="com.meta.horizon.platform.HORIZON_APP_ID"
+            android:value="31705015229097839" />
+    </application>
 </manifest>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "graph:impact": "node scripts/graph-impact.mjs",
     "audit:sbom-docs": "node --test scripts/audit-sbom-docs.test.mjs && node scripts/audit-sbom-docs.mjs",
     "audit:godot-binaries": "node --test scripts/audit-godot-binary-digests.test.mjs && node scripts/audit-godot-binary-digests.mjs",
-    "licenses:inventory": "node scripts/generate-third-party-notices.mjs",
+    "licenses:inventory": "node scripts/generate-third-party-notices.mjs godot --inventory",
     "audit:horizon-app-id": "node --test scripts/audit-horizon-example-app-id.test.mjs scripts/verify-horizon-merged-manifest.test.mjs && node scripts/audit-horizon-example-app-id.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "audit:facts": "node --test scripts/audit-facts.test.mjs scripts/graph-impact.test.mjs && node scripts/audit-facts.mjs",
     "graph:impact": "node scripts/graph-impact.mjs",
     "audit:sbom-docs": "node --test scripts/audit-sbom-docs.test.mjs && node scripts/audit-sbom-docs.mjs",
-    "audit:godot-binaries": "node --test scripts/audit-godot-binary-digests.test.mjs && node scripts/audit-godot-binary-digests.mjs"
+    "audit:godot-binaries": "node --test scripts/audit-godot-binary-digests.test.mjs && node scripts/audit-godot-binary-digests.mjs",
+    "licenses:inventory": "node scripts/generate-third-party-notices.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "prepare": "husky",
     "audit:release-sync": "node --test scripts/audit-release-sync-script.test.mjs && node scripts/audit-release-sync-script.mjs",
     "audit:facts": "node --test scripts/audit-facts.test.mjs scripts/graph-impact.test.mjs && node scripts/audit-facts.mjs",
-    "graph:impact": "node scripts/graph-impact.mjs"
+    "graph:impact": "node scripts/graph-impact.mjs",
+    "audit:sbom-docs": "node --test scripts/audit-sbom-docs.test.mjs && node scripts/audit-sbom-docs.mjs",
+    "audit:godot-binaries": "node --test scripts/audit-godot-binary-digests.test.mjs && node scripts/audit-godot-binary-digests.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "graph:impact": "node scripts/graph-impact.mjs",
     "audit:sbom-docs": "node --test scripts/audit-sbom-docs.test.mjs && node scripts/audit-sbom-docs.mjs",
     "audit:godot-binaries": "node --test scripts/audit-godot-binary-digests.test.mjs && node scripts/audit-godot-binary-digests.mjs",
-    "licenses:inventory": "node scripts/generate-third-party-notices.mjs"
+    "licenses:inventory": "node scripts/generate-third-party-notices.mjs",
+    "audit:horizon-app-id": "node --test scripts/audit-horizon-example-app-id.test.mjs scripts/verify-horizon-merged-manifest.test.mjs && node scripts/audit-horizon-example-app-id.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/google/Example/build.gradle.kts
+++ b/packages/google/Example/build.gradle.kts
@@ -61,11 +61,14 @@ android {
 
         // Ships the shared example app id like the framework examples; an empty
         // value would only surface as a startConnection crash on device.
-        val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID")
-            ?: localProperties.getProperty("EXAMPLE_OPENIAP_APP_ID")
-            ?: (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)
-            ?: (project.findProperty("EXAMPLE_OPENIAP_APP_ID") as String?)
-            ?: "31705015229097839"
+        // Blank counts as absent: getProperty returns "" for a key with no
+        // value, and "" is non-null, so elvis alone would keep it.
+        val appId = listOf(
+            localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),
+            localProperties.getProperty("EXAMPLE_OPENIAP_APP_ID"),
+            project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?,
+            project.findProperty("EXAMPLE_OPENIAP_APP_ID") as String?,
+        ).firstOrNull { !it.isNullOrBlank() } ?: "31705015229097839"
         buildConfigField("String", "HORIZON_APP_ID", "\"${appId}\"")
         // Ensure placeholder exists for all variants (play included)
         manifestPlaceholders["HORIZON_APP_ID"] = appId
@@ -93,9 +96,10 @@ android {
             buildConfigField("String", "OPENIAP_STORE", "\"horizon\"")
 
             // Dynamically inject the Horizon App ID into AndroidManifest
-            val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID")
-                ?: (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)
-                ?: "31705015229097839"
+            val appId = listOf(
+                localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),
+                project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?,
+            ).firstOrNull { !it.isNullOrBlank() } ?: "31705015229097839"
             manifestPlaceholders["HORIZON_APP_ID"] = appId
         }
 

--- a/packages/google/Example/build.gradle.kts
+++ b/packages/google/Example/build.gradle.kts
@@ -59,11 +59,13 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 
+        // Ships the shared example app id like the framework examples; an empty
+        // value would only surface as a startConnection crash on device.
         val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID")
             ?: localProperties.getProperty("EXAMPLE_OPENIAP_APP_ID")
             ?: (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)
             ?: (project.findProperty("EXAMPLE_OPENIAP_APP_ID") as String?)
-            ?: ""
+            ?: "31705015229097839"
         buildConfigField("String", "HORIZON_APP_ID", "\"${appId}\"")
         // Ensure placeholder exists for all variants (play included)
         manifestPlaceholders["HORIZON_APP_ID"] = appId
@@ -93,7 +95,7 @@ android {
             // Dynamically inject the Horizon App ID into AndroidManifest
             val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID")
                 ?: (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)
-                ?: ""
+                ?: "31705015229097839"
             manifestPlaceholders["HORIZON_APP_ID"] = appId
         }
 

--- a/packages/google/local.properties.example
+++ b/packages/google/local.properties.example
@@ -4,8 +4,9 @@
 # Location of the SDK. This is only used by Gradle.
 sdk.dir=/path/to/your/Android/sdk
 
-# Horizon OS App ID (Meta Quest)
-horizon.app.id=YOUR_HORIZON_APP_ID
+# Horizon OS App ID (Meta Quest). Optional: the Example falls back to the
+# shared OpenIAP example app id when this is unset.
+EXAMPLE_HORIZON_APP_ID=YOUR_HORIZON_APP_ID
 
 # IAPKit publishable key for mobile purchase verification.
 # Never put an openiap-kit_sk_ secret admin key in an app build.

--- a/scripts/audit-deprecation-schedule.mjs
+++ b/scripts/audit-deprecation-schedule.mjs
@@ -30,6 +30,11 @@ const IGNORED_SEGMENTS = new Set([
   "DerivedData",
   "node_modules",
   "obj",
+  // SwiftPM checkout cache. It vendors this repository's own sources, so a
+  // derivedDataPath that "build"/"DerivedData" do not cover (for example the
+  // ios/build-e2e-onside in .claude/commands/e2e-tests.md) otherwise reports
+  // the vendored copy as project source.
+  "SourcePackages",
 ]);
 
 export const completedRemovalRules = [

--- a/scripts/audit-deprecation-schedule.test.mjs
+++ b/scripts/audit-deprecation-schedule.test.mjs
@@ -13,7 +13,10 @@ import {
   completedRemovalRules,
 } from "./audit-deprecation-schedule.mjs";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 
 test("completed removal inventory covers every coordinated package", () => {
   assert.deepEqual(
@@ -185,7 +188,9 @@ test("repository schema deprecations all target a future removal train", () => {
     ).spec.split(".")[0],
   );
   for (const entry of deprecations.entries) {
-    const removalMajor = Number(/OpenIAP (\d+)\.\d+\.$/.exec(entry.reason)?.[1]);
+    const removalMajor = Number(
+      /OpenIAP (\d+)\.\d+\.$/.exec(entry.reason)?.[1],
+    );
     assert.ok(
       Number.isFinite(removalMajor),
       `${entry.ownerPath} must name its removal train`,
@@ -219,4 +224,31 @@ test("schema deprecation audit rejects malformed spec versions", () => {
     collectSchemaDeprecationFailures({ entries: [], issues: [] }, "not-semver"),
     ["openiap-versions.json: Invalid OpenIAP Spec version: 'not-semver'"],
   );
+});
+
+test("the walker skips SwiftPM checkouts of this repository", () => {
+  // An iOS derivedDataPath outside the "build"/"DerivedData" names — for
+  // example the ios/build-e2e-onside in .claude/commands/e2e-tests.md —
+  // leaves a SourcePackages tree that vendors this repository's own sources.
+  const fixture = path.join(repoRoot, ".tmp-source-packages-fixture");
+  const vendored = path.join(fixture, "SourcePackages", "checkouts", "openiap");
+  const authored = path.join(fixture, "src");
+  try {
+    fs.mkdirSync(vendored, { recursive: true });
+    fs.mkdirSync(authored, { recursive: true });
+    fs.writeFileSync(path.join(vendored, "Vendored.kt"), "val x = Removed\n");
+    fs.writeFileSync(path.join(authored, "Authored.kt"), "val y = Removed\n");
+
+    const matches = collectForbiddenMatches({
+      roots: [".tmp-source-packages-fixture"],
+      tokens: ["Removed"],
+    });
+
+    assert.deepEqual(
+      matches.map((match) => match.file),
+      [".tmp-source-packages-fixture/src/Authored.kt"],
+    );
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
 });

--- a/scripts/audit-godot-binary-digests.mjs
+++ b/scripts/audit-godot-binary-digests.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// The godot-iap addon ships native frameworks that are committed to the
+// repository rather than compiled by CI, so nothing in the release pipeline
+// otherwise records or verifies the bytes users execute. This audit pins them.
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const GODOT_ROOT = "libraries/godot-iap";
+export const DIGEST_MANIFEST = `${GODOT_ROOT}/prebuilt-binaries.sha256`;
+const BINARY_ROOT = `${GODOT_ROOT}/addons/godot-iap/bin`;
+// Identify payloads by Mach-O magic rather than by extension, so editor
+// metadata and future file types classify themselves.
+const MACH_O_MAGIC = new Set([
+  0xfeedface,
+  0xcefaedfe, // 32-bit, both byte orders
+  0xfeedfacf,
+  0xcffaedfe, // 64-bit, both byte orders
+  0xcafebabe,
+  0xbebafeca, // universal ("fat") archives
+]);
+
+const isMachO = (absolute) => {
+  const handle = fs.openSync(absolute, "r");
+  try {
+    const head = Buffer.alloc(4);
+    if (fs.readSync(handle, head, 0, 4, 0) < 4) return false;
+    return MACH_O_MAGIC.has(head.readUInt32BE(0));
+  } finally {
+    fs.closeSync(handle);
+  }
+};
+
+export function parseDigestManifest(contents) {
+  const entries = [];
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const match = trimmed.match(/^([0-9a-f]{64})\s+(\S.*)$/);
+    if (!match) {
+      entries.push({ malformed: trimmed });
+      continue;
+    }
+    entries.push({ digest: match[1], file: match[2] });
+  }
+  return entries;
+}
+
+const walk = (dir, acc = []) => {
+  if (!fs.existsSync(dir)) return acc;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const next = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(next, acc);
+    else acc.push(next);
+  }
+  return acc;
+};
+
+export function listTrackedBinaries(repoRoot) {
+  const root = path.resolve(repoRoot, BINARY_ROOT);
+  return walk(root)
+    .filter((file) => isMachO(file))
+    .map((file) =>
+      path
+        .relative(path.resolve(repoRoot, GODOT_ROOT), file)
+        .split(path.sep)
+        .join("/"),
+    )
+    .sort();
+}
+
+export function digestOf(repoRoot, relativeFile) {
+  const absolute = path.resolve(repoRoot, GODOT_ROOT, relativeFile);
+  return crypto
+    .createHash("sha256")
+    .update(fs.readFileSync(absolute))
+    .digest("hex");
+}
+
+export function collectGodotBinaryDigestFailures(repoRoot) {
+  const manifestPath = path.resolve(repoRoot, DIGEST_MANIFEST);
+  if (!fs.existsSync(manifestPath)) {
+    return [`${DIGEST_MANIFEST} is missing`];
+  }
+  const failures = [];
+  const entries = parseDigestManifest(fs.readFileSync(manifestPath, "utf8"));
+  for (const entry of entries) {
+    if (entry.malformed) {
+      failures.push(
+        `${DIGEST_MANIFEST} has a malformed line: ${entry.malformed}`,
+      );
+    }
+  }
+  const recorded = new Map(
+    entries
+      .filter((entry) => entry.digest)
+      .map((entry) => [entry.file, entry.digest]),
+  );
+  const present = listTrackedBinaries(repoRoot);
+
+  // A binary added to the addon without a digest is the case this exists for.
+  for (const file of present) {
+    if (!recorded.has(file)) {
+      failures.push(`${file} ships in the addon but has no recorded digest`);
+    }
+  }
+  for (const [file] of recorded) {
+    if (!present.includes(file)) {
+      failures.push(
+        `${DIGEST_MANIFEST} records ${file}, which no longer exists`,
+      );
+    }
+  }
+  for (const file of present) {
+    const expected = recorded.get(file);
+    if (!expected) continue;
+    const actual = digestOf(repoRoot, file);
+    if (actual !== expected) {
+      failures.push(`${file} changed: recorded ${expected}, found ${actual}`);
+    }
+  }
+  return failures;
+}
+
+export function renderDigestManifest(repoRoot, header) {
+  const lines = listTrackedBinaries(repoRoot).map(
+    (file) => `${digestOf(repoRoot, file)}  ${file}`,
+  );
+  return `${header.trimEnd()}\n${lines.join("\n")}\n`;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const repoRoot = path.resolve(import.meta.dirname, "..");
+  const manifestPath = path.resolve(repoRoot, DIGEST_MANIFEST);
+  if (process.argv.includes("--write")) {
+    const header = fs
+      .readFileSync(manifestPath, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("#") || line.trim() === "")
+      .join("\n");
+    fs.writeFileSync(manifestPath, renderDigestManifest(repoRoot, header));
+    console.log(`rewrote ${DIGEST_MANIFEST}`);
+    process.exit(0);
+  }
+  const failures = collectGodotBinaryDigestFailures(repoRoot);
+  for (const failure of failures) {
+    console.error(`FAIL ${failure}`);
+  }
+  if (failures.length > 0) {
+    console.error(
+      "\nIf the change was intentional, rebuild and run:\n" +
+        "  bun run audit:godot-binaries --write",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Godot prebuilt binary digests verified (${listTrackedBinaries(repoRoot).length} binaries).`,
+  );
+}

--- a/scripts/audit-godot-binary-digests.test.mjs
+++ b/scripts/audit-godot-binary-digests.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  DIGEST_MANIFEST,
+  collectGodotBinaryDigestFailures,
+  digestOf,
+  listTrackedBinaries,
+  parseDigestManifest,
+} from "./audit-godot-binary-digests.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("the shipped Godot binaries match their recorded digests", () => {
+  assert.deepEqual(collectGodotBinaryDigestFailures(repoRoot), []);
+});
+
+test("every binary that ships is covered", () => {
+  const covered = new Set(
+    parseDigestManifest(
+      fs.readFileSync(path.join(repoRoot, DIGEST_MANIFEST), "utf8"),
+    )
+      .filter((entry) => entry.digest)
+      .map((entry) => entry.file),
+  );
+  const shipped = listTrackedBinaries(repoRoot);
+  assert.ok(shipped.length > 0, "no binaries were discovered");
+  for (const file of shipped) {
+    assert.ok(covered.has(file), `${file} has no recorded digest`);
+  }
+});
+
+test("comments and blank lines are ignored, malformed lines are not", () => {
+  const entries = parseDigestManifest(
+    ["# header", "", `${"a".repeat(64)}  bin/x`, "garbage line"].join("\n"),
+  );
+  assert.deepEqual(entries, [
+    { digest: "a".repeat(64), file: "bin/x" },
+    { malformed: "garbage line" },
+  ]);
+});
+
+test("a changed binary is reported with both digests", () => {
+  const file = listTrackedBinaries(repoRoot)[0];
+  const real = digestOf(repoRoot, file);
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "godot-digests-"));
+  try {
+    // Copy the addon tree, then rewrite the manifest with one wrong digest.
+    const source = path.join(repoRoot, "libraries/godot-iap");
+    const target = path.join(scratch, "libraries/godot-iap");
+    fs.cpSync(source, target, { recursive: true });
+    const manifest = path.join(scratch, DIGEST_MANIFEST);
+    fs.writeFileSync(
+      manifest,
+      fs.readFileSync(manifest, "utf8").replace(real, "0".repeat(64)),
+    );
+    const failures = collectGodotBinaryDigestFailures(scratch);
+    assert.equal(failures.length, 1);
+    assert.match(
+      failures[0],
+      new RegExp(`^${file} changed: recorded 0{64}, found ${real}$`),
+    );
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("a missing manifest is reported instead of passing", () => {
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "godot-digests-empty-"));
+  try {
+    assert.deepEqual(collectGodotBinaryDigestFailures(empty), [
+      `${DIGEST_MANIFEST} is missing`,
+    ]);
+  } finally {
+    fs.rmSync(empty, { recursive: true, force: true });
+  }
+});

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Every example that can build the Horizon flavor must resolve a non-empty
+// HORIZON_APP_ID. Horizon's billing client reads the id from the merged
+// manifest and throws inside startConnection when it is missing, so an example
+// that omits it still compiles and only fails once it runs on a headset.
+import fs from "node:fs";
+import path from "node:path";
+
+export const HORIZON_APP_ID_META_DATA_NAME =
+  "com.meta.horizon.platform.HORIZON_APP_ID";
+
+// Each example declares the id in whichever file its toolchain merges into the
+// Android manifest.
+export const HORIZON_APP_ID_SOURCES = [
+  {
+    library: "react-native-iap",
+    file: "libraries/react-native-iap/example/android/app/src/main/AndroidManifest.xml",
+  },
+  {
+    library: "expo-iap",
+    file: "libraries/expo-iap/example/app.config.ts",
+  },
+  {
+    library: "flutter_inapp_purchase",
+    file: "libraries/flutter_inapp_purchase/example/android/app/build.gradle",
+  },
+  {
+    library: "kmp-iap",
+    file: "libraries/kmp-iap/example/composeApp/src/androidMain/AndroidManifest.xml",
+  },
+  {
+    library: "maui-iap",
+    file: "libraries/maui-iap/example/OpenIap.Maui.Example/Platforms/Android/AndroidManifest.xml",
+  },
+];
+
+// A literal id, or a placeholder whose fallback is a literal id. Rejects the
+// empty-string fallback that silently produces an unusable build.
+const LITERAL_APP_ID = /\b\d{10,}\b/;
+
+export function inspectHorizonAppIdSource(contents) {
+  if (!LITERAL_APP_ID.test(contents)) {
+    return "declares no literal Horizon app id";
+  }
+  for (const match of contents.matchAll(
+    /HORIZON_APP_ID"?\s*\)?\s*\?:\s*(""|'')/g,
+  )) {
+    return `falls back to an empty app id at ${JSON.stringify(match[0])}`;
+  }
+  return null;
+}
+
+export function collectHorizonExampleAppIdFailures(repoRoot) {
+  const failures = [];
+  for (const { library, file } of HORIZON_APP_ID_SOURCES) {
+    const absolute = path.resolve(repoRoot, file);
+    if (!fs.existsSync(absolute)) {
+      failures.push(`${library}: ${file} is missing`);
+      continue;
+    }
+    const issue = inspectHorizonAppIdSource(fs.readFileSync(absolute, "utf8"));
+    if (issue) {
+      failures.push(`${library}: ${file} ${issue}`);
+    }
+  }
+  return failures;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const repoRoot = path.resolve(import.meta.dirname, "..");
+  const failures = collectHorizonExampleAppIdFailures(repoRoot);
+  for (const failure of failures) {
+    console.error(`FAIL ${failure}`);
+  }
+  if (failures.length > 0) {
+    process.exit(1);
+  }
+  console.log(
+    `OK ${HORIZON_APP_ID_SOURCES.length} Horizon examples resolve an app id`,
+  );
+}

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -5,6 +5,7 @@
 // that omits it still compiles and only fails once it runs on a headset.
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 export const HORIZON_APP_ID_META_DATA_NAME =
   "com.meta.horizon.platform.HORIZON_APP_ID";
@@ -12,6 +13,11 @@ export const HORIZON_APP_ID_META_DATA_NAME =
 // Each example declares the id in whichever file its toolchain merges into the
 // Android manifest, so each kind is checked against its own syntax.
 export const HORIZON_APP_ID_SOURCES = [
+  {
+    library: "packages/google",
+    file: "packages/google/Example/build.gradle.kts",
+    kind: "gradle-fallback",
+  },
   {
     library: "react-native-iap",
     file: "libraries/react-native-iap/example/android/app/src/main/AndroidManifest.xml",
@@ -43,40 +49,76 @@ export const HORIZON_APP_ID_SOURCES = [
 // bound to the Horizon declaration: a bare number elsewhere in the file leaves
 // the merged manifest just as empty.
 const APP_ID = String.raw`\d{10,}`;
+const APP_ID_LITERAL = new RegExp(`^["']${APP_ID}["']$`);
 
-const XML_COMMENTS = /<!--[\s\S]*?-->/g;
-const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data>)/g;
+const stripXmlComments = (source) => source.replace(/<!--[\s\S]*?-->/g, "");
+const stripLineComments = (source) =>
+  source.replace(/(^|[^:])\/\/[^\n]*/g, "$1");
 
+const APPLICATION_ELEMENT = /<application\b[\s\S]*?<\/application\s*>/;
+const NESTED_ELEMENT =
+  /<(activity|service|receiver|provider)\b[\s\S]*?<\/\1\s*>/g;
+const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data\s*>)/g;
+
+// Horizon reads the id from <application>. A meta-data nested inside an
+// activity or service merges somewhere the platform never looks.
 const inspectAndroidManifest = (contents) => {
-  const source = contents.replace(XML_COMMENTS, "");
+  const application = stripXmlComments(contents).match(APPLICATION_ELEMENT);
+  if (!application) return "has no <application> element";
+  const direct = application[0].replace(NESTED_ELEMENT, "");
   let declared = false;
-  for (const [element] of source.matchAll(META_DATA_ELEMENT)) {
+  for (const [element] of direct.matchAll(META_DATA_ELEMENT)) {
     if (!element.includes(HORIZON_APP_ID_META_DATA_NAME)) continue;
     declared = true;
     if (new RegExp(`android:value\\s*=\\s*"${APP_ID}"`).test(element)) {
       return null;
     }
   }
-  return declared
-    ? "declares the Horizon meta-data without a literal app id"
+  if (declared) {
+    return "declares the Horizon meta-data without a literal app id";
+  }
+  return stripXmlComments(contents).includes(HORIZON_APP_ID_META_DATA_NAME)
+    ? "declares the Horizon meta-data outside <application>"
     : "declares no Horizon app id meta-data";
 };
 
+const APP_ID_PROPERTY = /(?:HORIZON|OPENIAP)_APP_ID"\s*\)/;
+const ELVIS_CONTINUATION = /^\s*\?:/;
+const ELVIS_OPERAND = /\?:\s*([^\n]+?)\s*$/;
+
+// Both Gradle examples resolve the id through an elvis chain. Only the value
+// that terminates the chain reaches manifestPlaceholders, so that is what must
+// be a literal — a literal anywhere else in the file is not the fallback.
 const inspectGradleFallback = (contents) => {
-  const read = String.raw`HORIZON_APP_ID"\s*\)\s*\?:\s*`;
-  if (new RegExp(`${read}"${APP_ID}"`).test(contents)) return null;
-  if (new RegExp(`${read}(?:""|'')`).test(contents)) {
-    return "falls back to an empty app id";
+  const source = stripLineComments(contents);
+  const start = source.search(APP_ID_PROPERTY);
+  if (start === -1) return "reads no Horizon app id property";
+  const lines = source.slice(start).split("\n");
+  const chain = [lines[0]];
+  for (let index = 1; index < lines.length; index += 1) {
+    if (!ELVIS_CONTINUATION.test(lines[index])) break;
+    chain.push(lines[index]);
   }
-  return "does not fall back to a literal Horizon app id";
+  const operands = chain
+    .map((line) => line.match(ELVIS_OPERAND))
+    .filter(Boolean)
+    .map((match) => match[1].trim());
+  if (operands.length === 0) return "has no fallback for the Horizon app id";
+  const terminal = operands[operands.length - 1];
+  if (APP_ID_LITERAL.test(terminal)) return null;
+  return terminal === '""' || terminal === "''"
+    ? "falls back to an empty app id"
+    : `falls back to ${terminal} instead of a literal Horizon app id`;
 };
 
-const inspectExpoPluginConfig = (contents) => {
-  const bound = new RegExp(
-    String.raw`horizon\s*:\s*\{[^}]*?appId\s*:\s*['"]${APP_ID}['"]`,
-  );
-  return bound.test(contents) ? null : "does not set a literal horizon.appId";
-};
+const EXPO_HORIZON_APP_ID = new RegExp(
+  String.raw`horizon\s*:\s*\{[^}]*?appId\s*:\s*['"]${APP_ID}['"]`,
+);
+
+const inspectExpoPluginConfig = (contents) =>
+  EXPO_HORIZON_APP_ID.test(stripLineComments(contents))
+    ? null
+    : "does not set a literal horizon.appId";
 
 const INSPECTORS = {
   "android-manifest": inspectAndroidManifest,
@@ -109,7 +151,13 @@ export function collectHorizonExampleAppIdFailures(repoRoot) {
   return failures;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// pathToFileURL, not `file://${argv[1]}` — the latter never matches when the
+// checkout path needs percent-encoding, which turns this CLI into a silent
+// no-op that exits 0.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   const repoRoot = path.resolve(import.meta.dirname, "..");
   const failures = collectHorizonExampleAppIdFailures(repoRoot);
   for (const failure of failures) {

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -10,55 +10,98 @@ export const HORIZON_APP_ID_META_DATA_NAME =
   "com.meta.horizon.platform.HORIZON_APP_ID";
 
 // Each example declares the id in whichever file its toolchain merges into the
-// Android manifest.
+// Android manifest, so each kind is checked against its own syntax.
 export const HORIZON_APP_ID_SOURCES = [
   {
     library: "react-native-iap",
     file: "libraries/react-native-iap/example/android/app/src/main/AndroidManifest.xml",
+    kind: "android-manifest",
   },
   {
     library: "expo-iap",
     file: "libraries/expo-iap/example/app.config.ts",
+    kind: "expo-plugin-config",
   },
   {
     library: "flutter_inapp_purchase",
     file: "libraries/flutter_inapp_purchase/example/android/app/build.gradle",
+    kind: "gradle-fallback",
   },
   {
     library: "kmp-iap",
     file: "libraries/kmp-iap/example/composeApp/src/androidMain/AndroidManifest.xml",
+    kind: "android-manifest",
   },
   {
     library: "maui-iap",
     file: "libraries/maui-iap/example/OpenIap.Maui.Example/Platforms/Android/AndroidManifest.xml",
+    kind: "android-manifest",
   },
 ];
 
-// A literal id, or a placeholder whose fallback is a literal id. Rejects the
-// empty-string fallback that silently produces an unusable build.
-const LITERAL_APP_ID = /\b\d{10,}\b/;
+// Horizon app ids are long numeric strings. The literal only counts when it is
+// bound to the Horizon declaration: a bare number elsewhere in the file leaves
+// the merged manifest just as empty.
+const APP_ID = String.raw`\d{10,}`;
 
-export function inspectHorizonAppIdSource(contents) {
-  if (!LITERAL_APP_ID.test(contents)) {
-    return "declares no literal Horizon app id";
+const XML_COMMENTS = /<!--[\s\S]*?-->/g;
+const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data>)/g;
+
+const inspectAndroidManifest = (contents) => {
+  const source = contents.replace(XML_COMMENTS, "");
+  let declared = false;
+  for (const [element] of source.matchAll(META_DATA_ELEMENT)) {
+    if (!element.includes(HORIZON_APP_ID_META_DATA_NAME)) continue;
+    declared = true;
+    if (new RegExp(`android:value\\s*=\\s*"${APP_ID}"`).test(element)) {
+      return null;
+    }
   }
-  for (const match of contents.matchAll(
-    /HORIZON_APP_ID"?\s*\)?\s*\?:\s*(""|'')/g,
-  )) {
-    return `falls back to an empty app id at ${JSON.stringify(match[0])}`;
+  return declared
+    ? "declares the Horizon meta-data without a literal app id"
+    : "declares no Horizon app id meta-data";
+};
+
+const inspectGradleFallback = (contents) => {
+  const read = String.raw`HORIZON_APP_ID"\s*\)\s*\?:\s*`;
+  if (new RegExp(`${read}"${APP_ID}"`).test(contents)) return null;
+  if (new RegExp(`${read}(?:""|'')`).test(contents)) {
+    return "falls back to an empty app id";
   }
-  return null;
+  return "does not fall back to a literal Horizon app id";
+};
+
+const inspectExpoPluginConfig = (contents) => {
+  const bound = new RegExp(
+    String.raw`horizon\s*:\s*\{[^}]*?appId\s*:\s*['"]${APP_ID}['"]`,
+  );
+  return bound.test(contents) ? null : "does not set a literal horizon.appId";
+};
+
+const INSPECTORS = {
+  "android-manifest": inspectAndroidManifest,
+  "gradle-fallback": inspectGradleFallback,
+  "expo-plugin-config": inspectExpoPluginConfig,
+};
+
+export function inspectHorizonAppIdSource(contents, kind) {
+  const inspect = INSPECTORS[kind];
+  if (!inspect) return `unknown source kind ${JSON.stringify(kind)}`;
+  return inspect(contents);
 }
 
 export function collectHorizonExampleAppIdFailures(repoRoot) {
   const failures = [];
-  for (const { library, file } of HORIZON_APP_ID_SOURCES) {
+  for (const { library, file, kind } of HORIZON_APP_ID_SOURCES) {
     const absolute = path.resolve(repoRoot, file);
     if (!fs.existsSync(absolute)) {
       failures.push(`${library}: ${file} is missing`);
       continue;
     }
-    const issue = inspectHorizonAppIdSource(fs.readFileSync(absolute, "utf8"));
+    const issue = inspectHorizonAppIdSource(
+      fs.readFileSync(absolute, "utf8"),
+      kind,
+    );
     if (issue) {
       failures.push(`${library}: ${file} ${issue}`);
     }

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -6,6 +6,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  maskKotlinCommentsAndStrings,
+  maskTypeScriptCommentsAndStrings,
+} from "./audit-purchase-payload-parity.mjs";
 
 export const HORIZON_APP_ID_META_DATA_NAME =
   "com.meta.horizon.platform.HORIZON_APP_ID";
@@ -51,28 +55,46 @@ export const HORIZON_APP_ID_SOURCES = [
 const APP_ID = String.raw`\d{10,}`;
 const APP_ID_LITERAL = new RegExp(`^["']${APP_ID}["']$`);
 
+// Structural scanning runs over masked text so a brace, paren, or comment
+// marker inside a string literal cannot be mistaken for syntax. The maskers
+// preserve offsets, so values are still read from the original source at the
+// same positions.
+// A match is real code only when the masker left that position intact:
+// comments and string bodies become spaces, while keywords and punctuation
+// survive. This lets values be read from the source without a comment counting.
+const matchesInCode = (
+  source,
+  masked,
+  pattern,
+  from = 0,
+  to = source.length,
+) => {
+  const found = [];
+  for (const match of source.slice(from, to).matchAll(pattern)) {
+    const at = from + match.index;
+    const anchor = match[0].search(/\S/);
+    if (masked[at + anchor] === source[at + anchor])
+      found.push({ ...match, index: at });
+  }
+  return found;
+};
+
+const maskedCode = (source, kind) =>
+  kind === "expo-plugin-config"
+    ? maskTypeScriptCommentsAndStrings(source)
+    : maskKotlinCommentsAndStrings(source);
+
 // Replace to a fixpoint: one pass over `<!-- <!-- -->` leaves a bare `<!--`,
 // so a single substitution is not a complete strip.
-const replaceToFixpoint = (source, pattern) => {
+const stripXmlComments = (source) => {
   let previous;
   let current = source;
   do {
     previous = current;
-    current = previous.replace(pattern, "");
+    current = previous.replace(/<!--[\s\S]*?-->/g, "");
   } while (current !== previous);
   return current;
 };
-
-const stripXmlComments = (source) =>
-  replaceToFixpoint(source, /<!--[\s\S]*?-->/g);
-
-// Kotlin, Groovy, and the Expo TypeScript config all use both comment forms,
-// and a commented-out declaration is not the active one.
-const stripCodeComments = (source) =>
-  replaceToFixpoint(source, /\/\*[\s\S]*?\*\//g).replace(
-    /(^|[^:])\/\/[^\n]*/g,
-    "$1",
-  );
 
 const APPLICATION_ELEMENT = /<application\b[\s\S]*?<\/application\s*>/;
 // activity-alias precedes activity: the alternation is ordered, and
@@ -104,48 +126,64 @@ const inspectAndroidManifest = (contents) => {
 };
 
 const APP_ID_PROPERTY = /(?:HORIZON|OPENIAP)_APP_ID["']\s*\)/g;
-const CONTINUATION = /^\s*(?:\?:|\.|\)|,)/;
 const ASSIGNMENT = /(?:^|\s)(?:val|var|def)\s+\w+\s*=|^\s*\w+\s*=[^=]/;
+// A wrapped line continues the statement it belongs to.
+const CONTINUATION = /^\s*(?:\?:|\?\.|\.|\)|\}|,)/;
 const STRING_LITERAL = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g;
 
+// Depth counts braces as well as parens: a multi-line `firstOrNull { … }` is
+// one statement, and stopping at the closing paren would cut off the fallback.
 const balanceOf = (line) =>
-  (line.match(/\(/g)?.length ?? 0) - (line.match(/\)/g)?.length ?? 0);
+  (line.match(/[({]/g)?.length ?? 0) - (line.match(/[)}]/g)?.length ?? 0);
 
-// Both Gradle examples resolve the id inside one statement, but they do not
-// share a shape: one is an elvis chain, the other a listOf(...).firstOrNull.
-// Rather than pattern-match either, take the whole statement that reads a
-// Horizon app id property and require the value it ends on to be a literal id.
-// A literal elsewhere in the file is not the fallback.
 // A build file can resolve the id more than once — packages/google does it in
 // defaultConfig and again in the horizon flavor — and the later one wins for
 // that flavor. Inspect every statement, not the first.
-export const extractAppIdStatements = (source) => {
+export const extractAppIdStatements = (source, masked = source) => {
   const lines = source.split("\n");
+  const maskedLines = masked.split("\n");
   const offsets = [];
   let cursor = 0;
-  for (const line of lines) {
+  for (const line of maskedLines) {
     offsets.push(cursor);
     cursor += line.length + 1;
   }
 
   const statements = [];
   const seen = new Set();
+  // Search the source so the quoted property name is visible, then keep only
+  // reads whose closing paren survived masking — a read inside a comment does
+  // not resolve anything.
   for (const match of source.matchAll(APP_ID_PROPERTY)) {
+    const close = match.index + match[0].length - 1;
+    if (masked[close] !== ")") continue;
     const line = offsets.findLastIndex((offset) => offset <= match.index);
 
     // The read can sit inside a multi-line expression, so walk back to the
-    // assignment that owns it before reading forward.
+    // assignment that owns it. Track depth so the walk cannot escape the block
+    // the read lives in and attach itself to an unrelated earlier assignment.
     let first = line;
-    while (first > 0 && !ASSIGNMENT.test(lines[first])) first -= 1;
+    let depth = 0;
+    while (first > 0 && !ASSIGNMENT.test(maskedLines[first])) {
+      const previous = first - 1;
+      // Stop rather than escape the block the read lives in, which would
+      // attach the statement to an unrelated earlier assignment.
+      if (depth + balanceOf(maskedLines[previous]) < 0) break;
+      depth += balanceOf(maskedLines[previous]);
+      first = previous;
+    }
+    // A read with no assignment above it still resolves something, so fall back
+    // to its own line. Skipping would make an unattributable read a silent pass.
+    if (!ASSIGNMENT.test(maskedLines[first])) first = line;
     if (seen.has(first)) continue;
     seen.add(first);
 
     const statement = [lines[first]];
-    let depth = balanceOf(lines[first]);
+    let open = balanceOf(maskedLines[first]);
     for (let next = first + 1; next < lines.length; next += 1) {
-      if (depth <= 0 && !CONTINUATION.test(lines[next])) break;
+      if (open <= 0 && !CONTINUATION.test(maskedLines[next])) break;
       statement.push(lines[next]);
-      depth += balanceOf(lines[next]);
+      open += balanceOf(maskedLines[next]);
     }
     statements.push(statement.join("\n"));
   }
@@ -156,7 +194,7 @@ export const extractAppIdStatements = (source) => {
 // present with no value, and "" is non-null, so a blank entry in the
 // developer's local.properties would defeat the literal fallback and put an
 // empty app id in the manifest. The statement must reject blank too.
-const REJECTS_BLANK = /isNullOrBlank|isNotBlank|\?\.trim\(\)|\.trim\(\)\s*\?:/;
+const REJECTS_BLANK = /isNullOrBlank|isNotBlank|\.trim\(\)/;
 
 export const inspectAppIdStatement = (statement) => {
   const literals = statement.match(STRING_LITERAL) ?? [];
@@ -174,7 +212,8 @@ export const inspectAppIdStatement = (statement) => {
 };
 
 const inspectGradleFallback = (contents) => {
-  const statements = extractAppIdStatements(stripCodeComments(contents));
+  const masked = maskedCode(contents, "gradle-fallback");
+  const statements = extractAppIdStatements(contents, masked);
   if (statements.length === 0) return "reads no Horizon app id property";
   for (const statement of statements) {
     const issue = inspectAppIdStatement(statement);
@@ -183,15 +222,15 @@ const inspectGradleFallback = (contents) => {
   return null;
 };
 
-// Brace-balanced rather than `[^}]*`, so a nested object between `horizon:`
-// and `appId:` does not truncate the block being searched.
-const extractBalancedBlock = (source, from) => {
+// Brace-balanced over masked text, so a brace inside a string neither truncates
+// the block nor stretches it into a later one.
+const extractBalancedBlock = (masked, from) => {
   let depth = 0;
-  for (let index = from; index < source.length; index += 1) {
-    if (source[index] === "{") depth += 1;
-    else if (source[index] === "}") {
+  for (let index = from; index < masked.length; index += 1) {
+    if (masked[index] === "{") depth += 1;
+    else if (masked[index] === "}") {
       depth -= 1;
-      if (depth === 0) return source.slice(from, index + 1);
+      if (depth === 0) return [from, index + 1];
     }
   }
   return null;
@@ -203,16 +242,24 @@ const LITERAL_APP_ID_ENTRY = new RegExp(
 );
 
 const inspectExpoPluginConfig = (contents) => {
-  const source = stripCodeComments(contents);
+  const masked = maskedCode(contents, "expo-plugin-config");
   let declared = false;
-  for (const match of source.matchAll(HORIZON_KEY)) {
-    const block = extractBalancedBlock(
-      source,
+  for (const match of masked.matchAll(HORIZON_KEY)) {
+    const span = extractBalancedBlock(
+      masked,
       match.index + match[0].length - 1,
     );
-    if (block === null) continue;
+    if (span === null) continue;
     declared = true;
-    if (LITERAL_APP_ID_ENTRY.test(block)) return null;
+    // Structure came from the masked text; the value comes from the source.
+    const bound = matchesInCode(
+      contents,
+      masked,
+      new RegExp(LITERAL_APP_ID_ENTRY.source, "g"),
+      span[0],
+      span[1],
+    );
+    if (bound.length > 0) return null;
   }
   return declared
     ? "declares horizon config without a literal appId"

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -9,7 +9,14 @@
 // that depends on which properties are set and how the expression
 // short-circuits, and reading it out of the build file's text can only
 // approximate it. `scripts/verify-horizon-merged-manifest.mjs` checks the value
-// the manifest merger actually produced, and CI runs it on a built variant.
+// the manifest merger actually produced.
+//
+// That merger check runs in CI for packages/google only, because it is the one
+// target whose Horizon variant CI already builds. A "templated-manifest" source
+// therefore has its declaration verified here and its resolved value verified
+// only where such a job exists; security/README.md records which. Do not close
+// that gap by re-adding a Gradle text check — the value is decided by the
+// merger, not by the build file's source.
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -19,8 +26,9 @@ export const HORIZON_APP_ID_META_DATA_NAME =
   "com.meta.horizon.platform.HORIZON_APP_ID";
 
 // "android-manifest"    — the manifest carries the literal id
-// "templated-manifest"  — the manifest carries a Gradle placeholder, and the
-//                         resolved value is verified against a built variant
+// "templated-manifest"  — the manifest carries a Gradle placeholder; the
+//                         resolved value needs a merger check on a built
+//                         variant, which exists for packages/google today
 // "expo-plugin-config"  — the config plugin binds the id
 export const HORIZON_APP_ID_SOURCES = [
   {

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -1,26 +1,32 @@
 #!/usr/bin/env node
-// Every example that can build the Horizon flavor must resolve a non-empty
-// HORIZON_APP_ID. Horizon's billing client reads the id from the merged
-// manifest and throws inside startConnection when it is missing, so an example
-// that omits it still compiles and only fails once it runs on a headset.
+// Every example that can build the Horizon flavor must declare
+// com.meta.horizon.platform.HORIZON_APP_ID, because the billing client reads it
+// from the merged manifest and throws inside startConnection when it is absent.
+// An example that omits it still compiles and only fails on a headset.
+//
+// This audit checks the DECLARATION, which is a static property of the source.
+// It deliberately does not try to prove what a Gradle expression resolves to —
+// that depends on which properties are set and how the expression
+// short-circuits, and reading it out of the build file's text can only
+// approximate it. `scripts/verify-horizon-merged-manifest.mjs` checks the value
+// the manifest merger actually produced, and CI runs it on a built variant.
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import {
-  maskKotlinCommentsAndStrings,
-  maskTypeScriptCommentsAndStrings,
-} from "./audit-purchase-payload-parity.mjs";
+import { maskTypeScriptCommentsAndStrings } from "./audit-purchase-payload-parity.mjs";
 
 export const HORIZON_APP_ID_META_DATA_NAME =
   "com.meta.horizon.platform.HORIZON_APP_ID";
 
-// Each example declares the id in whichever file its toolchain merges into the
-// Android manifest, so each kind is checked against its own syntax.
+// "android-manifest"    — the manifest carries the literal id
+// "templated-manifest"  — the manifest carries a Gradle placeholder, and the
+//                         resolved value is verified against a built variant
+// "expo-plugin-config"  — the config plugin binds the id
 export const HORIZON_APP_ID_SOURCES = [
   {
     library: "packages/google",
-    file: "packages/google/Example/build.gradle.kts",
-    kind: "gradle-fallback",
+    file: "packages/google/Example/src/main/AndroidManifest.xml",
+    kind: "templated-manifest",
   },
   {
     library: "react-native-iap",
@@ -34,8 +40,8 @@ export const HORIZON_APP_ID_SOURCES = [
   },
   {
     library: "flutter_inapp_purchase",
-    file: "libraries/flutter_inapp_purchase/example/android/app/build.gradle",
-    kind: "gradle-fallback",
+    file: "libraries/flutter_inapp_purchase/example/android/app/src/main/AndroidManifest.xml",
+    kind: "templated-manifest",
   },
   {
     library: "kmp-iap",
@@ -53,39 +59,9 @@ export const HORIZON_APP_ID_SOURCES = [
 // bound to the Horizon declaration: a bare number elsewhere in the file leaves
 // the merged manifest just as empty.
 const APP_ID = String.raw`\d{10,}`;
-const APP_ID_LITERAL = new RegExp(`^["']${APP_ID}["']$`);
 
-// Structural scanning runs over masked text so a brace, paren, or comment
-// marker inside a string literal cannot be mistaken for syntax. The maskers
-// preserve offsets, so values are still read from the original source at the
-// same positions.
-// A match is real code only when the masker left that position intact:
-// comments and string bodies become spaces, while keywords and punctuation
-// survive. This lets values be read from the source without a comment counting.
-const matchesInCode = (
-  source,
-  masked,
-  pattern,
-  from = 0,
-  to = source.length,
-) => {
-  const found = [];
-  for (const match of source.slice(from, to).matchAll(pattern)) {
-    const at = from + match.index;
-    const anchor = match[0].search(/\S/);
-    if (masked[at + anchor] === source[at + anchor])
-      found.push({ ...match, index: at });
-  }
-  return found;
-};
-
-const maskedCode = (source, kind) =>
-  kind === "expo-plugin-config"
-    ? maskTypeScriptCommentsAndStrings(source)
-    : maskKotlinCommentsAndStrings(source);
-
-// Replace to a fixpoint: one pass over `<!-- <!-- -->` leaves a bare `<!--`,
-// so a single substitution is not a complete strip.
+// Replace to a fixpoint: removing an inner `<!-- -->` can splice `<!-` and `-`
+// into a new opener the pass never saw, so one substitution is not a strip.
 const stripXmlComments = (source) => {
   let previous;
   let current = source;
@@ -102,124 +78,31 @@ const APPLICATION_ELEMENT = /<application\b[\s\S]*?<\/application\s*>/;
 const NESTED_ELEMENT =
   /<(activity-alias|activity|service|receiver|provider)\b[\s\S]*?<\/\1\s*>/g;
 const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data\s*>)/g;
+const LITERAL_VALUE = new RegExp(`android:value\\s*=\\s*["']${APP_ID}["']`);
+const PLACEHOLDER_VALUE = /android:value\s*=\s*["']\$\{(\w+)\}["']/;
 
 // Horizon reads the id from <application>. A meta-data nested inside an
 // activity or service merges somewhere the platform never looks.
-const inspectAndroidManifest = (contents) => {
-  const application = stripXmlComments(contents).match(APPLICATION_ELEMENT);
+const inspectManifest = (contents, allowPlaceholder) => {
+  const source = stripXmlComments(contents);
+  const application = source.match(APPLICATION_ELEMENT);
   if (!application) return "has no <application> element";
   const direct = application[0].replace(NESTED_ELEMENT, "");
   let declared = false;
   for (const [element] of direct.matchAll(META_DATA_ELEMENT)) {
     if (!element.includes(HORIZON_APP_ID_META_DATA_NAME)) continue;
     declared = true;
-    if (new RegExp(`android:value\\s*=\\s*["']${APP_ID}["']`).test(element)) {
-      return null;
-    }
+    if (LITERAL_VALUE.test(element)) return null;
+    if (allowPlaceholder && PLACEHOLDER_VALUE.test(element)) return null;
   }
   if (declared) {
-    return "declares the Horizon meta-data without a literal app id";
+    return allowPlaceholder
+      ? "declares the Horizon meta-data without a literal app id or a placeholder"
+      : "declares the Horizon meta-data without a literal app id";
   }
-  return stripXmlComments(contents).includes(HORIZON_APP_ID_META_DATA_NAME)
+  return source.includes(HORIZON_APP_ID_META_DATA_NAME)
     ? "declares the Horizon meta-data outside <application>"
     : "declares no Horizon app id meta-data";
-};
-
-const APP_ID_PROPERTY = /(?:HORIZON|OPENIAP)_APP_ID["']\s*\)/g;
-const ASSIGNMENT = /(?:^|\s)(?:val|var|def)\s+\w+\s*=|^\s*\w+\s*=[^=]/;
-// A wrapped line continues the statement it belongs to.
-const CONTINUATION = /^\s*(?:\?:|\?\.|\.|\)|\}|,)/;
-const STRING_LITERAL = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g;
-
-// Depth counts braces as well as parens: a multi-line `firstOrNull { … }` is
-// one statement, and stopping at the closing paren would cut off the fallback.
-const balanceOf = (line) =>
-  (line.match(/[({]/g)?.length ?? 0) - (line.match(/[)}]/g)?.length ?? 0);
-
-// A build file can resolve the id more than once — packages/google does it in
-// defaultConfig and again in the horizon flavor — and the later one wins for
-// that flavor. Inspect every statement, not the first.
-export const extractAppIdStatements = (source, masked = source) => {
-  const lines = source.split("\n");
-  const maskedLines = masked.split("\n");
-  const offsets = [];
-  let cursor = 0;
-  for (const line of maskedLines) {
-    offsets.push(cursor);
-    cursor += line.length + 1;
-  }
-
-  const statements = [];
-  const seen = new Set();
-  // Search the source so the quoted property name is visible, then keep only
-  // reads whose closing paren survived masking — a read inside a comment does
-  // not resolve anything.
-  for (const match of source.matchAll(APP_ID_PROPERTY)) {
-    const close = match.index + match[0].length - 1;
-    if (masked[close] !== ")") continue;
-    const line = offsets.findLastIndex((offset) => offset <= match.index);
-
-    // The read can sit inside a multi-line expression, so walk back to the
-    // assignment that owns it. Track depth so the walk cannot escape the block
-    // the read lives in and attach itself to an unrelated earlier assignment.
-    let first = line;
-    let depth = 0;
-    while (first > 0 && !ASSIGNMENT.test(maskedLines[first])) {
-      const previous = first - 1;
-      // Stop rather than escape the block the read lives in, which would
-      // attach the statement to an unrelated earlier assignment.
-      if (depth + balanceOf(maskedLines[previous]) < 0) break;
-      depth += balanceOf(maskedLines[previous]);
-      first = previous;
-    }
-    // A read with no assignment above it still resolves something, so fall back
-    // to its own line. Skipping would make an unattributable read a silent pass.
-    if (!ASSIGNMENT.test(maskedLines[first])) first = line;
-    if (seen.has(first)) continue;
-    seen.add(first);
-
-    const statement = [lines[first]];
-    let open = balanceOf(maskedLines[first]);
-    for (let next = first + 1; next < lines.length; next += 1) {
-      if (open <= 0 && !CONTINUATION.test(maskedLines[next])) break;
-      statement.push(lines[next]);
-      open += balanceOf(maskedLines[next]);
-    }
-    statements.push(statement.join("\n"));
-  }
-  return statements;
-};
-
-// Elvis alone is not enough: Properties.getProperty returns "" for a key
-// present with no value, and "" is non-null, so a blank entry in the
-// developer's local.properties would defeat the literal fallback and put an
-// empty app id in the manifest. The statement must reject blank too.
-const REJECTS_BLANK = /isNullOrBlank|isNotBlank|\.trim\(\)/;
-
-export const inspectAppIdStatement = (statement) => {
-  const literals = statement.match(STRING_LITERAL) ?? [];
-  const terminal = literals[literals.length - 1];
-  if (terminal === undefined) return "has no fallback for the Horizon app id";
-  if (!APP_ID_LITERAL.test(terminal)) {
-    return terminal === '""' || terminal === "''"
-      ? "falls back to an empty app id"
-      : `falls back to ${terminal} instead of a literal Horizon app id`;
-  }
-  if (!REJECTS_BLANK.test(statement)) {
-    return "accepts a blank override, which defeats the literal fallback";
-  }
-  return null;
-};
-
-const inspectGradleFallback = (contents) => {
-  const masked = maskedCode(contents, "gradle-fallback");
-  const statements = extractAppIdStatements(contents, masked);
-  if (statements.length === 0) return "reads no Horizon app id property";
-  for (const statement of statements) {
-    const issue = inspectAppIdStatement(statement);
-    if (issue) return issue;
-  }
-  return null;
 };
 
 // Brace-balanced over masked text, so a brace inside a string neither truncates
@@ -237,12 +120,16 @@ const extractBalancedBlock = (masked, from) => {
 };
 
 const HORIZON_KEY = /\bhorizon\s*:\s*\{/g;
-const LITERAL_APP_ID_ENTRY = new RegExp(
+const APP_ID_ENTRY = new RegExp(
   String.raw`\bappId\s*:\s*['"]${APP_ID}['"]`,
+  "g",
 );
 
 const inspectExpoPluginConfig = (contents) => {
-  const masked = maskedCode(contents, "expo-plugin-config");
+  // Structure comes from masked text so a brace in a string is not syntax; the
+  // value is read from the source at the same offset, and a match only counts
+  // when the masker left that position intact — a commented-out entry does not.
+  const masked = maskTypeScriptCommentsAndStrings(contents);
   let declared = false;
   for (const match of masked.matchAll(HORIZON_KEY)) {
     const span = extractBalancedBlock(
@@ -251,15 +138,12 @@ const inspectExpoPluginConfig = (contents) => {
     );
     if (span === null) continue;
     declared = true;
-    // Structure came from the masked text; the value comes from the source.
-    const bound = matchesInCode(
-      contents,
-      masked,
-      new RegExp(LITERAL_APP_ID_ENTRY.source, "g"),
-      span[0],
-      span[1],
-    );
-    if (bound.length > 0) return null;
+    for (const entry of contents
+      .slice(span[0], span[1])
+      .matchAll(APP_ID_ENTRY)) {
+      const at = span[0] + entry.index;
+      if (masked[at] === contents[at]) return null;
+    }
   }
   return declared
     ? "declares horizon config without a literal appId"
@@ -267,8 +151,8 @@ const inspectExpoPluginConfig = (contents) => {
 };
 
 const INSPECTORS = {
-  "android-manifest": inspectAndroidManifest,
-  "gradle-fallback": inspectGradleFallback,
+  "android-manifest": (contents) => inspectManifest(contents, false),
+  "templated-manifest": (contents) => inspectManifest(contents, true),
   "expo-plugin-config": inspectExpoPluginConfig,
 };
 
@@ -313,6 +197,6 @@ if (
     process.exit(1);
   }
   console.log(
-    `OK ${HORIZON_APP_ID_SOURCES.length} Horizon examples resolve an app id`,
+    `OK ${HORIZON_APP_ID_SOURCES.length} Horizon examples declare an app id`,
   );
 }

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -51,13 +51,34 @@ export const HORIZON_APP_ID_SOURCES = [
 const APP_ID = String.raw`\d{10,}`;
 const APP_ID_LITERAL = new RegExp(`^["']${APP_ID}["']$`);
 
-const stripXmlComments = (source) => source.replace(/<!--[\s\S]*?-->/g, "");
-const stripLineComments = (source) =>
-  source.replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+// Replace to a fixpoint: one pass over `<!-- <!-- -->` leaves a bare `<!--`,
+// so a single substitution is not a complete strip.
+const replaceToFixpoint = (source, pattern) => {
+  let previous;
+  let current = source;
+  do {
+    previous = current;
+    current = previous.replace(pattern, "");
+  } while (current !== previous);
+  return current;
+};
+
+const stripXmlComments = (source) =>
+  replaceToFixpoint(source, /<!--[\s\S]*?-->/g);
+
+// Kotlin, Groovy, and the Expo TypeScript config all use both comment forms,
+// and a commented-out declaration is not the active one.
+const stripCodeComments = (source) =>
+  replaceToFixpoint(source, /\/\*[\s\S]*?\*\//g).replace(
+    /(^|[^:])\/\/[^\n]*/g,
+    "$1",
+  );
 
 const APPLICATION_ELEMENT = /<application\b[\s\S]*?<\/application\s*>/;
+// activity-alias precedes activity: the alternation is ordered, and
+// `activity\b` would otherwise claim the prefix and mis-pair the closing tag.
 const NESTED_ELEMENT =
-  /<(activity|service|receiver|provider)\b[\s\S]*?<\/\1\s*>/g;
+  /<(activity-alias|activity|service|receiver|provider)\b[\s\S]*?<\/\1\s*>/g;
 const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data\s*>)/g;
 
 // Horizon reads the id from <application>. A meta-data nested inside an
@@ -83,28 +104,53 @@ const inspectAndroidManifest = (contents) => {
 };
 
 const APP_ID_PROPERTY = /(?:HORIZON|OPENIAP)_APP_ID"\s*\)/;
-const ELVIS_CONTINUATION = /^\s*\?:/;
-const ELVIS_OPERAND = /\?:\s*([^\n]+?)\s*$/;
+const CONTINUATION = /^\s*(?:\?:|\.|\)|,)/;
+const ASSIGNMENT = /(?:^|\s)(?:val|var|def)\s+\w+\s*=|^\s*\w+\s*=[^=]/;
+const STRING_LITERAL = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g;
 
-// Both Gradle examples resolve the id through an elvis chain. Only the value
-// that terminates the chain reaches manifestPlaceholders, so that is what must
-// be a literal — a literal anywhere else in the file is not the fallback.
-const inspectGradleFallback = (contents) => {
-  const source = stripLineComments(contents);
-  const start = source.search(APP_ID_PROPERTY);
-  if (start === -1) return "reads no Horizon app id property";
-  const lines = source.slice(start).split("\n");
-  const chain = [lines[0]];
-  for (let index = 1; index < lines.length; index += 1) {
-    if (!ELVIS_CONTINUATION.test(lines[index])) break;
-    chain.push(lines[index]);
+const balanceOf = (line) =>
+  (line.match(/\(/g)?.length ?? 0) - (line.match(/\)/g)?.length ?? 0);
+
+// Both Gradle examples resolve the id inside one statement, but they do not
+// share a shape: one is an elvis chain, the other a listOf(...).firstOrNull.
+// Rather than pattern-match either, take the whole statement that reads a
+// Horizon app id property and require the value it ends on to be a literal id.
+// A literal elsewhere in the file is not the fallback.
+export const extractAppIdStatement = (source) => {
+  const match = source.search(APP_ID_PROPERTY);
+  if (match === -1) return null;
+  const lines = source.split("\n");
+  const offsets = [];
+  let cursor = 0;
+  for (const line of lines) {
+    offsets.push(cursor);
+    cursor += line.length + 1;
   }
-  const operands = chain
-    .map((line) => line.match(ELVIS_OPERAND))
-    .filter(Boolean)
-    .map((match) => match[1].trim());
-  if (operands.length === 0) return "has no fallback for the Horizon app id";
-  const terminal = operands[operands.length - 1];
+  let index = offsets.findLastIndex((offset) => offset <= match);
+
+  // The property read can sit inside a multi-line expression, so walk back to
+  // the assignment that owns it before reading forward.
+  let first = index;
+  while (first > 0 && !ASSIGNMENT.test(lines[first])) first -= 1;
+
+  const statement = [lines[first]];
+  let depth = balanceOf(lines[first]);
+  for (let next = first + 1; next < lines.length; next += 1) {
+    if (depth <= 0 && !CONTINUATION.test(lines[next])) break;
+    statement.push(lines[next]);
+    depth += balanceOf(lines[next]);
+  }
+  return statement.join("\n");
+};
+
+const inspectGradleFallback = (contents) => {
+  const statement = extractAppIdStatement(stripCodeComments(contents));
+  if (statement === null) return "reads no Horizon app id property";
+  const literals = statement.match(STRING_LITERAL) ?? [];
+  // Property names are quoted too; the fallback is the last literal, which is
+  // the value the statement resolves to when every lookup misses.
+  const terminal = literals[literals.length - 1];
+  if (terminal === undefined) return "has no fallback for the Horizon app id";
   if (APP_ID_LITERAL.test(terminal)) return null;
   return terminal === '""' || terminal === "''"
     ? "falls back to an empty app id"
@@ -116,7 +162,7 @@ const EXPO_HORIZON_APP_ID = new RegExp(
 );
 
 const inspectExpoPluginConfig = (contents) =>
-  EXPO_HORIZON_APP_ID.test(stripLineComments(contents))
+  EXPO_HORIZON_APP_ID.test(stripCodeComments(contents))
     ? null
     : "does not set a literal horizon.appId";
 

--- a/scripts/audit-horizon-example-app-id.mjs
+++ b/scripts/audit-horizon-example-app-id.mjs
@@ -91,7 +91,7 @@ const inspectAndroidManifest = (contents) => {
   for (const [element] of direct.matchAll(META_DATA_ELEMENT)) {
     if (!element.includes(HORIZON_APP_ID_META_DATA_NAME)) continue;
     declared = true;
-    if (new RegExp(`android:value\\s*=\\s*"${APP_ID}"`).test(element)) {
+    if (new RegExp(`android:value\\s*=\\s*["']${APP_ID}["']`).test(element)) {
       return null;
     }
   }
@@ -103,7 +103,7 @@ const inspectAndroidManifest = (contents) => {
     : "declares no Horizon app id meta-data";
 };
 
-const APP_ID_PROPERTY = /(?:HORIZON|OPENIAP)_APP_ID"\s*\)/;
+const APP_ID_PROPERTY = /(?:HORIZON|OPENIAP)_APP_ID["']\s*\)/g;
 const CONTINUATION = /^\s*(?:\?:|\.|\)|,)/;
 const ASSIGNMENT = /(?:^|\s)(?:val|var|def)\s+\w+\s*=|^\s*\w+\s*=[^=]/;
 const STRING_LITERAL = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g;
@@ -116,9 +116,10 @@ const balanceOf = (line) =>
 // Rather than pattern-match either, take the whole statement that reads a
 // Horizon app id property and require the value it ends on to be a literal id.
 // A literal elsewhere in the file is not the fallback.
-export const extractAppIdStatement = (source) => {
-  const match = source.search(APP_ID_PROPERTY);
-  if (match === -1) return null;
+// A build file can resolve the id more than once — packages/google does it in
+// defaultConfig and again in the horizon flavor — and the later one wins for
+// that flavor. Inspect every statement, not the first.
+export const extractAppIdStatements = (source) => {
   const lines = source.split("\n");
   const offsets = [];
   let cursor = 0;
@@ -126,45 +127,97 @@ export const extractAppIdStatement = (source) => {
     offsets.push(cursor);
     cursor += line.length + 1;
   }
-  let index = offsets.findLastIndex((offset) => offset <= match);
 
-  // The property read can sit inside a multi-line expression, so walk back to
-  // the assignment that owns it before reading forward.
-  let first = index;
-  while (first > 0 && !ASSIGNMENT.test(lines[first])) first -= 1;
+  const statements = [];
+  const seen = new Set();
+  for (const match of source.matchAll(APP_ID_PROPERTY)) {
+    const line = offsets.findLastIndex((offset) => offset <= match.index);
 
-  const statement = [lines[first]];
-  let depth = balanceOf(lines[first]);
-  for (let next = first + 1; next < lines.length; next += 1) {
-    if (depth <= 0 && !CONTINUATION.test(lines[next])) break;
-    statement.push(lines[next]);
-    depth += balanceOf(lines[next]);
+    // The read can sit inside a multi-line expression, so walk back to the
+    // assignment that owns it before reading forward.
+    let first = line;
+    while (first > 0 && !ASSIGNMENT.test(lines[first])) first -= 1;
+    if (seen.has(first)) continue;
+    seen.add(first);
+
+    const statement = [lines[first]];
+    let depth = balanceOf(lines[first]);
+    for (let next = first + 1; next < lines.length; next += 1) {
+      if (depth <= 0 && !CONTINUATION.test(lines[next])) break;
+      statement.push(lines[next]);
+      depth += balanceOf(lines[next]);
+    }
+    statements.push(statement.join("\n"));
   }
-  return statement.join("\n");
+  return statements;
+};
+
+// Elvis alone is not enough: Properties.getProperty returns "" for a key
+// present with no value, and "" is non-null, so a blank entry in the
+// developer's local.properties would defeat the literal fallback and put an
+// empty app id in the manifest. The statement must reject blank too.
+const REJECTS_BLANK = /isNullOrBlank|isNotBlank|\?\.trim\(\)|\.trim\(\)\s*\?:/;
+
+export const inspectAppIdStatement = (statement) => {
+  const literals = statement.match(STRING_LITERAL) ?? [];
+  const terminal = literals[literals.length - 1];
+  if (terminal === undefined) return "has no fallback for the Horizon app id";
+  if (!APP_ID_LITERAL.test(terminal)) {
+    return terminal === '""' || terminal === "''"
+      ? "falls back to an empty app id"
+      : `falls back to ${terminal} instead of a literal Horizon app id`;
+  }
+  if (!REJECTS_BLANK.test(statement)) {
+    return "accepts a blank override, which defeats the literal fallback";
+  }
+  return null;
 };
 
 const inspectGradleFallback = (contents) => {
-  const statement = extractAppIdStatement(stripCodeComments(contents));
-  if (statement === null) return "reads no Horizon app id property";
-  const literals = statement.match(STRING_LITERAL) ?? [];
-  // Property names are quoted too; the fallback is the last literal, which is
-  // the value the statement resolves to when every lookup misses.
-  const terminal = literals[literals.length - 1];
-  if (terminal === undefined) return "has no fallback for the Horizon app id";
-  if (APP_ID_LITERAL.test(terminal)) return null;
-  return terminal === '""' || terminal === "''"
-    ? "falls back to an empty app id"
-    : `falls back to ${terminal} instead of a literal Horizon app id`;
+  const statements = extractAppIdStatements(stripCodeComments(contents));
+  if (statements.length === 0) return "reads no Horizon app id property";
+  for (const statement of statements) {
+    const issue = inspectAppIdStatement(statement);
+    if (issue) return issue;
+  }
+  return null;
 };
 
-const EXPO_HORIZON_APP_ID = new RegExp(
-  String.raw`horizon\s*:\s*\{[^}]*?appId\s*:\s*['"]${APP_ID}['"]`,
+// Brace-balanced rather than `[^}]*`, so a nested object between `horizon:`
+// and `appId:` does not truncate the block being searched.
+const extractBalancedBlock = (source, from) => {
+  let depth = 0;
+  for (let index = from; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(from, index + 1);
+    }
+  }
+  return null;
+};
+
+const HORIZON_KEY = /\bhorizon\s*:\s*\{/g;
+const LITERAL_APP_ID_ENTRY = new RegExp(
+  String.raw`\bappId\s*:\s*['"]${APP_ID}['"]`,
 );
 
-const inspectExpoPluginConfig = (contents) =>
-  EXPO_HORIZON_APP_ID.test(stripCodeComments(contents))
-    ? null
+const inspectExpoPluginConfig = (contents) => {
+  const source = stripCodeComments(contents);
+  let declared = false;
+  for (const match of source.matchAll(HORIZON_KEY)) {
+    const block = extractBalancedBlock(
+      source,
+      match.index + match[0].length - 1,
+    );
+    if (block === null) continue;
+    declared = true;
+    if (LITERAL_APP_ID_ENTRY.test(block)) return null;
+  }
+  return declared
+    ? "declares horizon config without a literal appId"
     : "does not set a literal horizon.appId";
+};
 
 const INSPECTORS = {
   "android-manifest": inspectAndroidManifest,

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -230,6 +230,72 @@ test("a short number is not accepted as a Horizon app id", () => {
   );
 });
 
+test("meta-data inside an activity-alias does not satisfy the audit", () => {
+  const contents = manifest(
+    `<activity-alias android:name=".Alias" android:targetActivity=".Main">${HORIZON_META("31705015229097839")}</activity-alias>`,
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares the Horizon meta-data outside <application>",
+  );
+});
+
+test("comment stripping survives an opener spliced together by removal", () => {
+  // Removing the inner `<!-- -->` joins `<!-` and `-` into a new `<!--` that
+  // the first pass never saw, so a single substitution leaves the
+  // commented-out declaration looking active.
+  const contents = manifest(
+    `<!-<!-- -->- ${HORIZON_META("31705015229097839")} -->`,
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares no Horizon app id meta-data",
+  );
+});
+
+test("a Gradle fallback inside a block comment does not satisfy the audit", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      '/*\nval appId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"\n*/',
+      "gradle-fallback",
+    ),
+    "reads no Horizon app id property",
+  );
+});
+
+test("an Expo appId inside a block comment does not satisfy the audit", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      "/* horizon: { appId: '31705015229097839' } */",
+      "expo-plugin-config",
+    ),
+    "does not set a literal horizon.appId",
+  );
+});
+
+test("the Gradle inspector reads the statement, not one syntax", () => {
+  // The two Gradle examples do not share a shape. Both must resolve, and both
+  // must fail when the value the statement ends on is blank.
+  const elvis =
+    'val appId = localProperties.getProperty("HORIZON_APP_ID")\n    ?: "31705015229097839"';
+  const listOf = [
+    "val appId = listOf(",
+    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
+    '    project.findProperty("EXAMPLE_OPENIAP_APP_ID") as String?,',
+    ').firstOrNull { !it.isNullOrBlank() } ?: "31705015229097839"',
+  ].join("\n");
+  for (const statement of [elvis, listOf]) {
+    assert.equal(inspectHorizonAppIdSource(statement, "gradle-fallback"), null);
+    assert.equal(
+      inspectHorizonAppIdSource(
+        statement.replace('"31705015229097839"', '""'),
+        "gradle-fallback",
+      ),
+      "falls back to an empty app id",
+    );
+  }
+});
+
 test("a missing source file is reported instead of silently passing", () => {
   const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), "horizon-audit-"));
   try {

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -210,6 +210,26 @@ test("the Expo plugin config must bind the id to horizon.appId", () => {
   );
 });
 
+test("a short number is not accepted as a Horizon app id", () => {
+  // Horizon app ids are long. Without this the digit-count constraint is
+  // unpinned and can be weakened to \\d+ with every other test still green.
+  assert.equal(
+    inspectHorizonAppIdSource(manifest(HORIZON_META("0")), "android-manifest"),
+    "declares the Horizon meta-data without a literal app id",
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(
+      'localProperties.getProperty("HORIZON_APP_ID") ?: "12345"',
+      "gradle-fallback",
+    ),
+    'falls back to "12345" instead of a literal Horizon app id',
+  );
+  assert.equal(
+    inspectHorizonAppIdSource("horizon: { appId: '42' }", "expo-plugin-config"),
+    "does not set a literal horizon.appId",
+  );
+});
+
 test("a missing source file is reported instead of silently passing", () => {
   const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), "horizon-audit-"));
   try {

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -69,13 +69,14 @@ test("meta-data nested inside an activity does not satisfy the audit", () => {
   );
 });
 
-test("only the value terminating the Gradle elvis chain counts", () => {
+test("only the value terminating a Gradle statement counts", () => {
   // The chain's earlier operands are property reads; the last one is what
   // actually reaches manifestPlaceholders.
   const chain = [
-    'val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID")',
-    '    ?: (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)',
-    '    ?: ""',
+    "val appId = listOf(",
+    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
+    '    project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?,',
+    ').firstOrNull { !it.isNullOrBlank() } ?: ""',
   ].join("\n");
   assert.equal(
     inspectHorizonAppIdSource(chain, "gradle-fallback"),
@@ -106,7 +107,7 @@ test("a commented-out Expo appId does not satisfy the audit", () => {
       "horizon: { // appId: '31705015229097839'\n }",
       "expo-plugin-config",
     ),
-    "does not set a literal horizon.appId",
+    "declares horizon config without a literal appId",
   );
 });
 
@@ -176,7 +177,7 @@ test("an empty Gradle fallback is rejected even when a literal id is nearby", ()
 test("a Gradle fallback to a literal id passes", () => {
   assert.equal(
     inspectHorizonAppIdSource(
-      'localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
+      'localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "31705015229097839"',
       "gradle-fallback",
     ),
     null,
@@ -203,10 +204,10 @@ test("the Expo plugin config must bind the id to horizon.appId", () => {
   );
   assert.equal(
     inspectHorizonAppIdSource(
-      "android: { horizon: { appId: process.env.HORIZON } }\nconst other = '31705015229097839'",
+      "android: { horizon: { appId: process.env.HORIZON } }",
       "expo-plugin-config",
     ),
-    "does not set a literal horizon.appId",
+    "declares horizon config without a literal appId",
   );
 });
 
@@ -219,14 +220,14 @@ test("a short number is not accepted as a Horizon app id", () => {
   );
   assert.equal(
     inspectHorizonAppIdSource(
-      'localProperties.getProperty("HORIZON_APP_ID") ?: "12345"',
+      'localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "12345"',
       "gradle-fallback",
     ),
     'falls back to "12345" instead of a literal Horizon app id',
   );
   assert.equal(
     inspectHorizonAppIdSource("horizon: { appId: '42' }", "expo-plugin-config"),
-    "does not set a literal horizon.appId",
+    "declares horizon config without a literal appId",
   );
 });
 
@@ -277,7 +278,7 @@ test("the Gradle inspector reads the statement, not one syntax", () => {
   // The two Gradle examples do not share a shape. Both must resolve, and both
   // must fail when the value the statement ends on is blank.
   const elvis =
-    'val appId = localProperties.getProperty("HORIZON_APP_ID")\n    ?: "31705015229097839"';
+    'val appId = localProperties.getProperty("HORIZON_APP_ID")?.trim()\n    ?: "31705015229097839"';
   const listOf = [
     "val appId = listOf(",
     '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
@@ -294,6 +295,62 @@ test("the Gradle inspector reads the statement, not one syntax", () => {
       "falls back to an empty app id",
     );
   }
+});
+
+test("every app id statement is inspected, not only the first", () => {
+  // packages/google resolves the id twice — defaultConfig and the horizon
+  // flavor — and the flavor's value is what that build actually uses.
+  const source = [
+    "val appId = listOf(",
+    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
+    ').firstOrNull { !it.isNullOrBlank() } ?: "31705015229097839"',
+    'create("horizon") {',
+    '    val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID") ?: ""',
+    "}",
+  ].join("\n");
+  assert.equal(
+    inspectHorizonAppIdSource(source, "gradle-fallback"),
+    "falls back to an empty app id",
+  );
+});
+
+test("a literal fallback that a blank override defeats is rejected", () => {
+  // Properties.getProperty returns "" for a key present with no value, and ""
+  // is non-null, so elvis alone never reaches the literal.
+  assert.equal(
+    inspectHorizonAppIdSource(
+      'horizonAppId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
+      "gradle-fallback",
+    ),
+    "accepts a blank override, which defeats the literal fallback",
+  );
+});
+
+test("a single-quoted Groovy property name is still recognised", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      "horizonAppId = localProperties.getProperty('HORIZON_APP_ID')?.trim() ?: '31705015229097839'",
+      "gradle-fallback",
+    ),
+    null,
+  );
+});
+
+test("a single-quoted manifest value is still recognised", () => {
+  const contents = manifest(
+    "<meta-data android:name=\"com.meta.horizon.platform.HORIZON_APP_ID\" android:value='31705015229097839' />",
+  );
+  assert.equal(inspectHorizonAppIdSource(contents, "android-manifest"), null);
+});
+
+test("a nested object between horizon and appId does not hide the id", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      "horizon: { extra: { store: 'meta' }, appId: '31705015229097839' }",
+      "expo-plugin-config",
+    ),
+    null,
+  );
 });
 
 test("a missing source file is reported instead of silently passing", () => {

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -30,6 +30,7 @@ test("the audit covers every library that ships a Horizon example", () => {
       "flutter_inapp_purchase",
       "kmp-iap",
       "maui-iap",
+      "packages/google",
       "react-native-iap",
     ],
   );
@@ -53,6 +54,59 @@ test("a manifest that binds the id to the Horizon meta-data passes", () => {
       "android-manifest",
     ),
     null,
+  );
+});
+
+test("meta-data nested inside an activity does not satisfy the audit", () => {
+  // Horizon reads the id from <application>; nested here it merges where the
+  // platform never looks, so the build still fails on device.
+  const contents = manifest(
+    `<activity android:name=".MainActivity">${HORIZON_META("31705015229097839")}</activity>`,
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares the Horizon meta-data outside <application>",
+  );
+});
+
+test("only the value terminating the Gradle elvis chain counts", () => {
+  // The chain's earlier operands are property reads; the last one is what
+  // actually reaches manifestPlaceholders.
+  const chain = [
+    'val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID")',
+    '    ?: (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)',
+    '    ?: ""',
+  ].join("\n");
+  assert.equal(
+    inspectHorizonAppIdSource(chain, "gradle-fallback"),
+    "falls back to an empty app id",
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(
+      chain.replace('?: ""', '?: "31705015229097839"'),
+      "gradle-fallback",
+    ),
+    null,
+  );
+});
+
+test("a commented-out Gradle fallback does not satisfy the audit", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      '// val appId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
+      "gradle-fallback",
+    ),
+    "reads no Horizon app id property",
+  );
+});
+
+test("a commented-out Expo appId does not satisfy the audit", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      "horizon: { // appId: '31705015229097839'\n }",
+      "expo-plugin-config",
+    ),
+    "does not set a literal horizon.appId",
   );
 });
 
@@ -135,7 +189,7 @@ test("a Gradle file with the id only in an unrelated place is rejected", () => {
       'def unrelated = "31705015229097839"\n',
       "gradle-fallback",
     ),
-    "does not fall back to a literal Horizon app id",
+    "reads no Horizon app id property",
   );
 });
 

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  HORIZON_APP_ID_SOURCES,
+  collectHorizonExampleAppIdFailures,
+  inspectHorizonAppIdSource,
+} from "./audit-horizon-example-app-id.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("every Horizon example in this repository resolves an app id", () => {
+  assert.deepEqual(collectHorizonExampleAppIdFailures(repoRoot), []);
+});
+
+test("the audit covers every library that ships a Horizon example", () => {
+  assert.deepEqual(
+    HORIZON_APP_ID_SOURCES.map((source) => source.library).sort(),
+    [
+      "expo-iap",
+      "flutter_inapp_purchase",
+      "kmp-iap",
+      "maui-iap",
+      "react-native-iap",
+    ],
+  );
+});
+
+test("a manifest without the app id is rejected", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      '<meta-data android:name="com.meta.horizon.platform.HORIZON_APP_ID" />',
+    ),
+    "declares no literal Horizon app id",
+  );
+});
+
+test("an empty Gradle fallback is rejected even when a literal id is nearby", () => {
+  const issue = inspectHorizonAppIdSource(
+    'def id = localProperties.getProperty("HORIZON_APP_ID") ?: ""\n// 31705015229097839',
+  );
+  assert.match(String(issue), /falls back to an empty app id/);
+});
+
+test("a Gradle fallback to a literal id passes", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      'localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
+    ),
+    null,
+  );
+});
+
+test("a missing source file is reported instead of silently passing", () => {
+  const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), "horizon-audit-"));
+  try {
+    const failures = collectHorizonExampleAppIdFailures(emptyRoot);
+    assert.equal(failures.length, HORIZON_APP_ID_SOURCES.length);
+    for (const failure of failures) {
+      assert.match(failure, /is missing$/);
+    }
+  } finally {
+    fs.rmSync(emptyRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -18,11 +18,11 @@ const HORIZON_META = (value) => `
       android:name="com.meta.horizon.platform.HORIZON_APP_ID"
       android:value="${value}" />`;
 
-test("every Horizon example in this repository resolves an app id", () => {
+test("every Horizon example in this repository declares an app id", () => {
   assert.deepEqual(collectHorizonExampleAppIdFailures(repoRoot), []);
 });
 
-test("the audit covers every library that ships a Horizon example", () => {
+test("the audit covers every target that builds the Horizon flavor", () => {
   assert.deepEqual(
     HORIZON_APP_ID_SOURCES.map((source) => source.library).sort(),
     [
@@ -38,9 +38,10 @@ test("the audit covers every library that ships a Horizon example", () => {
 
 test("every source declares a kind the audit knows how to inspect", () => {
   for (const source of HORIZON_APP_ID_SOURCES) {
-    const issue = inspectHorizonAppIdSource("", source.kind);
     assert.equal(
-      /unknown source kind/.test(String(issue)),
+      /unknown source kind/.test(
+        String(inspectHorizonAppIdSource("", source.kind)),
+      ),
       false,
       `${source.library} declares an uninspectable kind: ${source.kind}`,
     );
@@ -57,60 +58,6 @@ test("a manifest that binds the id to the Horizon meta-data passes", () => {
   );
 });
 
-test("meta-data nested inside an activity does not satisfy the audit", () => {
-  // Horizon reads the id from <application>; nested here it merges where the
-  // platform never looks, so the build still fails on device.
-  const contents = manifest(
-    `<activity android:name=".MainActivity">${HORIZON_META("31705015229097839")}</activity>`,
-  );
-  assert.equal(
-    inspectHorizonAppIdSource(contents, "android-manifest"),
-    "declares the Horizon meta-data outside <application>",
-  );
-});
-
-test("only the value terminating a Gradle statement counts", () => {
-  // The chain's earlier operands are property reads; the last one is what
-  // actually reaches manifestPlaceholders.
-  const chain = [
-    "val appId = listOf(",
-    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
-    '    project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?,',
-    ').firstOrNull { !it.isNullOrBlank() } ?: ""',
-  ].join("\n");
-  assert.equal(
-    inspectHorizonAppIdSource(chain, "gradle-fallback"),
-    "falls back to an empty app id",
-  );
-  assert.equal(
-    inspectHorizonAppIdSource(
-      chain.replace('?: ""', '?: "31705015229097839"'),
-      "gradle-fallback",
-    ),
-    null,
-  );
-});
-
-test("a commented-out Gradle fallback does not satisfy the audit", () => {
-  assert.equal(
-    inspectHorizonAppIdSource(
-      '// val appId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
-      "gradle-fallback",
-    ),
-    "reads no Horizon app id property",
-  );
-});
-
-test("a commented-out Expo appId does not satisfy the audit", () => {
-  assert.equal(
-    inspectHorizonAppIdSource(
-      "horizon: { // appId: '31705015229097839'\n }",
-      "expo-plugin-config",
-    ),
-    "declares horizon config without a literal appId",
-  );
-});
-
 test("a manifest with no Horizon meta-data is rejected", () => {
   assert.equal(
     inspectHorizonAppIdSource(manifest("<activity/>"), "android-manifest"),
@@ -119,7 +66,6 @@ test("a manifest with no Horizon meta-data is rejected", () => {
 });
 
 test("a numeric literal unbound from the declaration does not satisfy the audit", () => {
-  // The declaration is present but valueless; the id only appears in a comment.
   const contents = manifest(`
     <meta-data android:name="com.meta.horizon.platform.HORIZON_APP_ID" />
     <!-- app id is 31705015229097839 -->`);
@@ -147,50 +93,78 @@ test("a commented-out declaration does not satisfy the audit", () => {
   );
 });
 
-test("an unresolved manifest placeholder does not satisfy the audit", () => {
+test("comment stripping survives an opener spliced together by removal", () => {
+  // Removing the inner `<!-- -->` joins `<!-` and `-` into a new `<!--` that
+  // the first pass never saw, so a single substitution leaves the
+  // commented-out declaration looking active.
+  const contents = manifest(
+    `<!-<!-- -->- ${HORIZON_META("31705015229097839")} -->`,
+  );
   assert.equal(
-    inspectHorizonAppIdSource(
-      manifest(HORIZON_META("${HORIZON_APP_ID}")),
-      "android-manifest",
-    ),
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares no Horizon app id meta-data",
+  );
+});
+
+test("meta-data nested inside an activity does not satisfy the audit", () => {
+  const contents = manifest(
+    `<activity android:name=".MainActivity">${HORIZON_META("31705015229097839")}</activity>`,
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares the Horizon meta-data outside <application>",
+  );
+});
+
+test("meta-data inside an activity-alias does not satisfy the audit", () => {
+  const contents = manifest(
+    `<activity-alias android:name=".Alias" android:targetActivity=".Main">${HORIZON_META("31705015229097839")}</activity-alias>`,
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares the Horizon meta-data outside <application>",
+  );
+});
+
+test("a short number is not accepted as a Horizon app id", () => {
+  // Without this the digit-count constraint is unpinned and could be weakened
+  // to \\d+ with every other test still green.
+  assert.equal(
+    inspectHorizonAppIdSource(manifest(HORIZON_META("0")), "android-manifest"),
     "declares the Horizon meta-data without a literal app id",
   );
 });
 
-test("a second Horizon meta-data block can supply the id", () => {
+test("a single-quoted manifest value is still recognised", () => {
   const contents = manifest(
-    `${HORIZON_META("")}${HORIZON_META("31705015229097839")}`,
+    "<meta-data android:name=\"com.meta.horizon.platform.HORIZON_APP_ID\" android:value='31705015229097839' />",
   );
   assert.equal(inspectHorizonAppIdSource(contents, "android-manifest"), null);
 });
 
-test("an empty Gradle fallback is rejected even when a literal id is nearby", () => {
+test("a Gradle placeholder is accepted only where the build resolves it", () => {
+  const templated = manifest(HORIZON_META("${HORIZON_APP_ID}"));
+  // A templated manifest declares the slot; verify-horizon-merged-manifest.mjs
+  // checks what the merger puts in it.
   assert.equal(
-    inspectHorizonAppIdSource(
-      'def id = localProperties.getProperty("HORIZON_APP_ID") ?: ""\n// 31705015229097839',
-      "gradle-fallback",
-    ),
-    "falls back to an empty app id",
-  );
-});
-
-test("a Gradle fallback to a literal id passes", () => {
-  assert.equal(
-    inspectHorizonAppIdSource(
-      'localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "31705015229097839"',
-      "gradle-fallback",
-    ),
+    inspectHorizonAppIdSource(templated, "templated-manifest"),
     null,
   );
+  // An example that ships its id directly must not leave an unresolved slot.
+  assert.equal(
+    inspectHorizonAppIdSource(templated, "android-manifest"),
+    "declares the Horizon meta-data without a literal app id",
+  );
 });
 
-test("a Gradle file with the id only in an unrelated place is rejected", () => {
+test("a templated manifest still needs the declaration itself", () => {
   assert.equal(
-    inspectHorizonAppIdSource(
-      'def unrelated = "31705015229097839"\n',
-      "gradle-fallback",
-    ),
-    "reads no Horizon app id property",
+    inspectHorizonAppIdSource(manifest("<activity/>"), "templated-manifest"),
+    "declares no Horizon app id meta-data",
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(manifest(HORIZON_META("")), "templated-manifest"),
+    "declares the Horizon meta-data without a literal app id or a placeholder",
   );
 });
 
@@ -211,60 +185,14 @@ test("the Expo plugin config must bind the id to horizon.appId", () => {
   );
 });
 
-test("a short number is not accepted as a Horizon app id", () => {
-  // Horizon app ids are long. Without this the digit-count constraint is
-  // unpinned and can be weakened to \\d+ with every other test still green.
-  assert.equal(
-    inspectHorizonAppIdSource(manifest(HORIZON_META("0")), "android-manifest"),
-    "declares the Horizon meta-data without a literal app id",
-  );
+test("a commented-out Expo appId does not satisfy the audit", () => {
   assert.equal(
     inspectHorizonAppIdSource(
-      'localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "12345"',
-      "gradle-fallback",
+      "horizon: { // appId: '31705015229097839'\n }",
+      "expo-plugin-config",
     ),
-    'falls back to "12345" instead of a literal Horizon app id',
-  );
-  assert.equal(
-    inspectHorizonAppIdSource("horizon: { appId: '42' }", "expo-plugin-config"),
     "declares horizon config without a literal appId",
   );
-});
-
-test("meta-data inside an activity-alias does not satisfy the audit", () => {
-  const contents = manifest(
-    `<activity-alias android:name=".Alias" android:targetActivity=".Main">${HORIZON_META("31705015229097839")}</activity-alias>`,
-  );
-  assert.equal(
-    inspectHorizonAppIdSource(contents, "android-manifest"),
-    "declares the Horizon meta-data outside <application>",
-  );
-});
-
-test("comment stripping survives an opener spliced together by removal", () => {
-  // Removing the inner `<!-- -->` joins `<!-` and `-` into a new `<!--` that
-  // the first pass never saw, so a single substitution leaves the
-  // commented-out declaration looking active.
-  const contents = manifest(
-    `<!-<!-- -->- ${HORIZON_META("31705015229097839")} -->`,
-  );
-  assert.equal(
-    inspectHorizonAppIdSource(contents, "android-manifest"),
-    "declares no Horizon app id meta-data",
-  );
-});
-
-test("a Gradle fallback inside a block comment does not satisfy the audit", () => {
-  assert.equal(
-    inspectHorizonAppIdSource(
-      '/*\nval appId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"\n*/',
-      "gradle-fallback",
-    ),
-    "reads no Horizon app id property",
-  );
-});
-
-test("an Expo appId inside a block comment does not satisfy the audit", () => {
   assert.equal(
     inspectHorizonAppIdSource(
       "/* horizon: { appId: '31705015229097839' } */",
@@ -274,123 +202,19 @@ test("an Expo appId inside a block comment does not satisfy the audit", () => {
   );
 });
 
-test("the Gradle inspector reads the statement, not one syntax", () => {
-  // The two Gradle examples do not share a shape. Both must resolve, and both
-  // must fail when the value the statement ends on is blank.
-  const elvis =
-    'val appId = localProperties.getProperty("HORIZON_APP_ID")?.trim()\n    ?: "31705015229097839"';
-  const listOf = [
-    "val appId = listOf(",
-    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
-    '    project.findProperty("EXAMPLE_OPENIAP_APP_ID") as String?,',
-    ').firstOrNull { !it.isNullOrBlank() } ?: "31705015229097839"',
-  ].join("\n");
-  for (const statement of [elvis, listOf]) {
-    assert.equal(inspectHorizonAppIdSource(statement, "gradle-fallback"), null);
-    assert.equal(
-      inspectHorizonAppIdSource(
-        statement.replace('"31705015229097839"', '""'),
-        "gradle-fallback",
-      ),
-      "falls back to an empty app id",
-    );
-  }
-});
-
-test("every app id statement is inspected, not only the first", () => {
-  // packages/google resolves the id twice — defaultConfig and the horizon
-  // flavor — and the flavor's value is what that build actually uses.
-  const source = [
-    "val appId = listOf(",
-    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
-    ').firstOrNull { !it.isNullOrBlank() } ?: "31705015229097839"',
-    'create("horizon") {',
-    '    val appId = localProperties.getProperty("EXAMPLE_HORIZON_APP_ID") ?: ""',
-    "}",
-  ].join("\n");
-  assert.equal(
-    inspectHorizonAppIdSource(source, "gradle-fallback"),
-    "falls back to an empty app id",
-  );
-});
-
-test("a literal fallback that a blank override defeats is rejected", () => {
-  // Properties.getProperty returns "" for a key present with no value, and ""
-  // is non-null, so elvis alone never reaches the literal.
-  assert.equal(
-    inspectHorizonAppIdSource(
-      'horizonAppId = localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
-      "gradle-fallback",
-    ),
-    "accepts a blank override, which defeats the literal fallback",
-  );
-});
-
-test("a single-quoted Groovy property name is still recognised", () => {
-  assert.equal(
-    inspectHorizonAppIdSource(
-      "horizonAppId = localProperties.getProperty('HORIZON_APP_ID')?.trim() ?: '31705015229097839'",
-      "gradle-fallback",
-    ),
-    null,
-  );
-});
-
-test("a single-quoted manifest value is still recognised", () => {
-  const contents = manifest(
-    "<meta-data android:name=\"com.meta.horizon.platform.HORIZON_APP_ID\" android:value='31705015229097839' />",
-  );
-  assert.equal(inspectHorizonAppIdSource(contents, "android-manifest"), null);
-});
-
-test("a nested object between horizon and appId does not hide the id", () => {
-  assert.equal(
-    inspectHorizonAppIdSource(
-      "horizon: { extra: { store: 'meta' }, appId: '31705015229097839' }",
-      "expo-plugin-config",
-    ),
-    null,
-  );
-});
-
-test("structure is read from masked text, so strings cannot forge syntax", () => {
-  // Every case below came from a Grok review of an earlier revision that
-  // counted parens and braces inside string literals.
-  const wrappedTrim = [
-    'horizonAppId = localProperties.getProperty("HORIZON_APP_ID")',
-    '    ?.trim() ?: "31705015229097839"',
-  ].join("\n");
-  const multiLineLambda = [
-    "val appId = listOf(",
-    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
-    ").firstOrNull {",
-    "    !it.isNullOrBlank()",
-    '} ?: "31705015229097839"',
-  ].join("\n");
-  const parenInString = [
-    'val appId = localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "31705015229097839"',
-    'val other = "a ( b"',
-  ].join("\n");
+test("Expo braces inside strings are not syntax", () => {
+  // Both cases came from a Grok review of a revision that counted every brace.
   const braceInString = [
     "horizon: {",
     '  note: "needs a } here",',
     "  appId: '31705015229097839',",
     "}",
   ].join("\n");
-
-  for (const source of [wrappedTrim, multiLineLambda, parenInString]) {
-    assert.equal(
-      inspectHorizonAppIdSource(source, "gradle-fallback"),
-      null,
-      source,
-    );
-  }
   assert.equal(
     inspectHorizonAppIdSource(braceInString, "expo-plugin-config"),
     null,
   );
 
-  // A brace inside a string must not stretch the block into a later decoy.
   const stretchedIntoDecoy = [
     "horizon: {",
     '  note: "{ {",',

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -353,6 +353,57 @@ test("a nested object between horizon and appId does not hide the id", () => {
   );
 });
 
+test("structure is read from masked text, so strings cannot forge syntax", () => {
+  // Every case below came from a Grok review of an earlier revision that
+  // counted parens and braces inside string literals.
+  const wrappedTrim = [
+    'horizonAppId = localProperties.getProperty("HORIZON_APP_ID")',
+    '    ?.trim() ?: "31705015229097839"',
+  ].join("\n");
+  const multiLineLambda = [
+    "val appId = listOf(",
+    '    localProperties.getProperty("EXAMPLE_HORIZON_APP_ID"),',
+    ").firstOrNull {",
+    "    !it.isNullOrBlank()",
+    '} ?: "31705015229097839"',
+  ].join("\n");
+  const parenInString = [
+    'val appId = localProperties.getProperty("HORIZON_APP_ID")?.trim() ?: "31705015229097839"',
+    'val other = "a ( b"',
+  ].join("\n");
+  const braceInString = [
+    "horizon: {",
+    '  note: "needs a } here",',
+    "  appId: '31705015229097839',",
+    "}",
+  ].join("\n");
+
+  for (const source of [wrappedTrim, multiLineLambda, parenInString]) {
+    assert.equal(
+      inspectHorizonAppIdSource(source, "gradle-fallback"),
+      null,
+      source,
+    );
+  }
+  assert.equal(
+    inspectHorizonAppIdSource(braceInString, "expo-plugin-config"),
+    null,
+  );
+
+  // A brace inside a string must not stretch the block into a later decoy.
+  const stretchedIntoDecoy = [
+    "horizon: {",
+    '  note: "{ {",',
+    "  appId: process.env.HORIZON,",
+    "},",
+    "later: { appId: '31705015229097839' },",
+  ].join("\n");
+  assert.equal(
+    inspectHorizonAppIdSource(stretchedIntoDecoy, "expo-plugin-config"),
+    "declares horizon config without a literal appId",
+  );
+});
+
 test("a missing source file is reported instead of silently passing", () => {
   const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), "horizon-audit-"));
   try {

--- a/scripts/audit-horizon-example-app-id.test.mjs
+++ b/scripts/audit-horizon-example-app-id.test.mjs
@@ -11,6 +11,13 @@ import {
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
+const manifest = (body) =>
+  `<manifest><application>${body}</application></manifest>`;
+const HORIZON_META = (value) => `
+  <meta-data
+      android:name="com.meta.horizon.platform.HORIZON_APP_ID"
+      android:value="${value}" />`;
+
 test("every Horizon example in this repository resolves an app id", () => {
   assert.deepEqual(collectHorizonExampleAppIdFailures(repoRoot), []);
 });
@@ -28,28 +35,124 @@ test("the audit covers every library that ships a Horizon example", () => {
   );
 });
 
-test("a manifest without the app id is rejected", () => {
+test("every source declares a kind the audit knows how to inspect", () => {
+  for (const source of HORIZON_APP_ID_SOURCES) {
+    const issue = inspectHorizonAppIdSource("", source.kind);
+    assert.equal(
+      /unknown source kind/.test(String(issue)),
+      false,
+      `${source.library} declares an uninspectable kind: ${source.kind}`,
+    );
+  }
+});
+
+test("a manifest that binds the id to the Horizon meta-data passes", () => {
   assert.equal(
     inspectHorizonAppIdSource(
-      '<meta-data android:name="com.meta.horizon.platform.HORIZON_APP_ID" />',
+      manifest(HORIZON_META("31705015229097839")),
+      "android-manifest",
     ),
-    "declares no literal Horizon app id",
+    null,
   );
 });
 
-test("an empty Gradle fallback is rejected even when a literal id is nearby", () => {
-  const issue = inspectHorizonAppIdSource(
-    'def id = localProperties.getProperty("HORIZON_APP_ID") ?: ""\n// 31705015229097839',
+test("a manifest with no Horizon meta-data is rejected", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(manifest("<activity/>"), "android-manifest"),
+    "declares no Horizon app id meta-data",
   );
-  assert.match(String(issue), /falls back to an empty app id/);
+});
+
+test("a numeric literal unbound from the declaration does not satisfy the audit", () => {
+  // The declaration is present but valueless; the id only appears in a comment.
+  const contents = manifest(`
+    <meta-data android:name="com.meta.horizon.platform.HORIZON_APP_ID" />
+    <!-- app id is 31705015229097839 -->`);
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares the Horizon meta-data without a literal app id",
+  );
+});
+
+test("an id bound to some other meta-data does not satisfy the audit", () => {
+  const contents = manifest(`
+    <meta-data android:name="com.example.OTHER_ID" android:value="31705015229097839" />
+    <meta-data android:name="com.meta.horizon.platform.HORIZON_APP_ID" android:value="" />`);
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares the Horizon meta-data without a literal app id",
+  );
+});
+
+test("a commented-out declaration does not satisfy the audit", () => {
+  const contents = manifest(`<!-- ${HORIZON_META("31705015229097839")} -->`);
+  assert.equal(
+    inspectHorizonAppIdSource(contents, "android-manifest"),
+    "declares no Horizon app id meta-data",
+  );
+});
+
+test("an unresolved manifest placeholder does not satisfy the audit", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      manifest(HORIZON_META("${HORIZON_APP_ID}")),
+      "android-manifest",
+    ),
+    "declares the Horizon meta-data without a literal app id",
+  );
+});
+
+test("a second Horizon meta-data block can supply the id", () => {
+  const contents = manifest(
+    `${HORIZON_META("")}${HORIZON_META("31705015229097839")}`,
+  );
+  assert.equal(inspectHorizonAppIdSource(contents, "android-manifest"), null);
+});
+
+test("an empty Gradle fallback is rejected even when a literal id is nearby", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      'def id = localProperties.getProperty("HORIZON_APP_ID") ?: ""\n// 31705015229097839',
+      "gradle-fallback",
+    ),
+    "falls back to an empty app id",
+  );
 });
 
 test("a Gradle fallback to a literal id passes", () => {
   assert.equal(
     inspectHorizonAppIdSource(
       'localProperties.getProperty("HORIZON_APP_ID") ?: "31705015229097839"',
+      "gradle-fallback",
     ),
     null,
+  );
+});
+
+test("a Gradle file with the id only in an unrelated place is rejected", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      'def unrelated = "31705015229097839"\n',
+      "gradle-fallback",
+    ),
+    "does not fall back to a literal Horizon app id",
+  );
+});
+
+test("the Expo plugin config must bind the id to horizon.appId", () => {
+  assert.equal(
+    inspectHorizonAppIdSource(
+      "android: { horizon: { appId: '31705015229097839' } }",
+      "expo-plugin-config",
+    ),
+    null,
+  );
+  assert.equal(
+    inspectHorizonAppIdSource(
+      "android: { horizon: { appId: process.env.HORIZON } }\nconst other = '31705015229097839'",
+      "expo-plugin-config",
+    ),
+    "does not set a literal horizon.appId",
   );
 });
 

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -66,6 +66,7 @@ execFileSync(
   [
     "--test",
     path.resolve(root, "scripts/audit-horizon-example-app-id.test.mjs"),
+    path.resolve(root, "scripts/verify-horizon-merged-manifest.test.mjs"),
   ],
   { stdio: "inherit" },
 );

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -1989,7 +1989,9 @@ function walk(dir, acc = []) {
       entry.name === "bin" ||
       entry.name === "obj" ||
       entry.name === "Pods" ||
-      entry.name === "DerivedData"
+      entry.name === "DerivedData" ||
+      // SwiftPM checkout cache; it vendors this repository's own sources.
+      entry.name === "SourcePackages"
     ) {
       continue;
     }

--- a/scripts/audit-non-godot-parity.mjs
+++ b/scripts/audit-non-godot-parity.mjs
@@ -12,6 +12,7 @@ import { collectGeneratedSyncDrift } from "../specs/client/scripts/verify-genera
 import { collectCompletedRemovalFailures } from "./audit-deprecation-schedule.mjs";
 import { usesApi24ConcurrentKeySet } from "./audit-android-api-compat.mjs";
 import { assertSpecMatchesNativeFloor } from "./release-branch-policy.mjs";
+import { collectHorizonExampleAppIdFailures } from "./audit-horizon-example-app-id.mjs";
 import {
   collectPurchasePayloadParityFailures,
   extractBalancedAfterMarker,
@@ -57,6 +58,14 @@ execFileSync(
   [
     "--test",
     path.resolve(root, "scripts/audit-purchase-payload-parity.test.mjs"),
+  ],
+  { stdio: "inherit" },
+);
+execFileSync(
+  process.execPath,
+  [
+    "--test",
+    path.resolve(root, "scripts/audit-horizon-example-app-id.test.mjs"),
   ],
   { stdio: "inherit" },
 );
@@ -5581,13 +5590,11 @@ function checkFrameworkDependencyHygiene() {
       /^\s*git checkout\b/,
       packageIndex + 1,
     );
-    if (
-      !(
-        guardIndex >= 0 &&
-        packageIndex === guardIndex + 1 &&
-        checkoutIndex > packageIndex
-      )
-    ) {
+    if (!(
+      guardIndex >= 0 &&
+      packageIndex === guardIndex + 1 &&
+      checkoutIndex > packageIndex
+    )) {
       fail(
         `${frameworkReleaseWorkflow} must guard and check out the existing tag in one shell block`,
       );
@@ -9302,6 +9309,9 @@ checkExpoSsotRegistry();
 checkE2eExampleIds();
 checkGeneratedTypeSync();
 for (const issue of collectPurchasePayloadParityFailures(root)) {
+  fail(issue);
+}
+for (const issue of collectHorizonExampleAppIdFailures(root)) {
   fail(issue);
 }
 checkGqlRuntimeExports();

--- a/scripts/audit-npm-overrides.mjs
+++ b/scripts/audit-npm-overrides.mjs
@@ -29,6 +29,7 @@ const SKIPPED_DIRECTORIES = new Set([
   ".git",
   "dist",
   "build",
+  "SourcePackages",
   "Pods",
   ".next",
   ".expo",

--- a/scripts/audit-sbom-docs.mjs
+++ b/scripts/audit-sbom-docs.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// security/SBOM.md carries a reader-facing copy of the releasable component
+// list. The list itself lives in scripts/release-branch-policy.mjs and is
+// mirrored by scripts/generate-sbom.mjs; without this audit the documentation
+// copy drifts silently, which is how `commerce-protocol` shipped an SBOM
+// artifact while the documented matrix said the component did not exist.
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { versionSources } from "./release-branch-policy.mjs";
+import { __testing as sbomTesting } from "./generate-sbom.mjs";
+
+export const SBOM_DOC = "security/SBOM.md";
+
+const MATRIX_ROW = /^\|\s*`([a-z-]+)`\s*\|\s*`([^`]+)`\s*\|/gm;
+
+export function parseDocumentedComponents(markdown) {
+  return [...markdown.matchAll(MATRIX_ROW)].map(([, id, sbomName]) => ({
+    id,
+    sbomName,
+  }));
+}
+
+const describe = (ids) => ids.map((id) => `\`${id}\``).join(", ");
+
+export function collectSbomDocFailures(repoRoot) {
+  const failures = [];
+  const docPath = path.resolve(repoRoot, SBOM_DOC);
+  if (!fs.existsSync(docPath)) {
+    return [`${SBOM_DOC} is missing`];
+  }
+
+  const released = Object.keys(versionSources).sort();
+  const generated = Object.keys(sbomTesting.COMPONENTS).sort();
+
+  // The generator is what actually emits artifacts, so it must cover exactly
+  // the components the release policy knows how to version.
+  const ungenerated = released.filter((id) => !generated.includes(id));
+  const unreleased = generated.filter((id) => !released.includes(id));
+  if (ungenerated.length > 0) {
+    failures.push(
+      `releasable components with no SBOM generator entry: ${describe(ungenerated)}`,
+    );
+  }
+  if (unreleased.length > 0) {
+    failures.push(
+      `SBOM generator entries that are not releasable components: ${describe(unreleased)}`,
+    );
+  }
+
+  const documented = parseDocumentedComponents(
+    fs.readFileSync(docPath, "utf8"),
+  );
+  const documentedIds = documented.map((row) => row.id).sort();
+  const undocumented = generated.filter((id) => !documentedIds.includes(id));
+  const stale = documentedIds.filter((id) => !generated.includes(id));
+  if (undocumented.length > 0) {
+    failures.push(
+      `${SBOM_DOC} omits released components: ${describe(undocumented)}`,
+    );
+  }
+  if (stale.length > 0) {
+    failures.push(
+      `${SBOM_DOC} documents components that no longer exist: ${describe(stale)}`,
+    );
+  }
+
+  // A wrong SBOM name sends a reader to a file that was never published.
+  for (const row of documented) {
+    const definition = sbomTesting.COMPONENTS[row.id];
+    if (!definition) continue;
+    if (definition.sbomName !== row.sbomName) {
+      failures.push(
+        `${SBOM_DOC} lists \`${row.id}\` as \`${row.sbomName}\`, but the generator emits \`${definition.sbomName}\``,
+      );
+    }
+  }
+
+  return failures;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const repoRoot = path.resolve(import.meta.dirname, "..");
+  const failures = collectSbomDocFailures(repoRoot);
+  for (const failure of failures) {
+    console.error(`FAIL ${failure}`);
+  }
+  if (failures.length > 0) {
+    process.exit(1);
+  }
+  console.log(
+    `SBOM documentation audit passed (${Object.keys(versionSources).length} components).`,
+  );
+}

--- a/scripts/audit-sbom-docs.test.mjs
+++ b/scripts/audit-sbom-docs.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  SBOM_DOC,
+  collectSbomDocFailures,
+  parseDocumentedComponents,
+} from "./audit-sbom-docs.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("the documented component matrix matches the release and SBOM sources", () => {
+  assert.deepEqual(collectSbomDocFailures(repoRoot), []);
+});
+
+test("matrix rows are read as id and SBOM name pairs", () => {
+  const rows = parseDocumentedComponents(
+    [
+      "| Component | SBOM name | Distribution | Release tag |",
+      "| --- | --- | --- | --- |",
+      "| `godot` | `godot-iap` | GitHub Release | `godot-iap-<version>` |",
+      "| `commerce-protocol` | `openiap-commerce-protocol` | npm | `x` |",
+      "not a row",
+    ].join("\n"),
+  );
+  assert.deepEqual(rows, [
+    { id: "godot", sbomName: "godot-iap" },
+    { id: "commerce-protocol", sbomName: "openiap-commerce-protocol" },
+  ]);
+});
+
+const withDoc = (markdown, run) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "sbom-docs-"));
+  try {
+    fs.mkdirSync(path.join(root, "security"), { recursive: true });
+    fs.writeFileSync(path.join(root, SBOM_DOC), markdown);
+    run(collectSbomDocFailures(root));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test("a component missing from the documentation is reported", () => {
+  // The real matrix minus commerce-protocol — the exact drift that shipped.
+  const markdown = fs
+    .readFileSync(path.join(repoRoot, SBOM_DOC), "utf8")
+    .split("\n")
+    .filter((line) => !line.includes("`commerce-protocol`"))
+    .join("\n");
+  withDoc(markdown, (failures) => {
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /omits released components: `commerce-protocol`/);
+  });
+});
+
+test("a component the generator no longer emits is reported as stale", () => {
+  const markdown =
+    fs.readFileSync(path.join(repoRoot, SBOM_DOC), "utf8") +
+    "\n| `retired` | `openiap-retired` | npm | `retired-<version>` |\n";
+  withDoc(markdown, (failures) => {
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /no longer exist: `retired`/);
+  });
+});
+
+test("a wrong SBOM name is reported", () => {
+  const markdown = fs
+    .readFileSync(path.join(repoRoot, SBOM_DOC), "utf8")
+    .replace("`godot-iap`", "`godot-iap-addon`");
+  withDoc(markdown, (failures) => {
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /lists `godot` as `godot-iap-addon`/);
+  });
+});
+
+test("the audit reports a missing document instead of passing", () => {
+  const failures = collectSbomDocFailures(
+    path.join(repoRoot, "does-not-exist"),
+  );
+  assert.deepEqual(failures, [`${SBOM_DOC} is missing`]);
+});

--- a/scripts/audit-security.mjs
+++ b/scripts/audit-security.mjs
@@ -265,6 +265,40 @@ export function parseOsvIgnoredVulnerabilities(source) {
   return ignored;
 }
 
+// `bun audit` reaches a remote advisory service, and that call fails
+// intermittently. The failure is a transport error rather than a verdict, so it
+// is retried; anything else, including a real advisory, still fails the audit.
+const TRANSPORT_FAILURE =
+  /ConnectionClosed|ConnectionRefused|Timeout|ECONNRESET|ETIMEDOUT|socket hang up|audit request failed/i;
+
+export const isTransportFailure = (result) =>
+  TRANSPORT_FAILURE.test(`${result?.stdout ?? ""}${result?.stderr ?? ""}`);
+
+const sleepSync = (milliseconds) => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+};
+
+export const BUN_AUDIT_ATTEMPTS = 3;
+
+export function runBunAudit(
+  run,
+  directory,
+  { attempts = BUN_AUDIT_ATTEMPTS, sleep = sleepSync } = {},
+) {
+  let result;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    result = run("bun", ["audit", "--json"], {
+      cwd: directory,
+      encoding: "utf8",
+    });
+    // Only a transport error is worth repeating. A non-zero status carrying a
+    // verdict, or any other output, is the answer.
+    if (!isTransportFailure(result) || attempt === attempts) return result;
+    sleep(attempt * 2000);
+  }
+  return result;
+}
+
 export function auditDependencies(
   run = spawnSync,
   projects = BUN_PROJECTS,
@@ -272,14 +306,12 @@ export function auditDependencies(
   osvLockfiles = projects === BUN_PROJECTS
     ? OSV_LOCKFILES
     : projects.map(({ lockfile }) => lockfile),
+  auditOptions = {},
 ) {
   const findings = [];
   let ignoredCount = 0;
   for (const { directory, lockfile } of projects) {
-    const result = run("bun", ["audit", "--json"], {
-      cwd: resolve(repoRoot, directory),
-      encoding: "utf8",
-    });
+    const result = runBunAudit(run, resolve(repoRoot, directory), auditOptions);
     if (result.error) throw result.error;
     if (result.signal) {
       throw new Error(`${lockfile}: bun audit terminated by ${result.signal}`);

--- a/scripts/audit-security.test.mjs
+++ b/scripts/audit-security.test.mjs
@@ -5,15 +5,18 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import {
-  auditWorkflowFiles,
+  BUN_AUDIT_ATTEMPTS,
   auditDependencies,
+  auditWorkflowFiles,
   extractExternalUrls,
   findUnpinnedDockerBases,
   findWorkflowDependencyFindings,
   findWorkflowRunInterpolations,
+  isTransportFailure,
   listWorkflowFiles,
   parseBunAuditOutput,
   parseOsvIgnoredVulnerabilities,
+  runBunAudit,
   summarizeAdvisories,
 } from "./audit-security.mjs";
 
@@ -638,10 +641,7 @@ test("CodeQL scopes Swift pull requests to public macOS runners", () => {
     wrappers,
     /github\.event_name != 'pull_request'\s+&& \(matrix\.component == 'godot' && 'macos-26' \|\| 'xcode-27'\)/u,
   );
-  assert.match(
-    wrappers,
-    /\|\| needs\.pick-mac-runner\.outputs\.runner \}\}/u,
-  );
+  assert.match(wrappers, /\|\| needs\.pick-mac-runner\.outputs\.runner \}\}/u);
   assert.match(
     wrappers,
     /EXPECTED_XCODE_MAJOR: \$\{\{ github\.event_name == 'pull_request' && '26' \|\| '27' \}\}/u,
@@ -697,4 +697,51 @@ FROM base AS runtime
     ),
     ["alpine:latest"],
   );
+});
+
+test("a transport failure is retried, a verdict is not", () => {
+  // bun audit reaches a remote advisory service; that call fails
+  // intermittently and blocked this repository's CI three times. Only the
+  // transport error repeats — a real advisory must still fail the audit.
+  let transient = 0;
+  const flaky = () => {
+    transient += 1;
+    return transient < 3
+      ? {
+          status: 1,
+          stdout: "",
+          stderr: "ConnectionClosed: audit request failed",
+        }
+      : { status: 0, stdout: '{"advisories":{}}', stderr: "" };
+  };
+  const recovered = runBunAudit(flaky, "/tmp", { sleep: () => {} });
+  assert.equal(transient, 3);
+  assert.equal(recovered.stdout, '{"advisories":{}}');
+
+  let verdicts = 0;
+  const advisory = () => {
+    verdicts += 1;
+    return { status: 1, stdout: '{"advisories":{"pkg":[]}}', stderr: "" };
+  };
+  runBunAudit(advisory, "/tmp", { sleep: () => {} });
+  assert.equal(verdicts, 1, "a verdict must not be retried");
+});
+
+test("a persistent transport failure still fails after its attempts", () => {
+  let calls = 0;
+  const down = () => {
+    calls += 1;
+    return { status: 1, stdout: "", stderr: "Timeout: audit request failed" };
+  };
+  const result = runBunAudit(down, "/tmp", { sleep: () => {} });
+  assert.equal(calls, BUN_AUDIT_ATTEMPTS);
+  assert.ok(isTransportFailure(result), "the transport failure must survive");
+});
+
+test("transport detection does not swallow an ordinary failure", () => {
+  assert.equal(
+    isTransportFailure({ stdout: "", stderr: "bun: command not found" }),
+    false,
+  );
+  assert.equal(isTransportFailure({ stdout: "", stderr: "" }), false);
 });

--- a/scripts/generate-sbom.mjs
+++ b/scripts/generate-sbom.mjs
@@ -424,6 +424,9 @@ const COMPONENTS = {
           name: "SwiftGodotRuntime",
           spdxLicense: "MIT",
           supplier: "Miguel de Icaza",
+          // MIT requires the notice to travel with the binary. Verbatim
+          // upstream text, so the notice generator never has to compose one.
+          licenseFile: "libraries/godot-iap/third-party/SwiftGodot-LICENSE",
         },
         {
           kind: "embedded-binary",
@@ -431,6 +434,7 @@ const COMPONENTS = {
           name: "SwiftGodotRuntime-macOS",
           spdxLicense: "MIT",
           supplier: "Miguel de Icaza",
+          licenseFile: "libraries/godot-iap/third-party/SwiftGodot-LICENSE",
         },
       ],
     },

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// Derives per-component license evidence from the SBOM component table.
+//
+// Two outputs, both deterministic and both refusing to guess:
+//   inventory — every embedded third-party component with its declared SPDX id
+//   notices   — the verbatim upstream license text for components whose
+//               license requires the notice to travel with the binary
+//
+// A component that declares a license but commits no license text is an error,
+// not a blank section: MIT and the BSD family require the copyright notice in
+// every redistribution, and the godot-iap addon ZIP shipped without one.
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { __testing as sbomTesting } from "./generate-sbom.mjs";
+
+// Licenses whose text must be redistributed alongside the binary.
+export const NOTICE_REQUIRING_LICENSES = new Set([
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "MIT",
+]);
+
+// A component's source is either one entry or an aggregate of entries, and an
+// aggregate can nest, so walk it rather than assuming a single level.
+const embeddedBinaries = (source, found = []) => {
+  if (!source || typeof source !== "object") return found;
+  if (source.kind === "embedded-binary") {
+    found.push(source);
+    return found;
+  }
+  for (const nested of source.sources ?? []) {
+    embeddedBinaries(nested, found);
+  }
+  return found;
+};
+
+export function collectEmbeddedComponents(componentId) {
+  return embeddedBinaries(sbomTesting.COMPONENTS[componentId]?.source).map(
+    (part) => ({
+      name: part.name,
+      spdxLicense: part.spdxLicense ?? null,
+      supplier: part.supplier ?? null,
+      binary: part.file,
+      licenseFile: part.licenseFile ?? null,
+    }),
+  );
+}
+
+export function collectNoticeFailures(repoRoot, componentId) {
+  const failures = [];
+  for (const component of collectEmbeddedComponents(componentId)) {
+    if (!component.spdxLicense) {
+      failures.push(
+        `${component.name}: no SPDX license recorded; resolve it upstream rather than guessing`,
+      );
+      continue;
+    }
+    if (!NOTICE_REQUIRING_LICENSES.has(component.spdxLicense)) continue;
+    if (!component.licenseFile) {
+      failures.push(
+        `${component.name}: ${component.spdxLicense} requires its notice to ship, but no licenseFile is recorded`,
+      );
+      continue;
+    }
+    if (!fs.existsSync(path.resolve(repoRoot, component.licenseFile))) {
+      failures.push(
+        `${component.name}: licenseFile ${component.licenseFile} does not exist`,
+      );
+    }
+  }
+  return failures;
+}
+
+export function renderNotices(repoRoot, componentId) {
+  const failures = collectNoticeFailures(repoRoot, componentId);
+  if (failures.length > 0) {
+    throw new Error(
+      `cannot render notices for ${componentId}:\n${failures.map((f) => `  - ${f}`).join("\n")}`,
+    );
+  }
+  const components = collectEmbeddedComponents(componentId)
+    .filter((component) => NOTICE_REQUIRING_LICENSES.has(component.spdxLicense))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  // One section per distinct license file: two frameworks built from the same
+  // upstream project share one notice rather than repeating it.
+  const byLicenseFile = new Map();
+  for (const component of components) {
+    const existing = byLicenseFile.get(component.licenseFile);
+    if (existing) {
+      existing.names.push(component.name);
+      continue;
+    }
+    byLicenseFile.set(component.licenseFile, {
+      names: [component.name],
+      spdxLicense: component.spdxLicense,
+      supplier: component.supplier,
+    });
+  }
+
+  const sections = [...byLicenseFile.entries()].map(([file, entry]) => {
+    const text = fs.readFileSync(path.resolve(repoRoot, file), "utf8").trim();
+    const supplier = entry.supplier ? ` — ${entry.supplier}` : "";
+    return [
+      `## ${entry.names.join(", ")}${supplier}`,
+      "",
+      `SPDX-License-Identifier: ${entry.spdxLicense}`,
+      "",
+      "```text",
+      text,
+      "```",
+    ].join("\n");
+  });
+
+  return [
+    "# Third-party notices",
+    "",
+    `Components redistributed inside the \`${componentId}\` release artifact.`,
+    "Generated from the SBOM component table by",
+    "`scripts/generate-third-party-notices.mjs`; do not edit by hand.",
+    "",
+    ...sections,
+    "",
+  ].join("\n");
+}
+
+export function renderInventory(componentId) {
+  const components = collectEmbeddedComponents(componentId).sort(
+    (left, right) => left.name.localeCompare(right.name),
+  );
+  const rows = components.map((component) =>
+    [
+      component.name,
+      component.spdxLicense ?? "UNKNOWN — needs review",
+      component.supplier ?? "unknown",
+      component.binary,
+    ].join("\t"),
+  );
+  return ["name\tlicense\tsupplier\tbinary", ...rows].join("\n") + "\n";
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const repoRoot = path.resolve(import.meta.dirname, "..");
+  const [componentId, outputPath] = process.argv.slice(2);
+  if (!componentId) {
+    console.error(
+      "usage: generate-third-party-notices.mjs <component> [output]\n" +
+        `components: ${Object.keys(sbomTesting.COMPONENTS).sort().join(", ")}`,
+    );
+    process.exit(2);
+  }
+  if (!sbomTesting.COMPONENTS[componentId]) {
+    console.error(`unknown component ${JSON.stringify(componentId)}`);
+    process.exit(2);
+  }
+  let notices;
+  try {
+    notices = renderNotices(repoRoot, componentId);
+  } catch (error) {
+    console.error(String(error.message));
+    process.exit(1);
+  }
+  if (outputPath) {
+    fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+    fs.writeFileSync(path.resolve(outputPath), notices);
+    console.log(`wrote ${outputPath}`);
+  } else {
+    process.stdout.write(notices);
+  }
+}

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -65,9 +65,18 @@ export function collectNoticeFailures(repoRoot, componentId) {
       );
       continue;
     }
-    if (!fs.existsSync(path.resolve(repoRoot, component.licenseFile))) {
+    const licensePath = path.resolve(repoRoot, component.licenseFile);
+    if (!fs.existsSync(licensePath)) {
       failures.push(
         `${component.name}: licenseFile ${component.licenseFile} does not exist`,
+      );
+      continue;
+    }
+    // An empty file is not a notice. Without this the generator renders a
+    // blank fenced block, which is the empty section it exists to refuse.
+    if (fs.readFileSync(licensePath, "utf8").trim() === "") {
+      failures.push(
+        `${component.name}: licenseFile ${component.licenseFile} is empty`,
       );
     }
   }

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -159,6 +159,10 @@ if (
     console.error(`unknown component ${JSON.stringify(componentId)}`);
     process.exit(2);
   }
+  if (process.argv.includes("--inventory")) {
+    process.stdout.write(renderInventory(componentId));
+    process.exit(0);
+  }
   let notices;
   try {
     notices = renderNotices(repoRoot, componentId);

--- a/scripts/generate-third-party-notices.test.mjs
+++ b/scripts/generate-third-party-notices.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  NOTICE_REQUIRING_LICENSES,
+  collectEmbeddedComponents,
+  collectNoticeFailures,
+  renderNotices,
+} from "./generate-third-party-notices.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("the godot component's embedded binaries are notice-ready", () => {
+  assert.deepEqual(collectNoticeFailures(repoRoot, "godot"), []);
+});
+
+test("the rendered notice carries the upstream text verbatim", () => {
+  const notices = renderNotices(repoRoot, "godot");
+  const upstream = fs
+    .readFileSync(
+      path.join(repoRoot, "libraries/godot-iap/third-party/SwiftGodot-LICENSE"),
+      "utf8",
+    )
+    .trim();
+  assert.ok(
+    notices.includes(upstream),
+    "upstream licence text is not verbatim",
+  );
+  assert.match(notices, /SPDX-License-Identifier: MIT/);
+});
+
+test("every embedded component declares a licence the audit knows", () => {
+  for (const component of collectEmbeddedComponents("godot")) {
+    assert.ok(component.spdxLicense, `${component.name} has no SPDX licence`);
+    if (NOTICE_REQUIRING_LICENSES.has(component.spdxLicense)) {
+      assert.ok(
+        component.licenseFile,
+        `${component.name} needs its notice to ship but has no licenseFile`,
+      );
+    }
+  }
+});
+
+test("an empty licence file is refused, not rendered as a blank section", () => {
+  // The generator exists to fail rather than emit an empty notice, and a file
+  // that exists but holds nothing defeats that just as surely as a missing one.
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "notices-"));
+  try {
+    const target = path.join(
+      scratch,
+      "libraries/godot-iap/third-party/SwiftGodot-LICENSE",
+    );
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "   \n\t\n");
+    const failures = collectNoticeFailures(scratch, "godot");
+    assert.ok(failures.length > 0, "an empty licence file was accepted");
+    for (const failure of failures) assert.match(failure, /is empty$/);
+    assert.throws(() => renderNotices(scratch, "godot"), /is empty/);
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("a missing licence file is refused", () => {
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "notices-missing-"));
+  try {
+    const failures = collectNoticeFailures(empty, "godot");
+    assert.ok(failures.length > 0);
+    for (const failure of failures) assert.match(failure, /does not exist$/);
+  } finally {
+    fs.rmSync(empty, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-horizon-merged-manifest.mjs
+++ b/scripts/verify-horizon-merged-manifest.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Assert that a merged Android manifest resolves a usable Horizon app id.
+//
+// A build file's text cannot prove this. The value reaching the manifest
+// depends on which properties are set, which flavor is building, and how the
+// expression short-circuits, so a static read of the Gradle source can only
+// approximate it. The manifest merger has already made that decision, so this
+// reads its output instead.
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const HORIZON_APP_ID_META_DATA_NAME =
+  "com.meta.horizon.platform.HORIZON_APP_ID";
+
+const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data\s*>)/g;
+const VALUE_ATTRIBUTE = /android:value\s*=\s*"([^"]*)"/;
+const APP_ID = /^\d{10,}$/;
+
+export function inspectMergedManifest(contents) {
+  const elements = [...contents.matchAll(META_DATA_ELEMENT)]
+    .map(([element]) => element)
+    .filter((element) => element.includes(HORIZON_APP_ID_META_DATA_NAME));
+
+  if (elements.length === 0) {
+    return `the merged manifest declares no ${HORIZON_APP_ID_META_DATA_NAME}`;
+  }
+  for (const element of elements) {
+    const value = element.match(VALUE_ATTRIBUTE)?.[1];
+    if (value === undefined)
+      return "the Horizon meta-data has no android:value";
+    if (value === "") {
+      return "the Horizon app id merged as empty, so startConnection will throw";
+    }
+    // An unresolved placeholder means the build never supplied the property.
+    if (value.startsWith("${")) {
+      return `the Horizon app id merged unresolved as ${value}`;
+    }
+    if (!APP_ID.test(value)) {
+      return `the Horizon app id merged as ${JSON.stringify(value)}, which is not an app id`;
+    }
+  }
+  return null;
+}
+
+export function verifyMergedManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) {
+    return `${manifestPath} does not exist; build the Horizon variant first`;
+  }
+  return inspectMergedManifest(fs.readFileSync(manifestPath, "utf8"));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const [manifestPath] = process.argv.slice(2);
+  if (!manifestPath) {
+    console.error(
+      "usage: verify-horizon-merged-manifest.mjs <AndroidManifest.xml>",
+    );
+    process.exit(2);
+  }
+  const resolved = path.resolve(manifestPath);
+  const issue = verifyMergedManifest(resolved);
+  if (issue) {
+    console.error(`FAIL ${issue}`);
+    process.exit(1);
+  }
+  console.log(
+    `Horizon app id resolves in ${path.relative(process.cwd(), resolved)}`,
+  );
+}

--- a/scripts/verify-horizon-merged-manifest.mjs
+++ b/scripts/verify-horizon-merged-manifest.mjs
@@ -14,13 +14,31 @@ export const HORIZON_APP_ID_META_DATA_NAME =
   "com.meta.horizon.platform.HORIZON_APP_ID";
 
 const META_DATA_ELEMENT = /<meta-data\b[\s\S]*?(?:\/>|<\/meta-data\s*>)/g;
+const NAME_ATTRIBUTE = /android:name\s*=\s*"([^"]*)"/;
 const VALUE_ATTRIBUTE = /android:value\s*=\s*"([^"]*)"/;
 const APP_ID = /^\d{10,}$/;
 
+// Replace to a fixpoint: removing an inner `<!-- -->` can splice `<!-` and `-`
+// into a new opener the pass never saw, so one substitution is not a strip.
+const stripXmlComments = (source) => {
+  let previous;
+  let current = source;
+  do {
+    previous = current;
+    current = previous.replace(/<!--[\s\S]*?-->/g, "");
+  } while (current !== previous);
+  return current;
+};
+
 export function inspectMergedManifest(contents) {
-  const elements = [...contents.matchAll(META_DATA_ELEMENT)]
+  // Comments are not declarations, and android:name must match exactly — a
+  // substring test would accept com.example.<the Horizon name>.
+  const elements = [...stripXmlComments(contents).matchAll(META_DATA_ELEMENT)]
     .map(([element]) => element)
-    .filter((element) => element.includes(HORIZON_APP_ID_META_DATA_NAME));
+    .filter(
+      (element) =>
+        element.match(NAME_ATTRIBUTE)?.[1] === HORIZON_APP_ID_META_DATA_NAME,
+    );
 
   if (elements.length === 0) {
     return `the merged manifest declares no ${HORIZON_APP_ID_META_DATA_NAME}`;

--- a/scripts/verify-horizon-merged-manifest.test.mjs
+++ b/scripts/verify-horizon-merged-manifest.test.mjs
@@ -54,6 +54,33 @@ test("a manifest without the declaration is reported", () => {
   );
 });
 
+test("a commented-out declaration is not a declaration", () => {
+  const contents = [
+    "<manifest><application>",
+    "  <!--",
+    '  <meta-data android:name="com.meta.horizon.platform.HORIZON_APP_ID"',
+    '      android:value="31705015229097839" />',
+    "  -->",
+    "</application></manifest>",
+  ].join("\n");
+  assert.match(
+    String(inspectMergedManifest(contents)),
+    /declares no com\.meta\.horizon\.platform\.HORIZON_APP_ID/,
+  );
+});
+
+test("android:name must match exactly, not by substring", () => {
+  const contents = `<manifest><application>
+    <meta-data
+        android:name="com.example.com.meta.horizon.platform.HORIZON_APP_ID"
+        android:value="31705015229097839" />
+  </application></manifest>`;
+  assert.match(
+    String(inspectMergedManifest(contents)),
+    /declares no com\.meta\.horizon\.platform\.HORIZON_APP_ID/,
+  );
+});
+
 test("a missing manifest is reported instead of passing", () => {
   const missing = path.join(
     fs.mkdtempSync(path.join(os.tmpdir(), "horizon-merged-")),

--- a/scripts/verify-horizon-merged-manifest.test.mjs
+++ b/scripts/verify-horizon-merged-manifest.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  inspectMergedManifest,
+  verifyMergedManifest,
+} from "./verify-horizon-merged-manifest.mjs";
+
+const merged = (value) =>
+  `<manifest><application>
+    <meta-data
+        android:name="com.meta.horizon.platform.HORIZON_APP_ID"
+        android:value="${value}" />
+  </application></manifest>`;
+
+test("a resolved app id passes", () => {
+  assert.equal(inspectMergedManifest(merged("31705015229097839")), null);
+});
+
+test("an empty merged value is the defect this exists for", () => {
+  // Reproduced against a real Gradle run: reverting the example's fallback and
+  // clearing the local property merges "" here, and the app then throws inside
+  // startConnection on the headset.
+  assert.equal(
+    inspectMergedManifest(merged("")),
+    "the Horizon app id merged as empty, so startConnection will throw",
+  );
+});
+
+test("an unresolved placeholder is reported as such", () => {
+  assert.equal(
+    inspectMergedManifest(merged("${HORIZON_APP_ID}")),
+    "the Horizon app id merged unresolved as ${HORIZON_APP_ID}",
+  );
+});
+
+test("a value that is not an app id is rejected", () => {
+  assert.equal(
+    inspectMergedManifest(merged("not-an-id")),
+    'the Horizon app id merged as "not-an-id", which is not an app id',
+  );
+  assert.equal(
+    inspectMergedManifest(merged("0")),
+    'the Horizon app id merged as "0", which is not an app id',
+  );
+});
+
+test("a manifest without the declaration is reported", () => {
+  assert.match(
+    String(inspectMergedManifest("<manifest><application/></manifest>")),
+    /declares no com\.meta\.horizon\.platform\.HORIZON_APP_ID/,
+  );
+});
+
+test("a missing manifest is reported instead of passing", () => {
+  const missing = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "horizon-merged-")),
+    "AndroidManifest.xml",
+  );
+  assert.match(String(verifyMergedManifest(missing)), /does not exist/);
+});

--- a/security/README.md
+++ b/security/README.md
@@ -196,6 +196,33 @@ which serves the uploaded file verbatim, and less so for registries that may
 re-archive on ingest. None of it is implemented yet, and an existence check must
 not be relabelled as verification in the meantime.
 
+### Horizon app id resolution
+
+The Horizon billing client reads `com.meta.horizon.platform.HORIZON_APP_ID` from
+the merged Android manifest and throws inside `startConnection` when it is
+absent, so an example that omits it compiles, installs, and fails only on a
+headset.
+
+Two checks cover this, and they prove different things:
+
+| Check                                        | Proves                                                                                                          |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `bun run audit:horizon-app-id`               | every example _declares_ the meta-data under `<application>`, with a literal id or a Gradle placeholder         |
+| `scripts/verify-horizon-merged-manifest.mjs` | the value the manifest merger actually _resolved_ is a real app id, not empty and not an unresolved placeholder |
+
+The declaration check is static and runs on every pull request. The resolution
+check needs a built variant, and CI runs it for `packages/google` only, because
+that is the one target whose Horizon variant CI already builds.
+
+`libraries/flutter_inapp_purchase/example` also resolves its id through a Gradle
+placeholder, and its resolution is therefore **not** verified in CI — that
+workflow builds no Android variant. Its declaration is checked, and its resolved
+value was verified by hand against a real merge. Closing this properly means
+adding an Android job to the Flutter workflow, not adding a static check that
+reads the build file's text: the value is decided by the manifest merger, and
+approximating that decision from source is what an earlier revision of the audit
+got wrong.
+
 ### Release immutability
 
 GitHub's immutable releases would stop a published asset being replaced after

--- a/security/README.md
+++ b/security/README.md
@@ -137,8 +137,27 @@ gates remain independent of that hosted view.
 - CodeQL's traced Kotlin jobs build the Google and KMP Android cores plus the
   React Native, Expo, Flutter, Godot, and MAUI JVM wrappers. Its traced Swift
   jobs build the Apple core, KMP Swift bridge, and React Native, Expo, Flutter,
-  and Godot wrappers. KMP Kotlin/Native remains covered by its compile/test lane
-  and review because CodeQL's Kotlin extractor traces JVM compilation.
+  and Godot wrappers.
+- CodeQL's Kotlin extractor traces JVM compilation, so it cannot analyse
+  Kotlin/Native. This is a CodeQL platform limitation, not an OpenIAP
+  configuration gap: no CodeQL setting reaches this code. The uncovered shipped
+  surface is exactly `libraries/kmp-iap/library/src/iosMain` — 4 files, 1,931
+  lines, 13% of the library's main-source Kotlin. `commonMain` (7,337 lines) is
+  covered, because it compiles into the traced Android target.
+  Three things bound the residual risk, each independently checkable:
+  - The uncovered code performs no security-relevant operation. Searching
+    `iosMain` for URL loading, Keychain or `SecItem`, file and defaults writes,
+    crypto, and unsafe interop (`memScoped`, `usePinned`, `refTo`, `cstr`)
+    returns no hits, and the repository defines no custom cinterop `.def` file.
+  - Every StoreKit call, receipt read, JWS fetch, and IAPKit HTTP request runs
+    in `packages/apple`, which the traced Swift job does analyse. The one place
+    `iosMain` touches a secret forwards the API key and JWS straight into that
+    module without storing, logging, or reshaping them.
+  - `ci-kmp-iap.yml` runs `:library:iosSimulatorArm64Test`, which compiles
+    `iosMain` for a real Kotlin/Native target and runs the `iosTest` suite.
+    A Kotlin linter would not change this: Detekt and ktlint find style and
+    complexity issues, not the taint flows CodeQL is here for, so adding one
+    would grow the toolchain without closing the gap.
 - OpenIAP does not claim continuous fuzzing. Security-boundary changes require
   explicit negative regression tests, but the whole repository is not under a
   fuzzing service.
@@ -149,6 +168,46 @@ gates remain independent of that hosted view.
   has no npm provenance. Version 1.0.1 is the first provenance-verified release;
   tag, registry-integrity, reproducibility, and SBOM evidence for 1.0.0 do not
   retroactively create npm build provenance.
+
+## Release artifact verification
+
+What each lane proves about the bytes a consumer actually receives. The
+distinction that matters is whether a check runs against the _published_
+artifact or against a local copy that was never at risk.
+
+| Lane                                                             | Attested                                       | Post-publication check                                                     |
+| ---------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------- |
+| npm (`react-native`, `expo`, `conformance`, `commerce-protocol`) | npm provenance, bound to the published tarball | `scripts/verify-npm-release-provenance.mjs`                                |
+| GitHub Release (`godot`)                                         | `attest-build-provenance` over the ZIP         | downloads the served asset, compares SHA-256, runs `gh attestation verify` |
+| Maven Central (`google`, `kmp`)                                  | no                                             | none                                                                       |
+| pub.dev (`flutter`)                                              | no                                             | none                                                                       |
+| NuGet (`maui`)                                                   | no                                             | none                                                                       |
+| CocoaPods / SwiftPM (`apple`)                                    | no                                             | none                                                                       |
+| SBOM artifacts (all components)                                  | `attest-build-provenance` over the `.cdx.json` | `sbom.yml` re-verifies an existing SBOM before replacing it                |
+
+The `curl`-based HTTP status checks in the Maven, pub.dev, and NuGet lanes are
+**pre-publish** guards that stop a duplicate upload. They answer "does this
+coordinate already exist", not "are the published bytes the bytes CI built", and
+should not be read as post-publication verification.
+
+Closing the remaining rows means downloading each published artifact and
+comparing it to the build output. That is straightforward for Maven Central,
+which serves the uploaded file verbatim, and less so for registries that may
+re-archive on ingest. None of it is implemented yet, and an existence check must
+not be relabelled as verification in the meantime.
+
+### Release immutability
+
+GitHub's immutable releases would stop a published asset being replaced after
+the fact, which is the threat the digest and attestation checks above only
+_detect_. It is deliberately **not enabled**, for a mechanical reason: SBOMs are
+attached by `sbom.yml` after the release exists, so turning immutability on today
+would make every SBOM upload fail.
+
+Enabling it requires moving SBOM generation into each release job so the release
+is created complete. Until then the compensating controls are the attestation
+and post-publication digest check on the lanes that have them, and `sbom.yml`
+verifying an existing SBOM's attestation before it would replace one.
 
 ## Scanning posture
 

--- a/security/SBOM.md
+++ b/security/SBOM.md
@@ -21,22 +21,25 @@ hand, and none are committed to the repository.
 One SBOM per **releasable component**, not one per repository. A single
 monorepo-wide document would describe an artifact nobody installs.
 
-The component list is not maintained here. It is read from the release
-single-source-of-truth, `scripts/release-branch-policy.mjs`, so a component
+The releasable components are defined by `versionSources` in
+`scripts/release-branch-policy.mjs` and mirrored by `COMPONENTS` in
+`scripts/generate-sbom.mjs`. This table is a third copy for readers;
+`bun run audit:sbom-docs` fails when it drifts from either, so a component
 cannot be released without also being described:
 
-| Component      | SBOM name                | Distribution                     | Release tag                     |
-| -------------- | ------------------------ | -------------------------------- | ------------------------------- |
-| `apple`        | `openiap`                | CocoaPods, Swift Package Manager | `<version>`                     |
-| `google`       | `openiap-google`         | Maven Central                    | `google-<version>`              |
-| `react-native` | `react-native-iap`       | npm                              | `react-native-iap-<version>`    |
-| `expo`         | `expo-iap`               | npm                              | `expo-iap-<version>`            |
-| `conformance`  | `openiap-conformance`    | npm                              | `openiap-conformance-<version>` |
-| `flutter`      | `flutter_inapp_purchase` | pub.dev                          | `flutter-iap-<version>`         |
-| `kmp`          | `kmp-iap`                | Maven Central                    | `kmp-iap-<version>`             |
-| `maui`         | `OpenIap.Maui`           | NuGet                            | `maui-iap-<version>`            |
-| `godot`        | `godot-iap`              | GitHub Release                   | `godot-iap-<version>`           |
-| `docs`         | `openiap-spec`           | GitHub Release                   | `docs-<version>`                |
+| Component           | SBOM name                   | Distribution                     | Release tag                           |
+| ------------------- | --------------------------- | -------------------------------- | ------------------------------------- |
+| `apple`             | `openiap`                   | CocoaPods, Swift Package Manager | `<version>`                           |
+| `google`            | `openiap-google`            | Maven Central                    | `google-<version>`                    |
+| `react-native`      | `react-native-iap`          | npm                              | `react-native-iap-<version>`          |
+| `expo`              | `expo-iap`                  | npm                              | `expo-iap-<version>`                  |
+| `conformance`       | `openiap-conformance`       | npm                              | `openiap-conformance-<version>`       |
+| `flutter`           | `flutter_inapp_purchase`    | pub.dev                          | `flutter-iap-<version>`               |
+| `kmp`               | `kmp-iap`                   | Maven Central                    | `kmp-iap-<version>`                   |
+| `maui`              | `OpenIap.Maui`              | NuGet                            | `maui-iap-<version>`                  |
+| `godot`             | `godot-iap`                 | GitHub Release                   | `godot-iap-<version>`                 |
+| `docs`              | `openiap-spec`              | GitHub Release                   | `docs-<version>`                      |
+| `commerce-protocol` | `openiap-commerce-protocol` | npm                              | `openiap-commerce-protocol-<version>` |
 
 `packages/kit` (IAPKit) is deliberately outside this list. It is a deployed
 service rather than a distributed package: consumers call it over HTTPS and
@@ -77,12 +80,12 @@ consumer-visible descriptor over HTTPS as a required inventory input. With
 `--with-licenses`, the generator also performs best-effort license and supplier
 enrichment:
 
-| Registry                                          | Required inventory input      | Best-effort enrichment       |
-| ------------------------------------------------- | ----------------------------- | ---------------------------- |
-| [Maven Central](https://repo1.maven.org/maven2/)  | Maven coordinate POMs         | License and organization     |
-| [Google Maven](https://maven.google.com/)         | Android/Google Maven POMs     | License and organization     |
-| [nuget.org](https://www.nuget.org/)               | NuGet `.nuspec` dependencies | License and authors          |
-| [registry.npmjs.org](https://registry.npmjs.org/) | —                             | npm license and author data  |
+| Registry                                          | Required inventory input     | Best-effort enrichment      |
+| ------------------------------------------------- | ---------------------------- | --------------------------- |
+| [Maven Central](https://repo1.maven.org/maven2/)  | Maven coordinate POMs        | License and organization    |
+| [Google Maven](https://maven.google.com/)         | Android/Google Maven POMs    | License and organization    |
+| [nuget.org](https://www.nuget.org/)               | NuGet `.nuspec` dependencies | License and authors         |
+| [registry.npmjs.org](https://registry.npmjs.org/) | —                            | npm license and author data |
 
 Failure to read a required POM or nuspec blocks generation because the
 dependency inventory would be incomplete. A metadata-enrichment failure

--- a/security/SBOM.md
+++ b/security/SBOM.md
@@ -47,6 +47,26 @@ never install its dependency tree. Its source dependency graph is covered by
 the repository gates, and its current source image is scanned before deployment
 and by the weekly security workflow — see [README.md](README.md).
 
+## Licence notices
+
+The SBOM records an SPDX identifier per component. For components whose licence
+requires the notice to be redistributed with the binary — MIT, ISC, and the
+Apache and BSD families — the verbatim upstream licence text is committed
+alongside the binary and referenced from the component's `licenseFile`.
+
+`scripts/generate-third-party-notices.mjs` renders those into a
+`THIRD_PARTY_NOTICES.md` shipped inside the release artifact, and prints a
+licence inventory with `--inventory`. It refuses to render when a component
+declares such a licence with no committed text, so the failure mode is a failed
+release rather than a notice with an empty section. Nothing composes or infers
+licence text.
+
+Today this applies to `godot`, the only component that redistributes a
+third-party binary: the addon ZIP embeds `SwiftGodotRuntime` (MIT) and ships its
+notice plus the addon's own `LICENSE`. Registry-distributed components carry
+their dependencies by coordinate rather than by embedding them, so the consuming
+package manager resolves those licences.
+
 ## Standards
 
 | Concern            | Standard                                                                                                                                                   |


### PR DESCRIPTION
Four Horizon examples could not connect to the store. Fixing that surfaced defects in the guard written to prevent it, and a supply-chain audit found that the evidence published around the `godot-iap` release did not describe the artifact it was published for.

## What was broken

| Area | Defect | Why it survived |
| --- | --- | --- |
| **Horizon** | `kmp-iap`, `maui-iap`, `flutter`, `packages/google` resolved an empty `HORIZON_APP_ID`, so `startConnection` threw | Compiles and installs; fails only on a headset |
| | `packages/google/local.properties.example` documented `horizon.app.id`, which no Gradle file reads | `CONTRIBUTING.md` used the real key, so the two contradicted each other |
| **godot release** | The attested SBOM records no hash for the ZIP it describes, and nothing attested the ZIP | A replaced asset verified clean |
| | The ZIP ships two MIT binaries with no licence text | MIT requires the notice in every redistribution |
| | The native frameworks are committed, not built by CI, and nothing recorded their bytes | `validate-ios` only checked the directories exist |
| **audits** | Three audits read a vendored copy of this repo (`SourcePackages`) as project source | 58 false positives, reachable by following `e2e-tests.md` |
| | `security/SBOM.md` omitted `commerce-protocol` while claiming the table was generated | Nothing checked it |
| | `bun audit` had no retry, so a registry timeout failed CI | The same workflow already retries `bun install` |
| **kmp-iap** | `run-ios.sh` called a Gradle task that does not exist | Failed on its first line for every user |

## Verification

Physical Quest 3 — every example now completes the chain:

```text
HzServiceConnection: Horizon Platform connection success!
Iap: launchCheckoutFlow  statusCode=0  sku=dev.hyo.martie.10bulbs
Iap: consumePurchase     statusCode=0  {"success":true}
```

Device regression passed on 6 frameworks across Play, Fire OS, Horizon, iOS and Vega.

## What guards it now

The Horizon check is split, because the two halves are provable in different places:

| | Proves | Runs |
| --- | --- | --- |
| `audit-horizon-app-id` | the meta-data is **declared** under `<application>`, literal or placeholder | every PR |
| `verify-horizon-merged-manifest` | the value the merger **resolved** is a real app id | on a built variant |

The second reads the manifest merger's output rather than the build file's text. Proven against a real Gradle run: reverting the fix merges `""` and it fails.

Also added: a Mach-O digest manifest for the four committed `godot` frameworks; a `THIRD_PARTY_NOTICES` generator that renders verbatim upstream licence text and refuses to render when a declared licence has no committed text; an `audit:sbom-docs` tying `security/SBOM.md` to `versionSources` and the SBOM generator; ZIP attestation plus a post-publication digest check on the godot release; and a transport-only retry for `bun audit` that still fails immediately on a real advisory.

Every guard is mutation-proved — reverting the defect fails a specific test.

## Deliberately not done

- **A container SBOM for IAPKit** — it deploys through a Fly.io remote builder, so a CI-generated SBOM would not describe the deployed image.
- **Immutable releases** — `sbom.yml` attaches SBOMs after the release exists, so enabling it today would fail every SBOM upload. Documented with the prerequisite.
- **Post-publication byte verification for Maven, pub.dev and NuGet** — needs a live publish to validate against. Their `curl` status checks are pre-publish duplicate guards and are now labelled as such.
- **A merger check for the Flutter example** — that workflow builds no Android variant. Recorded in `security/README.md`; closing it means adding an Android job, not reading Gradle source.
- **The `OpenIAP compliant` claim in `react-native-iap`** — flagged during the audit, but the package passes 24 behavioral conformance cases, so the claim holds.

## Reviews

CodeRabbit (7 threads), CodeQL, and four rounds of Grok. Grok found a live bug in the Flutter example and an audit that inspected only the first of two resolutions, then judged the Gradle text checks to pass "by matching the house style, not the rule" — which is why that logic was **removed** rather than patched again, and replaced with the merged-manifest check.

## Checks

`node --test scripts/*.test.mjs` 364 passed · `audit:parity`, `audit:docs`, `audit:sbom-docs`, `audit:godot-binaries`, `audit:horizon-app-id`, `audit:layout`, `audit:facts`, `audit:overrides`, `audit:deprecations`, `audit:release-state` · `sbom:test` 45 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
