### PR TITLE
fix: correct the documented tree and what the project says it is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,8 @@ openiap/
 │   ├── kit/           # Purchase validation + entitlement infrastructure (Fly.io app)
 │   └── mcp-server/    # IAPKit MCP server (hosted at kit.openiap.dev/mcp)
 ├── specs/             # Publishable specifications; never deployed services
-│   └── openiap/
-│       ├── client/             # Client GraphQL contract + multiplatform code generation
-│       └── commerce-protocol/  # Vendor-neutral server-side commerce contract
+│   ├── client/             # Client GraphQL contract + multiplatform code generation
+│   └── commerce-protocol/  # Vendor-neutral server-side commerce contract
 ├── plugins/
 │   └── openiap/       # Codex + Claude Code plugin (skills + MCP config)
 ├── libraries/         # Framework SDK implementations

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -1,9 +1,9 @@
 # OpenIAP Complete Reference
 
-> OpenIAP: Unified in-app purchase specification for iOS & Android
+> OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-09-02T01:55:36.595Z
+> Generated: 2026-09-05T04:10:09.550Z
 
 ## Table of Contents
 1. Installation

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -1,9 +1,9 @@
 # OpenIAP Quick Reference
 
-> OpenIAP: Unified in-app purchase specification for iOS & Android
+> OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-09-02T01:55:36.595Z
+> Generated: 2026-09-05T04:10:09.550Z
 
 ## Installation
 

--- a/scripts/agent/compile-context.ts
+++ b/scripts/agent/compile-context.ts
@@ -265,7 +265,7 @@ async function generateLlmsTxt(): Promise<{ quick: number; full: number }> {
   // Combine all external docs for llms-full.txt
   let fullContent = `# OpenIAP Complete Reference
 
-> OpenIAP: Unified in-app purchase specification for iOS & Android
+> OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
 > Generated: ${generatedAt}
@@ -679,7 +679,7 @@ async Task FinishPurchaseSafelyAsync(Purchase purchase)
   // Generate llms.txt (quick reference - condensed version)
   let quickContent = `# OpenIAP Quick Reference
 
-> OpenIAP: Unified in-app purchase specification for iOS & Android
+> OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
 > Generated: ${generatedAt}

--- a/scripts/audit-repo-layout.mjs
+++ b/scripts/audit-repo-layout.mjs
@@ -100,12 +100,14 @@ export function findDuplicateRootPaths(root = repositoryRoot) {
  * is resolved against its parent rather than read as a top-level name.
  */
 export function findDocumentedTreePaths(markdown) {
-  const block = markdown.match(/```text\n([\s\S]*?)```/u);
-  if (!block) return [];
+  // CRLF counts: a checkout with Windows line endings would otherwise match
+  // nothing and the audit would pass having checked nothing at all.
+  const block = markdown.match(/```text\r?\n([\s\S]*?)```/u);
+  if (!block) return null;
 
   const paths = [];
   const parents = [];
-  for (const line of block[1].split("\n")) {
+  for (const line of block[1].split(/\r?\n/u)) {
     const branch = line.match(/^([\s│]*)(?:├──|└──)\s+(\S+)/u);
     if (!branch) continue;
     const depth = Math.floor(branch[1].length / 4);
@@ -125,13 +127,20 @@ export function auditRepositoryLayout(root = repositoryRoot) {
 
   const agentsPath = path.join(root, "AGENTS.md");
   if (fs.existsSync(agentsPath)) {
-    for (const documented of findDocumentedTreePaths(
+    const documented = findDocumentedTreePaths(
       fs.readFileSync(agentsPath, "utf8"),
-    )) {
-      if (!fs.existsSync(path.join(root, documented))) {
-        violations.push(
-          `AGENTS.md documents ${documented}/, which does not exist`,
-        );
+    );
+    if (documented === null) {
+      // Returning an empty list here would pass silently, which is the one
+      // outcome this check must never have.
+      violations.push("AGENTS.md has no readable structure diagram");
+    } else {
+      for (const entry of documented) {
+        if (!fs.existsSync(path.join(root, entry))) {
+          violations.push(
+            `AGENTS.md documents ${entry}/, which does not exist`,
+          );
+        }
       }
     }
   }

--- a/scripts/audit-repo-layout.mjs
+++ b/scripts/audit-repo-layout.mjs
@@ -87,11 +87,54 @@ export function findDuplicateRootPaths(root = repositoryRoot) {
     .sort((left, right) => left.canonical.localeCompare(right.canonical));
 }
 
+/**
+ * Paths the structure diagram in AGENTS.md claims exist.
+ *
+ * That diagram is the map every agent reads before touching anything, and it
+ * drifted: it showed `specs/openiap/client` long after the umbrella directory
+ * was removed — a layout this very audit rejects on disk. Enforcing the
+ * filesystem while leaving the documented tree unchecked meant the rule and
+ * the map could disagree indefinitely.
+ *
+ * Depth comes from the indent before the branch character, so a nested entry
+ * is resolved against its parent rather than read as a top-level name.
+ */
+export function findDocumentedTreePaths(markdown) {
+  const block = markdown.match(/```text\n([\s\S]*?)```/u);
+  if (!block) return [];
+
+  const paths = [];
+  const parents = [];
+  for (const line of block[1].split("\n")) {
+    const branch = line.match(/^([\s│]*)(?:├──|└──)\s+(\S+)/u);
+    if (!branch) continue;
+    const depth = Math.floor(branch[1].length / 4);
+    const name = branch[2].replace(/\/$/u, "");
+    parents.length = depth;
+    parents[depth] = name;
+    paths.push(parents.slice(0, depth + 1).join("/"));
+  }
+  return paths;
+}
+
 export function auditRepositoryLayout(root = repositoryRoot) {
   const violations = findDuplicateRootPaths(root).map(
     ({ duplicate, canonical }) =>
       `remove duplicate root ${duplicate}/; use ${canonical}/ instead`,
   );
+
+  const agentsPath = path.join(root, "AGENTS.md");
+  if (fs.existsSync(agentsPath)) {
+    for (const documented of findDocumentedTreePaths(
+      fs.readFileSync(agentsPath, "utf8"),
+    )) {
+      if (!fs.existsSync(path.join(root, documented))) {
+        violations.push(
+          `AGENTS.md documents ${documented}/, which does not exist`,
+        );
+      }
+    }
+  }
 
   const legacyGqlPath = path.join(root, "packages", "gql");
   if (fs.existsSync(legacyGqlPath)) {

--- a/scripts/audit-repo-layout.test.mjs
+++ b/scripts/audit-repo-layout.test.mjs
@@ -264,7 +264,18 @@ test("the structure diagram in AGENTS.md must match the tree", () => {
     ["specs", "specs/client", "scripts"],
   );
 
-  assert.deepEqual(findDocumentedTreePaths("no code block here"), []);
+  // CRLF is the same diagram. Matching only LF returned nothing, and the audit
+  // then passed having read nothing.
+  assert.deepEqual(
+    findDocumentedTreePaths(
+      tree(["├── specs/", "│   └── client/"]).replace(/\n/gu, "\r\n"),
+    ).slice(-2),
+    ["specs", "specs/client"],
+  );
+
+  // No diagram is null, not an empty list: the caller has to tell "nothing
+  // documented" apart from "nothing readable".
+  assert.equal(findDocumentedTreePaths("no code block here"), null);
 });
 
 test("a documented directory that does not exist is a violation", () => {
@@ -281,6 +292,17 @@ test("a documented directory that does not exist is a violation", () => {
     assert.deepEqual(auditRepositoryLayout(root), [
       "AGENTS.md documents specs/, which does not exist",
       "AGENTS.md documents specs/openiap/, which does not exist",
+    ]);
+  });
+});
+
+test("an unreadable structure diagram is a violation, not a pass", () => {
+  withTemporaryRepository((root) => {
+    // The failure mode this guards: a diagram the parser cannot read makes the
+    // check vacuous, and a vacuous check reads exactly like a clean one.
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "# no diagram here\n");
+    assert.deepEqual(auditRepositoryLayout(root), [
+      "AGENTS.md has no readable structure diagram",
     ]);
   });
 });

--- a/scripts/audit-repo-layout.test.mjs
+++ b/scripts/audit-repo-layout.test.mjs
@@ -5,7 +5,10 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { auditRepositoryLayout } from "./audit-repo-layout.mjs";
+import {
+  auditRepositoryLayout,
+  findDocumentedTreePaths,
+} from "./audit-repo-layout.mjs";
 
 function withTemporaryRepository(run) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "openiap-layout-"));
@@ -215,4 +218,69 @@ test("keeps lockfile workspace names aligned with package manifests", () => {
     );
     assert.equal(entry.name, manifest.name, workspacePath || "<root>");
   }
+});
+
+test("the structure diagram in AGENTS.md must match the tree", () => {
+  const tree = (specs) =>
+    [
+      "```text",
+      "openiap/",
+      "├── packages/",
+      "│   ├── docs/          # Documentation site",
+      "│   └── kit/           # Purchase validation",
+      ...specs,
+      "```",
+      "",
+    ].join("\n");
+
+  // Depth has to come from the indent: `client/` nested under `openiap/` is
+  // `specs/openiap/client`, not `specs/client`. Reading the leaf name alone
+  // made every nested entry look like a top-level directory.
+  assert.deepEqual(
+    findDocumentedTreePaths(
+      tree([
+        "├── specs/",
+        "│   └── openiap/",
+        "│       ├── client/",
+        "│       └── commerce-protocol/",
+      ]),
+    ),
+    [
+      "packages",
+      "packages/docs",
+      "packages/kit",
+      "specs",
+      "specs/openiap",
+      "specs/openiap/client",
+      "specs/openiap/commerce-protocol",
+    ],
+  );
+
+  // A sibling after a deeper branch returns to its own depth.
+  assert.deepEqual(
+    findDocumentedTreePaths(
+      tree(["├── specs/", "│   └── client/", "└── scripts/"]),
+    ).slice(-3),
+    ["specs", "specs/client", "scripts"],
+  );
+
+  assert.deepEqual(findDocumentedTreePaths("no code block here"), []);
+});
+
+test("a documented directory that does not exist is a violation", () => {
+  withTemporaryRepository((root) => {
+    // The real drift: AGENTS.md kept documenting specs/openiap/client long
+    // after the umbrella directory was removed — a layout this same audit
+    // rejects on disk, so the rule and the map disagreed.
+    fs.writeFileSync(
+      path.join(root, "AGENTS.md"),
+      ["```text", "openiap/", "├── specs/", "│   └── openiap/", "```", ""].join(
+        "\n",
+      ),
+    );
+    assert.deepEqual(auditRepositoryLayout(root), [
+      "AGENTS.md documents specs/, which does not exist",
+      "AGENTS.md documents specs/openiap/, which does not exist",
+    ]);
+  });
 });


### PR DESCRIPTION
Two things every reader meets first were out of date.

## The structure diagram was wrong

AGENTS.md showed `specs/openiap/client` and `specs/openiap/commerce-protocol`. That umbrella directory no longer exists — specifications sit directly under `specs/`.

`audit-repo-layout.mjs` already rejects `specs/openiap/` **on disk**:

```
remove legacy specs/openiap/; specifications sit directly under specs/
```

So the rule and the map disagreed, and the map is what an agent reads before touching anything. The audit now reads the diagram too, reconstructing each path from its indent so a nested entry resolves against its parent:

```
AGENTS.md documents specs/openiap/, which does not exist
AGENTS.md documents specs/openiap/client/, which does not exist
AGENTS.md documents specs/openiap/commerce-protocol/, which does not exist
```

## The project undersold itself to AI readers

`llms.txt` opened with:

> OpenIAP: Unified in-app purchase specification for iOS & Android

That is the first line an AI reads about this project. It omits Meta Horizon and Amazon — both stores the client API supports, and both sponsors — and the entire server-side commerce protocol. Now:

> OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events

Fixed at its source in `compile-context.ts` (both call sites), which generates `llms.txt` and `llms-full.txt`.

## Checks

435 tests pass; `audit:layout`, `audit:agents`, `audit:ci-paths`, `audit:parity`, `audit:docs` clean. Two mutations proved: ignoring indent depth, and skipping the diagram entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated OpenIAP documentation to clarify its vendor-neutral scope across Apple, Google, Meta Horizon, and Amazon.
  - Expanded descriptions to include the server-side commerce protocol for verification, entitlements, and store events.
  - Refreshed generated documentation timestamps and reorganized the documented repository structure.

- **Chores**
  - Improved repository layout checks to detect discrepancies between documented paths and the actual project structure.
  - Added coverage for repository documentation and layout validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->