### PR TITLE
docs(commerce-protocol): draw the four things the prose cannot show

### DIFF
--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-09-05T07:06:39.280Z
+> Last updated: 2026-09-05T07:09:17.460Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -5866,7 +5866,8 @@ project-wide event feed and its signing secret must never reach a distributed
 app. An application that needs device push gets it from its own authenticated
 backend, downstream of this contract.
 
-One delivery, end to end. §9.4.1–9.4.4 below state each step normatively:
+The following sequence summarizes one delivery under §9.4.1–9.4.4, which state
+each step normatively:
 
 ```mermaid
 sequenceDiagram
@@ -6413,7 +6414,8 @@ deployment for a managed one, a managed one for their own — and their downstre
 integrations SHOULD survive it. What follows is what actually carries across, and
 what does not.
 
-What a swap looks like from the consumer's side:
+The following shows what a swap carries across and what it does not, from the
+consumer's side:
 
 ```mermaid
 flowchart LR
@@ -6431,7 +6433,7 @@ flowchart LR
   end
   subgraph breaks ["Does not carry across"]
     n1["eventId and projectId — emitter-assigned, a new id space"]
-    n2["eventId deduplication history — a cutover overlap is processed twice"]
+    n2["a consumer deduplicating only on eventId processes a cutover overlap twice"]
     n3["sourceStoreEventId is not a repair — siblings legitimately share one"]
   end
 ```

--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-09-05T07:09:17.460Z
+> Last updated: 2026-09-05T07:14:38.380Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -5878,15 +5878,15 @@ sequenceDiagram
   Note over Emitter,Consumer: Delivery is duplicate-capable and unordered, with no exactly-once guarantee (§9.4.4). This is one attempt.
 
   Store->>Emitter: store-native notification
-  Emitter->>Emitter: normalize (§9.2); derive the lifecycle and entitlement events (§9.1)
+  Emitter->>Emitter: normalize (§9.2), then derive the lifecycle and entitlement events (§9.1)
   Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
-  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received; HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim; accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header; be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
+  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received, then HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim — accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header — be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
     Consumer-->>Emitter: 2xx
     Note over Emitter: delivered
   else 408, 429, 5xx — or no response (timeout, connection error)
     Consumer-->>Emitter: 408 / 429 / 5xx, or nothing
-    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id; eventually stop and dead-letter
+    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id — eventually stop and dead-letter
   else 3xx, or any other 4xx
     Consumer-->>Emitter: 3xx / other 4xx
     Note over Emitter: permanent failure — a redirect is not followed, nothing is retried

--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-09-05T06:55:13.780Z
+> Last updated: 2026-09-05T07:06:39.280Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -5693,33 +5693,30 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
-The state each of those events lands in, and the ones that move no state at
-all:
+The state each lifecycle event names, as the GraphQL contract enforces it. The
+specification says where an event lands, not where it came from:
 
 ```mermaid
-stateDiagram-v2
-  direction LR
-  state "any prior state" as Prior
-
-  Prior --> Active: started / renewed / recovered / resumed
-  Prior --> InGracePeriod: entered_grace_period
-  Prior --> InBillingRetry: entered_billing_retry
-  Prior --> Paused: paused
-  Prior --> Expired: expired
-  Prior --> Revoked: revoked
-  Prior --> Refunded: refunded
-
-  note right of Active
-    canceled, uncanceled, product_changed, price_changed
-    and deferred move no state. canceled flips willRenew
-    only; access continues until expiresAt.
-  end note
-
-  note left of InBillingRetry
-    Entitled: Active and InGracePeriod, while now is
-    before expiresAt. Every other state: not entitled.
-    Read subscription.active. Never re-derive it from state.
-  end note
+flowchart LR
+  subgraph lands ["names a state — the snapshot MUST agree"]
+    direction LR
+    e1["started<br/>renewed<br/>recovered<br/>resumed"] --> Active
+    e2["entered_grace_period"] --> InGracePeriod
+    e3["entered_billing_retry"] --> InBillingRetry
+    e4["paused"] --> Paused
+    e5["expired"] --> Expired
+    e6["revoked"] --> Revoked
+    e7["refunded"] --> Refunded
+  end
+  subgraph none ["names no state — the snapshot keeps the state that actually followed the store transition"]
+    direction LR
+    e8["canceled · uncanceled<br/>product_changed · price_changed · deferred"]
+  end
+  subgraph predicate ["entitled? (§2.3) — read subscription.active; a consumer MUST NOT recompute it from state and ignore active"]
+    direction LR
+    p1["Active, InGracePeriod: yes while now is before expiresAt; with no expiresAt, yes.<br/>For InGracePeriod, expiresAt is the end of the grace window."]
+    p2["InBillingRetry, Paused, Expired, Revoked, Refunded, Unknown: no"]
+  end
 ```
 
 ### Entitlement delta
@@ -5877,16 +5874,21 @@ sequenceDiagram
   participant Emitter as Backend (emitter)
   participant Consumer as Consumer endpoint
 
+  Note over Emitter,Consumer: Delivery is duplicate-capable and unordered, with no exactly-once guarantee (§9.4.4). This is one attempt.
+
   Store->>Emitter: store-native notification
-  Emitter->>Emitter: normalize (§9.2), derive lifecycle and entitlement events (§9.1)
-  Emitter->>Consumer: POST one event as raw UTF-8 JSON<br/>openiap-signature: v1=hex (several, comma-separated, during rotation)<br/>openiap-timestamp: Unix seconds<br/>openiap-event-id, openiap-delivery-id
-  Note over Consumer: reject if abs(now − timestamp) > 300 s<br/>signed = timestamp + "." + the exact body bytes received<br/>HMAC-SHA256 with the shared secret, constant-time compare,<br/>any presented v1= against any currently valid secret<br/>take eventId from the body, deduplicate on it, ack before slow work
+  Emitter->>Emitter: normalize (§9.2); derive the lifecycle and entitlement events (§9.1)
+  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
+  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received; HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim; accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header; be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
-    Consumer-->>Emitter: delivered
-  else 408, 429, 5xx, timeout, connection error
-    Consumer-->>Emitter: retry with exponential backoff — same body and eventId,<br/>fresh timestamp, recomputed signature, same delivery-id — then dead-letter
+    Consumer-->>Emitter: 2xx
+    Note over Emitter: delivered
+  else 408, 429, 5xx — or no response (timeout, connection error)
+    Consumer-->>Emitter: 408 / 429 / 5xx, or nothing
+    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id; eventually stop and dead-letter
   else 3xx, or any other 4xx
-    Consumer-->>Emitter: permanent failure — no redirect is followed, nothing is retried
+    Consumer-->>Emitter: 3xx / other 4xx
+    Note over Emitter: permanent failure — a redirect is not followed, nothing is retried
   end
 ```
 

--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-09-04T13:33:15.491Z
+> Last updated: 2026-09-05T06:55:13.780Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -5693,6 +5693,35 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
+The state each of those events lands in, and the ones that move no state at
+all:
+
+```mermaid
+stateDiagram-v2
+  direction LR
+  state "any prior state" as Prior
+
+  Prior --> Active: started / renewed / recovered / resumed
+  Prior --> InGracePeriod: entered_grace_period
+  Prior --> InBillingRetry: entered_billing_retry
+  Prior --> Paused: paused
+  Prior --> Expired: expired
+  Prior --> Revoked: revoked
+  Prior --> Refunded: refunded
+
+  note right of Active
+    canceled, uncanceled, product_changed, price_changed
+    and deferred move no state. canceled flips willRenew
+    only; access continues until expiresAt.
+  end note
+
+  note left of InBillingRetry
+    Entitled: Active and InGracePeriod, while now is
+    before expiresAt. Every other state: not entitled.
+    Read subscription.active. Never re-derive it from state.
+  end note
+```
+
 ### Entitlement delta
 
 | Event                 | Meaning                 |
@@ -5839,6 +5868,27 @@ endpoint, WebSocket, push relay, or long-poll feed for shipped applications: a
 project-wide event feed and its signing secret must never reach a distributed
 app. An application that needs device push gets it from its own authenticated
 backend, downstream of this contract.
+
+One delivery, end to end. §9.4.1–9.4.4 below state each step normatively:
+
+```mermaid
+sequenceDiagram
+  participant Store
+  participant Emitter as Backend (emitter)
+  participant Consumer as Consumer endpoint
+
+  Store->>Emitter: store-native notification
+  Emitter->>Emitter: normalize (§9.2), derive lifecycle and entitlement events (§9.1)
+  Emitter->>Consumer: POST one event as raw UTF-8 JSON<br/>openiap-signature: v1=hex (several, comma-separated, during rotation)<br/>openiap-timestamp: Unix seconds<br/>openiap-event-id, openiap-delivery-id
+  Note over Consumer: reject if abs(now − timestamp) > 300 s<br/>signed = timestamp + "." + the exact body bytes received<br/>HMAC-SHA256 with the shared secret, constant-time compare,<br/>any presented v1= against any currently valid secret<br/>take eventId from the body, deduplicate on it, ack before slow work
+  alt 2xx
+    Consumer-->>Emitter: delivered
+  else 408, 429, 5xx, timeout, connection error
+    Consumer-->>Emitter: retry with exponential backoff — same body and eventId,<br/>fresh timestamp, recomputed signature, same delivery-id — then dead-letter
+  else 3xx, or any other 4xx
+    Consumer-->>Emitter: permanent failure — no redirect is followed, nothing is retried
+  end
+```
 
 #### 9.4.1 Request
 
@@ -6360,6 +6410,29 @@ An adopter may replace the backend behind this contract — a self-hosted
 deployment for a managed one, a managed one for their own — and their downstream
 integrations SHOULD survive it. What follows is what actually carries across, and
 what does not.
+
+What a swap looks like from the consumer's side:
+
+```mermaid
+flowchart LR
+  consumer["A consumer written against this specification<br/>— unchanged by the swap"]
+  A["Backend A<br/>before"]
+  B["Backend B<br/>after"]
+  A -- "events (§9)" --> consumer
+  B -- "events (§9)" --> consumer
+
+  subgraph carries ["Carries across"]
+    c1["event types · envelope shape · entitlement predicate"]
+    c2["signature scheme · per-store semantics"]
+    c3["sourceStoreEventId — the store's own notification id"]
+    c4["userId, when the adopter assigns it"]
+  end
+  subgraph breaks ["Does not carry across"]
+    n1["eventId and projectId — emitter-assigned, a new id space"]
+    n2["eventId deduplication history — a cutover overlap is processed twice"]
+    n3["sourceStoreEventId is not a repair — siblings legitimately share one"]
+  end
+```
 
 **Carries across.** Event types, envelope shape, the entitlement predicate,
 signature scheme, and per-store semantics are all defined here, not by a backend.

--- a/knowledge/_agent-context/context.md
+++ b/knowledge/_agent-context/context.md
@@ -1,7 +1,7 @@
 # OpenIAP Project Context
 
 > **Auto-generated shared context for AI assistants**
-> Last updated: 2026-09-05T07:14:38.380Z
+> Last updated: 2026-09-05T07:23:55.615Z
 >
 > Canonical file: `knowledge/_agent-context/context.md`
 
@@ -5693,12 +5693,12 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
-The state each lifecycle event names, as the GraphQL contract enforces it. The
-specification says where an event lands, not where it came from:
+The following maps each lifecycle event to the snapshot state it names, as the
+GraphQL contract enforces it:
 
 ```mermaid
 flowchart LR
-  subgraph lands ["names a state — the snapshot MUST agree"]
+  subgraph lands ["names a state — when a snapshot is present, its state MUST agree"]
     direction LR
     e1["started<br/>renewed<br/>recovered<br/>resumed"] --> Active
     e2["entered_grace_period"] --> InGracePeriod
@@ -5708,7 +5708,7 @@ flowchart LR
     e6["revoked"] --> Revoked
     e7["refunded"] --> Refunded
   end
-  subgraph none ["names no state — the snapshot keeps the state that actually followed the store transition"]
+  subgraph none ["names no state — the contract pairs no state with these, so a snapshot keeps the state that actually followed the store transition"]
     direction LR
     e8["canceled · uncanceled<br/>product_changed · price_changed · deferred"]
   end
@@ -5879,7 +5879,7 @@ sequenceDiagram
 
   Store->>Emitter: store-native notification
   Emitter->>Emitter: normalize (§9.2), then derive the lifecycle and entitlement events (§9.1)
-  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
+  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, Content-Encoding absent or identity<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
   Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received, then HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim — accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header — be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
     Consumer-->>Emitter: 2xx

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-09-05T04:10:09.550Z
+> Generated: 2026-09-05T06:55:13.788Z
 
 ## Table of Contents
 1. Installation
@@ -2683,6 +2683,35 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
+The state each of those events lands in, and the ones that move no state at
+all:
+
+```mermaid
+stateDiagram-v2
+  direction LR
+  state "any prior state" as Prior
+
+  Prior --> Active: started / renewed / recovered / resumed
+  Prior --> InGracePeriod: entered_grace_period
+  Prior --> InBillingRetry: entered_billing_retry
+  Prior --> Paused: paused
+  Prior --> Expired: expired
+  Prior --> Revoked: revoked
+  Prior --> Refunded: refunded
+
+  note right of Active
+    canceled, uncanceled, product_changed, price_changed
+    and deferred move no state. canceled flips willRenew
+    only; access continues until expiresAt.
+  end note
+
+  note left of InBillingRetry
+    Entitled: Active and InGracePeriod, while now is
+    before expiresAt. Every other state: not entitled.
+    Read subscription.active. Never re-derive it from state.
+  end note
+```
+
 ### Entitlement delta
 
 | Event                 | Meaning                 |
@@ -2829,6 +2858,27 @@ endpoint, WebSocket, push relay, or long-poll feed for shipped applications: a
 project-wide event feed and its signing secret must never reach a distributed
 app. An application that needs device push gets it from its own authenticated
 backend, downstream of this contract.
+
+One delivery, end to end. §9.4.1–9.4.4 below state each step normatively:
+
+```mermaid
+sequenceDiagram
+  participant Store
+  participant Emitter as Backend (emitter)
+  participant Consumer as Consumer endpoint
+
+  Store->>Emitter: store-native notification
+  Emitter->>Emitter: normalize (§9.2), derive lifecycle and entitlement events (§9.1)
+  Emitter->>Consumer: POST one event as raw UTF-8 JSON<br/>openiap-signature: v1=hex (several, comma-separated, during rotation)<br/>openiap-timestamp: Unix seconds<br/>openiap-event-id, openiap-delivery-id
+  Note over Consumer: reject if abs(now − timestamp) > 300 s<br/>signed = timestamp + "." + the exact body bytes received<br/>HMAC-SHA256 with the shared secret, constant-time compare,<br/>any presented v1= against any currently valid secret<br/>take eventId from the body, deduplicate on it, ack before slow work
+  alt 2xx
+    Consumer-->>Emitter: delivered
+  else 408, 429, 5xx, timeout, connection error
+    Consumer-->>Emitter: retry with exponential backoff — same body and eventId,<br/>fresh timestamp, recomputed signature, same delivery-id — then dead-letter
+  else 3xx, or any other 4xx
+    Consumer-->>Emitter: permanent failure — no redirect is followed, nothing is retried
+  end
+```
 
 #### 9.4.1 Request
 
@@ -3350,6 +3400,29 @@ An adopter may replace the backend behind this contract — a self-hosted
 deployment for a managed one, a managed one for their own — and their downstream
 integrations SHOULD survive it. What follows is what actually carries across, and
 what does not.
+
+What a swap looks like from the consumer's side:
+
+```mermaid
+flowchart LR
+  consumer["A consumer written against this specification<br/>— unchanged by the swap"]
+  A["Backend A<br/>before"]
+  B["Backend B<br/>after"]
+  A -- "events (§9)" --> consumer
+  B -- "events (§9)" --> consumer
+
+  subgraph carries ["Carries across"]
+    c1["event types · envelope shape · entitlement predicate"]
+    c2["signature scheme · per-store semantics"]
+    c3["sourceStoreEventId — the store's own notification id"]
+    c4["userId, when the adopter assigns it"]
+  end
+  subgraph breaks ["Does not carry across"]
+    n1["eventId and projectId — emitter-assigned, a new id space"]
+    n2["eventId deduplication history — a cutover overlap is processed twice"]
+    n3["sourceStoreEventId is not a repair — siblings legitimately share one"]
+  end
+```
 
 **Carries across.** Event types, envelope shape, the entitlement predicate,
 signature scheme, and per-store semantics are all defined here, not by a backend.

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-09-05T07:14:38.387Z
+> Generated: 2026-09-05T07:23:55.623Z
 
 ## Table of Contents
 1. Installation
@@ -2683,12 +2683,12 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
-The state each lifecycle event names, as the GraphQL contract enforces it. The
-specification says where an event lands, not where it came from:
+The following maps each lifecycle event to the snapshot state it names, as the
+GraphQL contract enforces it:
 
 ```mermaid
 flowchart LR
-  subgraph lands ["names a state — the snapshot MUST agree"]
+  subgraph lands ["names a state — when a snapshot is present, its state MUST agree"]
     direction LR
     e1["started<br/>renewed<br/>recovered<br/>resumed"] --> Active
     e2["entered_grace_period"] --> InGracePeriod
@@ -2698,7 +2698,7 @@ flowchart LR
     e6["revoked"] --> Revoked
     e7["refunded"] --> Refunded
   end
-  subgraph none ["names no state — the snapshot keeps the state that actually followed the store transition"]
+  subgraph none ["names no state — the contract pairs no state with these, so a snapshot keeps the state that actually followed the store transition"]
     direction LR
     e8["canceled · uncanceled<br/>product_changed · price_changed · deferred"]
   end
@@ -2869,7 +2869,7 @@ sequenceDiagram
 
   Store->>Emitter: store-native notification
   Emitter->>Emitter: normalize (§9.2), then derive the lifecycle and entitlement events (§9.1)
-  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
+  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, Content-Encoding absent or identity<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
   Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received, then HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim — accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header — be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
     Consumer-->>Emitter: 2xx

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-09-05T07:06:39.288Z
+> Generated: 2026-09-05T07:09:17.467Z
 
 ## Table of Contents
 1. Installation
@@ -2856,7 +2856,8 @@ project-wide event feed and its signing secret must never reach a distributed
 app. An application that needs device push gets it from its own authenticated
 backend, downstream of this contract.
 
-One delivery, end to end. §9.4.1–9.4.4 below state each step normatively:
+The following sequence summarizes one delivery under §9.4.1–9.4.4, which state
+each step normatively:
 
 ```mermaid
 sequenceDiagram
@@ -3403,7 +3404,8 @@ deployment for a managed one, a managed one for their own — and their downstre
 integrations SHOULD survive it. What follows is what actually carries across, and
 what does not.
 
-What a swap looks like from the consumer's side:
+The following shows what a swap carries across and what it does not, from the
+consumer's side:
 
 ```mermaid
 flowchart LR
@@ -3421,7 +3423,7 @@ flowchart LR
   end
   subgraph breaks ["Does not carry across"]
     n1["eventId and projectId — emitter-assigned, a new id space"]
-    n2["eventId deduplication history — a cutover overlap is processed twice"]
+    n2["a consumer deduplicating only on eventId processes a cutover overlap twice"]
     n3["sourceStoreEventId is not a repair — siblings legitimately share one"]
   end
 ```

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-09-05T07:09:17.467Z
+> Generated: 2026-09-05T07:14:38.387Z
 
 ## Table of Contents
 1. Installation
@@ -2868,15 +2868,15 @@ sequenceDiagram
   Note over Emitter,Consumer: Delivery is duplicate-capable and unordered, with no exactly-once guarantee (§9.4.4). This is one attempt.
 
   Store->>Emitter: store-native notification
-  Emitter->>Emitter: normalize (§9.2); derive the lifecycle and entitlement events (§9.1)
+  Emitter->>Emitter: normalize (§9.2), then derive the lifecycle and entitlement events (§9.1)
   Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
-  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received; HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim; accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header; be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
+  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received, then HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim — accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header — be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
     Consumer-->>Emitter: 2xx
     Note over Emitter: delivered
   else 408, 429, 5xx — or no response (timeout, connection error)
     Consumer-->>Emitter: 408 / 429 / 5xx, or nothing
-    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id; eventually stop and dead-letter
+    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id — eventually stop and dead-letter
   else 3xx, or any other 4xx
     Consumer-->>Emitter: 3xx / other 4xx
     Note over Emitter: permanent failure — a redirect is not followed, nothing is retried

--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Quick Reference: https://openiap.dev/llms.txt
-> Generated: 2026-09-05T06:55:13.788Z
+> Generated: 2026-09-05T07:06:39.288Z
 
 ## Table of Contents
 1. Installation
@@ -2683,33 +2683,30 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
-The state each of those events lands in, and the ones that move no state at
-all:
+The state each lifecycle event names, as the GraphQL contract enforces it. The
+specification says where an event lands, not where it came from:
 
 ```mermaid
-stateDiagram-v2
-  direction LR
-  state "any prior state" as Prior
-
-  Prior --> Active: started / renewed / recovered / resumed
-  Prior --> InGracePeriod: entered_grace_period
-  Prior --> InBillingRetry: entered_billing_retry
-  Prior --> Paused: paused
-  Prior --> Expired: expired
-  Prior --> Revoked: revoked
-  Prior --> Refunded: refunded
-
-  note right of Active
-    canceled, uncanceled, product_changed, price_changed
-    and deferred move no state. canceled flips willRenew
-    only; access continues until expiresAt.
-  end note
-
-  note left of InBillingRetry
-    Entitled: Active and InGracePeriod, while now is
-    before expiresAt. Every other state: not entitled.
-    Read subscription.active. Never re-derive it from state.
-  end note
+flowchart LR
+  subgraph lands ["names a state — the snapshot MUST agree"]
+    direction LR
+    e1["started<br/>renewed<br/>recovered<br/>resumed"] --> Active
+    e2["entered_grace_period"] --> InGracePeriod
+    e3["entered_billing_retry"] --> InBillingRetry
+    e4["paused"] --> Paused
+    e5["expired"] --> Expired
+    e6["revoked"] --> Revoked
+    e7["refunded"] --> Refunded
+  end
+  subgraph none ["names no state — the snapshot keeps the state that actually followed the store transition"]
+    direction LR
+    e8["canceled · uncanceled<br/>product_changed · price_changed · deferred"]
+  end
+  subgraph predicate ["entitled? (§2.3) — read subscription.active; a consumer MUST NOT recompute it from state and ignore active"]
+    direction LR
+    p1["Active, InGracePeriod: yes while now is before expiresAt; with no expiresAt, yes.<br/>For InGracePeriod, expiresAt is the end of the grace window."]
+    p2["InBillingRetry, Paused, Expired, Revoked, Refunded, Unknown: no"]
+  end
 ```
 
 ### Entitlement delta
@@ -2867,16 +2864,21 @@ sequenceDiagram
   participant Emitter as Backend (emitter)
   participant Consumer as Consumer endpoint
 
+  Note over Emitter,Consumer: Delivery is duplicate-capable and unordered, with no exactly-once guarantee (§9.4.4). This is one attempt.
+
   Store->>Emitter: store-native notification
-  Emitter->>Emitter: normalize (§9.2), derive lifecycle and entitlement events (§9.1)
-  Emitter->>Consumer: POST one event as raw UTF-8 JSON<br/>openiap-signature: v1=hex (several, comma-separated, during rotation)<br/>openiap-timestamp: Unix seconds<br/>openiap-event-id, openiap-delivery-id
-  Note over Consumer: reject if abs(now − timestamp) > 300 s<br/>signed = timestamp + "." + the exact body bytes received<br/>HMAC-SHA256 with the shared secret, constant-time compare,<br/>any presented v1= against any currently valid secret<br/>take eventId from the body, deduplicate on it, ack before slow work
+  Emitter->>Emitter: normalize (§9.2); derive the lifecycle and entitlement events (§9.1)
+  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
+  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received; HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim; accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header; be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
-    Consumer-->>Emitter: delivered
-  else 408, 429, 5xx, timeout, connection error
-    Consumer-->>Emitter: retry with exponential backoff — same body and eventId,<br/>fresh timestamp, recomputed signature, same delivery-id — then dead-letter
+    Consumer-->>Emitter: 2xx
+    Note over Emitter: delivered
+  else 408, 429, 5xx — or no response (timeout, connection error)
+    Consumer-->>Emitter: 408 / 429 / 5xx, or nothing
+    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id; eventually stop and dead-letter
   else 3xx, or any other 4xx
-    Consumer-->>Emitter: permanent failure — no redirect is followed, nothing is retried
+    Consumer-->>Emitter: 3xx / other 4xx
+    Note over Emitter: permanent failure — a redirect is not followed, nothing is retried
   end
 ```
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-09-05T06:55:13.788Z
+> Generated: 2026-09-05T07:06:39.288Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-09-05T04:10:09.550Z
+> Generated: 2026-09-05T06:55:13.788Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-09-05T07:09:17.467Z
+> Generated: 2026-09-05T07:14:38.387Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-09-05T07:06:39.288Z
+> Generated: 2026-09-05T07:09:17.467Z
 
 ## Installation
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -3,7 +3,7 @@
 > OpenIAP: Vendor-neutral in-app purchase specification — a client API across Apple, Google, Meta Horizon and Amazon, and a server-side commerce protocol for verification, entitlements and store events
 > Documentation: https://openiap.dev
 > Full Reference: https://openiap.dev/llms-full.txt
-> Generated: 2026-09-05T07:14:38.387Z
+> Generated: 2026-09-05T07:23:55.623Z
 
 ## Installation
 

--- a/specs/commerce-protocol/README.md
+++ b/specs/commerce-protocol/README.md
@@ -23,11 +23,13 @@ Where the contract sits:
 flowchart TB
   stores["Apple / Google / Meta / Amazon<br/>the stores"]
   backend["A backend that implements this specification<br/>IAPKit, another provider, or the adopter's own — in any language<br/><br/>verify → normalize → lifecycle → entitle"]
-  app["developer backend / app"]
+  app["shipped application<br/>verification role (§5)"]
+  server["the adopter's backend<br/>server role (§5)"]
   consumers["any consumer<br/>analytics · subscriber experience · data pipeline"]
 
   stores -->|"store-native notifications and APIs"| backend
-  app <-->|"operations (§4): verify, status, entitlements, bind, erase, capabilities<br/>over REST (§6) or GraphQL (§7)"| backend
+  app -->|"verifyPurchase, providerCapabilities (§4.1, §4.6)<br/>over REST (§6) or GraphQL (§7)"| backend
+  server -->|"those, plus subscriptionStatus, entitlements, bindPurchase, eraseUser (§4.2–§4.5)<br/>server role only — never a shipped app"| backend
   backend -->|"OpenIAP Commerce Protocol events (§9)"| consumers
 ```
 

--- a/specs/commerce-protocol/README.md
+++ b/specs/commerce-protocol/README.md
@@ -17,6 +17,20 @@ it does not sit in the path of anyone's commerce.
 
 **[Read the specification →](./SPEC.md)**
 
+Where the contract sits:
+
+```mermaid
+flowchart TB
+  stores["Apple · Google · Meta Horizon · Amazon<br/>store-native notifications and APIs"]
+  backend["A backend that implements this specification<br/>IAPKit, another provider, or the adopter's own — in any language<br/><br/>verify → normalize → lifecycle → entitle"]
+  app["The adopter's backend or app"]
+  consumers["Any consumer<br/>analytics · CRM · data pipeline · subscriber experience"]
+
+  stores -->|"notifications"| backend
+  app <-->|"operations (§4): verify, status, entitlements, bind, erase, capabilities<br/>over REST (§6) or GraphQL (§7)"| backend
+  backend -->|"events (§9): signed webhooks"| consumers
+```
+
 ## Reviewing a change
 
 Review only the authored surfaces, in this order:

--- a/specs/commerce-protocol/README.md
+++ b/specs/commerce-protocol/README.md
@@ -21,14 +21,14 @@ Where the contract sits:
 
 ```mermaid
 flowchart TB
-  stores["Apple · Google · Meta Horizon · Amazon<br/>store-native notifications and APIs"]
+  stores["Apple / Google / Meta / Amazon<br/>the stores"]
   backend["A backend that implements this specification<br/>IAPKit, another provider, or the adopter's own — in any language<br/><br/>verify → normalize → lifecycle → entitle"]
-  app["The adopter's backend or app"]
-  consumers["Any consumer<br/>analytics · CRM · data pipeline · subscriber experience"]
+  app["developer backend / app"]
+  consumers["any consumer<br/>analytics · subscriber experience · data pipeline"]
 
-  stores -->|"notifications"| backend
+  stores -->|"store-native notifications and APIs"| backend
   app <-->|"operations (§4): verify, status, entitlements, bind, erase, capabilities<br/>over REST (§6) or GraphQL (§7)"| backend
-  backend -->|"events (§9): signed webhooks"| consumers
+  backend -->|"OpenIAP Commerce Protocol events (§9)"| consumers
 ```
 
 ## Reviewing a change

--- a/specs/commerce-protocol/README.md
+++ b/specs/commerce-protocol/README.md
@@ -17,15 +17,15 @@ it does not sit in the path of anyone's commerce.
 
 **[Read the specification →](./SPEC.md)**
 
-Where the contract sits:
+The contract sits between the stores and everything downstream of a backend:
 
 ```mermaid
 flowchart TB
   stores["Apple / Google / Meta / Amazon<br/>the stores"]
-  backend["A backend that implements this specification<br/>IAPKit, another provider, or the adopter's own — in any language<br/><br/>verify → normalize → lifecycle → entitle"]
+  backend["A backend that implements this spec<br/>IAPKit, another provider, or the adopter's own — in any language<br/><br/>verify → normalize → lifecycle → entitle"]
   app["shipped application<br/>verification role (§5)"]
   server["the adopter's backend<br/>server role (§5)"]
-  consumers["any consumer<br/>analytics · subscriber experience · data pipeline"]
+  consumers["any consumer<br/>data pipeline / CRM / analytics"]
 
   stores -->|"store-native notifications and APIs"| backend
   app -->|"verifyPurchase, providerCapabilities (§4.1, §4.6)<br/>over REST (§6) or GraphQL (§7)"| backend

--- a/specs/commerce-protocol/SPEC.md
+++ b/specs/commerce-protocol/SPEC.md
@@ -836,15 +836,15 @@ sequenceDiagram
   Note over Emitter,Consumer: Delivery is duplicate-capable and unordered, with no exactly-once guarantee (§9.4.4). This is one attempt.
 
   Store->>Emitter: store-native notification
-  Emitter->>Emitter: normalize (§9.2); derive the lifecycle and entitlement events (§9.1)
+  Emitter->>Emitter: normalize (§9.2), then derive the lifecycle and entitlement events (§9.1)
   Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
-  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received; HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim; accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header; be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
+  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received, then HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim — accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header — be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
     Consumer-->>Emitter: 2xx
     Note over Emitter: delivered
   else 408, 429, 5xx — or no response (timeout, connection error)
     Consumer-->>Emitter: 408 / 429 / 5xx, or nothing
-    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id; eventually stop and dead-letter
+    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id — eventually stop and dead-letter
   else 3xx, or any other 4xx
     Consumer-->>Emitter: 3xx / other 4xx
     Note over Emitter: permanent failure — a redirect is not followed, nothing is retried

--- a/specs/commerce-protocol/SPEC.md
+++ b/specs/commerce-protocol/SPEC.md
@@ -651,33 +651,30 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
-The state each of those events lands in, and the ones that move no state at
-all:
+The state each lifecycle event names, as the GraphQL contract enforces it. The
+specification says where an event lands, not where it came from:
 
 ```mermaid
-stateDiagram-v2
-  direction LR
-  state "any prior state" as Prior
-
-  Prior --> Active: started / renewed / recovered / resumed
-  Prior --> InGracePeriod: entered_grace_period
-  Prior --> InBillingRetry: entered_billing_retry
-  Prior --> Paused: paused
-  Prior --> Expired: expired
-  Prior --> Revoked: revoked
-  Prior --> Refunded: refunded
-
-  note right of Active
-    canceled, uncanceled, product_changed, price_changed
-    and deferred move no state. canceled flips willRenew
-    only; access continues until expiresAt.
-  end note
-
-  note left of InBillingRetry
-    Entitled: Active and InGracePeriod, while now is
-    before expiresAt. Every other state: not entitled.
-    Read subscription.active. Never re-derive it from state.
-  end note
+flowchart LR
+  subgraph lands ["names a state — the snapshot MUST agree"]
+    direction LR
+    e1["started<br/>renewed<br/>recovered<br/>resumed"] --> Active
+    e2["entered_grace_period"] --> InGracePeriod
+    e3["entered_billing_retry"] --> InBillingRetry
+    e4["paused"] --> Paused
+    e5["expired"] --> Expired
+    e6["revoked"] --> Revoked
+    e7["refunded"] --> Refunded
+  end
+  subgraph none ["names no state — the snapshot keeps the state that actually followed the store transition"]
+    direction LR
+    e8["canceled · uncanceled<br/>product_changed · price_changed · deferred"]
+  end
+  subgraph predicate ["entitled? (§2.3) — read subscription.active; a consumer MUST NOT recompute it from state and ignore active"]
+    direction LR
+    p1["Active, InGracePeriod: yes while now is before expiresAt; with no expiresAt, yes.<br/>For InGracePeriod, expiresAt is the end of the grace window."]
+    p2["InBillingRetry, Paused, Expired, Revoked, Refunded, Unknown: no"]
+  end
 ```
 
 ### Entitlement delta
@@ -835,16 +832,21 @@ sequenceDiagram
   participant Emitter as Backend (emitter)
   participant Consumer as Consumer endpoint
 
+  Note over Emitter,Consumer: Delivery is duplicate-capable and unordered, with no exactly-once guarantee (§9.4.4). This is one attempt.
+
   Store->>Emitter: store-native notification
-  Emitter->>Emitter: normalize (§9.2), derive lifecycle and entitlement events (§9.1)
-  Emitter->>Consumer: POST one event as raw UTF-8 JSON<br/>openiap-signature: v1=hex (several, comma-separated, during rotation)<br/>openiap-timestamp: Unix seconds<br/>openiap-event-id, openiap-delivery-id
-  Note over Consumer: reject if abs(now − timestamp) > 300 s<br/>signed = timestamp + "." + the exact body bytes received<br/>HMAC-SHA256 with the shared secret, constant-time compare,<br/>any presented v1= against any currently valid secret<br/>take eventId from the body, deduplicate on it, ack before slow work
+  Emitter->>Emitter: normalize (§9.2); derive the lifecycle and entitlement events (§9.1)
+  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
+  Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received; HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim; accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header; be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
-    Consumer-->>Emitter: delivered
-  else 408, 429, 5xx, timeout, connection error
-    Consumer-->>Emitter: retry with exponential backoff — same body and eventId,<br/>fresh timestamp, recomputed signature, same delivery-id — then dead-letter
+    Consumer-->>Emitter: 2xx
+    Note over Emitter: delivered
+  else 408, 429, 5xx — or no response (timeout, connection error)
+    Consumer-->>Emitter: 408 / 429 / 5xx, or nothing
+    Note over Emitter: retry with exponential backoff: same body and eventId, fresh openiap-timestamp,<br/>recomputed signature, same openiap-delivery-id; eventually stop and dead-letter
   else 3xx, or any other 4xx
-    Consumer-->>Emitter: permanent failure — no redirect is followed, nothing is retried
+    Consumer-->>Emitter: 3xx / other 4xx
+    Note over Emitter: permanent failure — a redirect is not followed, nothing is retried
   end
 ```
 

--- a/specs/commerce-protocol/SPEC.md
+++ b/specs/commerce-protocol/SPEC.md
@@ -651,6 +651,35 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
+The state each of those events lands in, and the ones that move no state at
+all:
+
+```mermaid
+stateDiagram-v2
+  direction LR
+  state "any prior state" as Prior
+
+  Prior --> Active: started / renewed / recovered / resumed
+  Prior --> InGracePeriod: entered_grace_period
+  Prior --> InBillingRetry: entered_billing_retry
+  Prior --> Paused: paused
+  Prior --> Expired: expired
+  Prior --> Revoked: revoked
+  Prior --> Refunded: refunded
+
+  note right of Active
+    canceled, uncanceled, product_changed, price_changed
+    and deferred move no state. canceled flips willRenew
+    only; access continues until expiresAt.
+  end note
+
+  note left of InBillingRetry
+    Entitled: Active and InGracePeriod, while now is
+    before expiresAt. Every other state: not entitled.
+    Read subscription.active. Never re-derive it from state.
+  end note
+```
+
 ### Entitlement delta
 
 | Event                 | Meaning                 |
@@ -797,6 +826,27 @@ endpoint, WebSocket, push relay, or long-poll feed for shipped applications: a
 project-wide event feed and its signing secret must never reach a distributed
 app. An application that needs device push gets it from its own authenticated
 backend, downstream of this contract.
+
+One delivery, end to end. §9.4.1–9.4.4 below state each step normatively:
+
+```mermaid
+sequenceDiagram
+  participant Store
+  participant Emitter as Backend (emitter)
+  participant Consumer as Consumer endpoint
+
+  Store->>Emitter: store-native notification
+  Emitter->>Emitter: normalize (§9.2), derive lifecycle and entitlement events (§9.1)
+  Emitter->>Consumer: POST one event as raw UTF-8 JSON<br/>openiap-signature: v1=hex (several, comma-separated, during rotation)<br/>openiap-timestamp: Unix seconds<br/>openiap-event-id, openiap-delivery-id
+  Note over Consumer: reject if abs(now − timestamp) > 300 s<br/>signed = timestamp + "." + the exact body bytes received<br/>HMAC-SHA256 with the shared secret, constant-time compare,<br/>any presented v1= against any currently valid secret<br/>take eventId from the body, deduplicate on it, ack before slow work
+  alt 2xx
+    Consumer-->>Emitter: delivered
+  else 408, 429, 5xx, timeout, connection error
+    Consumer-->>Emitter: retry with exponential backoff — same body and eventId,<br/>fresh timestamp, recomputed signature, same delivery-id — then dead-letter
+  else 3xx, or any other 4xx
+    Consumer-->>Emitter: permanent failure — no redirect is followed, nothing is retried
+  end
+```
 
 #### 9.4.1 Request
 
@@ -1318,6 +1368,29 @@ An adopter may replace the backend behind this contract — a self-hosted
 deployment for a managed one, a managed one for their own — and their downstream
 integrations SHOULD survive it. What follows is what actually carries across, and
 what does not.
+
+What a swap looks like from the consumer's side:
+
+```mermaid
+flowchart LR
+  consumer["A consumer written against this specification<br/>— unchanged by the swap"]
+  A["Backend A<br/>before"]
+  B["Backend B<br/>after"]
+  A -- "events (§9)" --> consumer
+  B -- "events (§9)" --> consumer
+
+  subgraph carries ["Carries across"]
+    c1["event types · envelope shape · entitlement predicate"]
+    c2["signature scheme · per-store semantics"]
+    c3["sourceStoreEventId — the store's own notification id"]
+    c4["userId, when the adopter assigns it"]
+  end
+  subgraph breaks ["Does not carry across"]
+    n1["eventId and projectId — emitter-assigned, a new id space"]
+    n2["eventId deduplication history — a cutover overlap is processed twice"]
+    n3["sourceStoreEventId is not a repair — siblings legitimately share one"]
+  end
+```
 
 **Carries across.** Event types, envelope shape, the entitlement predicate,
 signature scheme, and per-store semantics are all defined here, not by a backend.

--- a/specs/commerce-protocol/SPEC.md
+++ b/specs/commerce-protocol/SPEC.md
@@ -651,12 +651,12 @@ transitions at least one store can actually report, and nothing speculative.
 | `subscription.paused`                | The subscription was paused                                                                                                                                                                                                                                              |
 | `subscription.resumed`               | A paused subscription resumed                                                                                                                                                                                                                                            |
 
-The state each lifecycle event names, as the GraphQL contract enforces it. The
-specification says where an event lands, not where it came from:
+The following maps each lifecycle event to the snapshot state it names, as the
+GraphQL contract enforces it:
 
 ```mermaid
 flowchart LR
-  subgraph lands ["names a state — the snapshot MUST agree"]
+  subgraph lands ["names a state — when a snapshot is present, its state MUST agree"]
     direction LR
     e1["started<br/>renewed<br/>recovered<br/>resumed"] --> Active
     e2["entered_grace_period"] --> InGracePeriod
@@ -666,7 +666,7 @@ flowchart LR
     e6["revoked"] --> Revoked
     e7["refunded"] --> Refunded
   end
-  subgraph none ["names no state — the snapshot keeps the state that actually followed the store transition"]
+  subgraph none ["names no state — the contract pairs no state with these, so a snapshot keeps the state that actually followed the store transition"]
     direction LR
     e8["canceled · uncanceled<br/>product_changed · price_changed · deferred"]
   end
@@ -837,7 +837,7 @@ sequenceDiagram
 
   Store->>Emitter: store-native notification
   Emitter->>Emitter: normalize (§9.2), then derive the lifecycle and entitlement events (§9.1)
-  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, no Content-Encoding<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
+  Emitter->>Consumer: POST to the consumer's HTTPS URL — Content-Type: application/json, Content-Encoding absent or identity<br/>body: one event, the exact UTF-8 bytes<br/>openiap-signature: v1=lowercase hex (several, comma-separated, during rotation)<br/>openiap-timestamp: exactly one, Unix seconds, base-10, no sign<br/>openiap-event-id · openiap-delivery-id
   Note over Consumer: MUST: reject if abs(now − timestamp) > 300 s<br/>MUST: signed = ascii(timestamp) + "." + the exact body bytes received, then HMAC-SHA256 with the shared secret<br/>MUST: split openiap-signature on "," and trim — accept if any presented v1= matches any valid secret, compared in constant time<br/>MUST: take eventId from the parsed body, not the header — be idempotent on it<br/>SHOULD: acknowledge before slow downstream work
   alt 2xx
     Consumer-->>Emitter: 2xx

--- a/specs/commerce-protocol/SPEC.md
+++ b/specs/commerce-protocol/SPEC.md
@@ -824,7 +824,8 @@ project-wide event feed and its signing secret must never reach a distributed
 app. An application that needs device push gets it from its own authenticated
 backend, downstream of this contract.
 
-One delivery, end to end. §9.4.1–9.4.4 below state each step normatively:
+The following sequence summarizes one delivery under §9.4.1–9.4.4, which state
+each step normatively:
 
 ```mermaid
 sequenceDiagram
@@ -1371,7 +1372,8 @@ deployment for a managed one, a managed one for their own — and their downstre
 integrations SHOULD survive it. What follows is what actually carries across, and
 what does not.
 
-What a swap looks like from the consumer's side:
+The following shows what a swap carries across and what it does not, from the
+consumer's side:
 
 ```mermaid
 flowchart LR
@@ -1389,7 +1391,7 @@ flowchart LR
   end
   subgraph breaks ["Does not carry across"]
     n1["eventId and projectId — emitter-assigned, a new id space"]
-    n2["eventId deduplication history — a cutover overlap is processed twice"]
+    n2["a consumer deduplicating only on eventId processes a cutover overlap twice"]
     n3["sourceStoreEventId is not a repair — siblings legitimately share one"]
   end
 ```


### PR DESCRIPTION
SPEC.md is 1,385 lines — about 52 minutes of reading — with 121 table rows and no diagram. The docs site has SVG diagrams, but the spec as fetched from GitHub or npm, which is how an adopter or an agent first meets it, had none. GitHub renders Mermaid natively.

## Four diagrams, one question each

**README — where the contract sits.** Stores, a replaceable backend, and the two surfaces it exposes. A Mermaid rendering of the ASCII already in §1.1.

**§9.1 — which state each lifecycle event lands in.** This is the trap the README warns about in words: `canceled` stays `Active`, flips `willRenew`, and access continues to `expiresAt`. Five events move no state at all; the diagram says which.

**§9.4 — one webhook delivery, end to end.** Headers, the signed material, the consumer's checks, and what each response class means. Every step restates §9.4.1–9.4.4. Nothing is added to the contract.

**§13 — what carries across a provider swap and what does not.**

## Placement was checked, not assumed

Seven tests and two build scripts read SPEC.md. Each one's anchor was read before choosing where to insert:

- the §9.4 diagram sits before `#### 9.4.1`, outside the window `audit-docs.ts` uses to compare the §9.4.3 response table;
- the §9.1 diagram sits before `### Entitlement delta`, after the lifecycle table;
- no label uses a term `decentralization.test.mjs` forbids (`sponsor`, `backer`, `kit.openiap.dev`, …).

Additions only. No existing line changed.

## Checks

commerce-protocol `bun run test` — 336/336 with `prettier --check` clean. Root suite 439/439. `audit:docs`, `audit:layout`, `audit:facts`, `audit:sbom-docs`, `audit:parity` clean. Rendering verified on GitHub's own Mermaid engine before opening this PR.

No release: documentation only, no package or version touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised diagrams for subscription lifecycle transitions, webhook delivery, provider switching, and the commerce protocol contract.
  - Clarified subscription state mappings and state-preserving events.
  - Clarified webhook normalization, signing and verification, delivery guarantees, idempotency, duplicate or unordered delivery, retries, and permanent failures.
  - Updated provider-switching flow descriptions, including potential duplicate processing during cutover.
  - Refreshed generated documentation timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->