### PR TITLE
fix(android): support agp 9 built-in kotlin

### DIFF
--- a/.github/workflows/ci-react-native-iap.yml
+++ b/.github/workflows/ci-react-native-iap.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, next]
     paths:
       - "libraries/react-native-iap/**"
+      - "libraries/expo-iap/android/**"
+      - "libraries/expo-iap/package.json"
+      - "libraries/expo-iap/bun.lock"
+      - "scripts/test-android-gradle-compatibility.mjs"
       - "specs/client/src/generated/types.ts"
       - "packages/apple/Sources/**"
       - "packages/apple/Package.swift"
@@ -18,6 +22,10 @@ on:
     branches: [main, next]
     paths:
       - "libraries/react-native-iap/**"
+      - "libraries/expo-iap/android/**"
+      - "libraries/expo-iap/package.json"
+      - "libraries/expo-iap/bun.lock"
+      - "scripts/test-android-gradle-compatibility.mjs"
       - "specs/client/src/generated/types.ts"
       - "packages/apple/Sources/**"
       - "packages/apple/Package.swift"
@@ -153,6 +161,59 @@ jobs:
       - name: Run Android unit tests
         working-directory: libraries/react-native-iap/example/android
         run: ./gradlew :react-native-iap:testDebugUnitTest --stacktrace
+
+  android-gradle-compatibility:
+    name: Android Gradle ${{ matrix.agp }} (${{ matrix.mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - agp: "8.8.2"
+            mode: default
+            gradle: "8.13"
+            kotlin: "2.1.20"
+          - agp: "8.13.2"
+            mode: default
+          - agp: "9.0.1"
+            mode: default
+          - agp: "9.2.1"
+            mode: default
+          - agp: "9.2.1"
+            mode: opt-out
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 20
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.13
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+        with:
+          gradle-version: ${{ matrix.gradle || '9.4.1' }}
+      - name: Install React Native dependencies and generate bindings
+        run: |
+          corepack enable && corepack prepare yarn@3.6.1 --activate
+          yarn install --immutable
+          yarn nitrogen
+      - name: Install Expo dependencies
+        working-directory: libraries/expo-iap
+        run: bun install --frozen-lockfile
+      - name: Verify both Android library build scripts
+        working-directory: .
+        env:
+          AGP_VERSION: ${{ matrix.agp }}
+          KOTLIN_MODE: ${{ matrix.mode }}
+          KOTLIN_VERSION: ${{ matrix.kotlin }}
+        run: node scripts/test-android-gradle-compatibility.mjs "$AGP_VERSION" "$KOTLIN_MODE"
 
   ios-xcode-27:
     name: iOS example (Xcode 27)

--- a/libraries/expo-iap/android/build.gradle
+++ b/libraries/expo-iap/android/build.gradle
@@ -2,7 +2,13 @@ import groovy.json.JsonSlurper
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+  apply plugin: 'kotlin-android'
+}
 
 group = 'expo.modules.iap'
 

--- a/libraries/expo-iap/android/build.gradle
+++ b/libraries/expo-iap/android/build.gradle
@@ -2,10 +2,7 @@ import groovy.json.JsonSlurper
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 apply plugin: 'com.android.library'
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
+// AGP 9 registers Kotlin itself unless the consumer opts out.
 if (project.extensions.findByName('kotlin') == null) {
   apply plugin: 'kotlin-android'
 }
@@ -85,6 +82,9 @@ if (useManagedAndroidSdkVersions) {
 
 android {
   namespace = "expo.modules.iap"
+  buildFeatures {
+    buildConfig = true
+  }
   defaultConfig {
     versionCode = 1
     versionName = expoIapPackageVersion

--- a/libraries/react-native-iap/android/build.gradle
+++ b/libraries/react-native-iap/android/build.gradle
@@ -79,7 +79,13 @@ if (!(googleVersion instanceof String) || !googleVersion.trim()) {
 def googleVersionString = googleVersion.trim()
 
 apply plugin: "com.android.library"
-apply plugin: 'org.jetbrains.kotlin.android'
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying the Kotlin plugin on top of it fails configuration with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
+// registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+  apply plugin: 'org.jetbrains.kotlin.android'
+}
 
 // Only apply Nitro autolinking if the file exists
 def nitroAutolinkingFile = file('../nitrogen/generated/android/NitroIap+autolinking.gradle')

--- a/libraries/react-native-iap/android/build.gradle
+++ b/libraries/react-native-iap/android/build.gradle
@@ -79,10 +79,7 @@ if (!(googleVersion instanceof String) || !googleVersion.trim()) {
 def googleVersionString = googleVersion.trim()
 
 apply plugin: "com.android.library"
-// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
-// itself. Applying the Kotlin plugin on top of it fails configuration with
-// "Cannot add extension with name 'kotlin'". Only apply it when nothing has
-// registered that extension yet.
+// AGP 9 registers Kotlin itself unless the consumer opts out.
 if (project.extensions.findByName('kotlin') == null) {
   apply plugin: 'org.jetbrains.kotlin.android'
 }
@@ -91,6 +88,8 @@ if (project.extensions.findByName('kotlin') == null) {
 def nitroAutolinkingFile = file('../nitrogen/generated/android/NitroIap+autolinking.gradle')
 if (nitroAutolinkingFile.exists()) {
   apply from: nitroAutolinkingFile
+  // Built-in Kotlin does not compile custom java.srcDirs added by Nitrogen.
+  android.sourceSets.main.kotlin.srcDir('../nitrogen/generated/android/kotlin')
 }
 
 apply from: "./fix-prefab.gradle"
@@ -157,11 +156,11 @@ android {
   namespace = "com.margelo.nitro.iap"
 
   ndkVersion = getExtOrDefault("ndkVersion")
-  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+  compileSdk = getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
-    minSdkVersion = getExtOrIntegerDefault("minSdkVersion")
-    targetSdkVersion = getExtOrIntegerDefault("targetSdkVersion")
+    minSdk = getExtOrIntegerDefault("minSdkVersion")
+    targetSdk = getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     // Ship consumer keep rules so Nitro HybridObjects aren't stripped in app release builds
     consumerProguardFiles 'consumer-rules.pro'
@@ -174,15 +173,6 @@ android {
         cppFlags "-frtti -fexceptions -Wall -Wextra -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         abiFilters (*reactNativeArchitectures())
-
-        buildTypes {
-          debug {
-            cppFlags "-O1 -g"
-          }
-          release {
-            cppFlags "-O2"
-          }
-        }
       }
     }
   }
@@ -193,10 +183,8 @@ android {
     }
   }
 
-  packagingOptions {
-    excludes = [
-            "META-INF",
-            "META-INF/**",
+  packaging {
+    def excludedLibraries = [
             "**/libc++_shared.so",
             "**/libfbjni.so",
             "**/libjsi.so",
@@ -212,6 +200,8 @@ android {
             "**/libreact_nativemodule_core.so",
             "**/libjscexecutor.so"
     ]
+    resources.excludes += ["META-INF", "META-INF/**"] + excludedLibraries
+    jniLibs.excludes += excludedLibraries
   }
 
   buildFeatures {
@@ -220,8 +210,12 @@ android {
   }
 
   buildTypes {
+    debug {
+      externalNativeBuild.cmake.cppFlags "-O1 -g"
+    }
     release {
       minifyEnabled = false
+      externalNativeBuild.cmake.cppFlags "-O2"
     }
   }
   
@@ -230,11 +224,9 @@ android {
     targetCompatibility JavaVersion.VERSION_17
   }
   
-  lintOptions {
-    disable "GradleCompatible"
+  lint {
+    disable += "GradleCompatible"
   }
-
-  // Removed sourceSets configuration for codegen as it's not needed for library modules
 }
 
 kotlin {

--- a/libraries/react-native-iap/android/fix-prefab.gradle
+++ b/libraries/react-native-iap/android/fix-prefab.gradle
@@ -1,7 +1,5 @@
 tasks.configureEach { task ->
-  // Make sure that we generate our prefab publication file only after having built the native library
-  // so that not a header publication file, but a full configuration publication will be generated, which
-  // will include the .so file
+  // Publish prefab metadata only after its native library exists.
 
   def prefabConfigurePattern = ~/^prefab(.+)ConfigurePackage$/
   def matcher = task.name =~ prefabConfigurePattern
@@ -12,14 +10,16 @@ tasks.configureEach { task ->
   }
 }
 
-afterEvaluate {
+gradle.projectsEvaluated {
   def abis = reactNativeArchitectures()
   rootProject.allprojects.each { proj ->
     if (proj === rootProject) return
 
     def dependsOnThisLib = proj.configurations.findAll { it.canBeResolved }.any { config ->
-      config.dependencies.any { dep ->
-        dep.group == project.group && dep.name == project.name
+      config.allDependencies.any { dep ->
+        dep instanceof ProjectDependency
+            ? dep.path == project.path
+            : dep.group == project.group && dep.name == project.name
       }
     }
     if (!dependsOnThisLib && proj != project) return
@@ -28,24 +28,11 @@ afterEvaluate {
       return
     }
 
-    def variants = proj.android.hasProperty('applicationVariants') ? proj.android.applicationVariants : proj.android.libraryVariants
-    // Touch the prefab_config.json files to ensure that in ExternalNativeJsonGenerator.kt we will re-trigger the prefab CLI to
-    // generate a libnameConfig.cmake file that will contain our native library (.so).
-    // See this condition: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ExternalNativeJsonGenerator.kt;l=207-219?q=createPrefabBuildSystemGlue
-    variants.all { variant ->
-      def variantName = variant.name
-      abis.each { abi ->
-        def searchDir = new File(proj.projectDir, ".cxx/${variantName}")
-        if (!searchDir.exists()) return
-        def matches = []
-        searchDir.eachDir { randomDir ->
-          def prefabFile = new File(randomDir, "${abi}/prefab_config.json")
-          if (prefabFile.exists()) matches << prefabFile
-        }
-        matches.each { prefabConfig ->
-          prefabConfig.setLastModified(System.currentTimeMillis())
-        }
-      }
+    // Refresh existing prefab metadata so CMake discovers newly built libraries.
+    proj.fileTree('.cxx') {
+      abis.each { abi -> include "*/*/${abi}/prefab_config.json" }
+    }.each { prefabConfig ->
+      prefabConfig.setLastModified(System.currentTimeMillis())
     }
   }
 }

--- a/scripts/test-android-gradle-compatibility.mjs
+++ b/scripts/test-android-gradle-compatibility.mjs
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const [agp, mode = "default"] = process.argv.slice(2);
+assert.match(
+  agp ?? "",
+  /^\d+\.\d+\.\d+$/,
+  "Usage: node scripts/test-android-gradle-compatibility.mjs <AGP version> [default|opt-out]",
+);
+assert.ok(["default", "opt-out"].includes(mode));
+const gradle = process.env.GRADLE_BIN || "gradle";
+const sdk = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+assert.ok(sdk, "Set ANDROID_HOME to an installed Android SDK.");
+const root = mkdtempSync(join(tmpdir(), "openiap-gradle-"));
+const rn = join(repo, "libraries/react-native-iap");
+const expo = join(repo, "libraries/expo-iap");
+const defaults = Object.fromEntries(
+  readFileSync(join(rn, "android/gradle.properties"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => line.split("=")),
+);
+const kotlin = process.env.KOTLIN_VERSION || defaults.NitroIap_kotlinVersion;
+assert.match(kotlin, /^\d+\.\d+\.\d+$/);
+const builtIn = Number(agp.split(".")[0]) >= 9 && mode === "default";
+
+function write(path, body) {
+  const target = join(root, path);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, body);
+}
+
+function copy(source, target) {
+  mkdirSync(dirname(join(root, target)), { recursive: true });
+  cpSync(source, join(root, target));
+}
+
+try {
+  write(
+    "settings.gradle",
+    `
+rootProject.name = 'openiap-gradle-compatibility'
+include ':rn', ':expo', ':expo-modules-core', ':consumer', ':unrelated'
+project(':rn').projectDir = file('react-native-iap/android')
+project(':expo').projectDir = file('expo-iap/android')
+`,
+  );
+  write(
+    "gradle.properties",
+    `
+org.gradle.jvmargs=-Xmx2g
+org.gradle.workers.max=2
+android.useAndroidX=true
+reactNativeArchitectures=arm64-v8a
+${mode === "opt-out" ? "android.builtInKotlin=false\nandroid.newDsl=false" : ""}
+`,
+  );
+  write("local.properties", `sdk.dir=${sdk.replaceAll("\\", "\\\\")}\n`);
+  write(
+    "build.gradle",
+    `
+buildscript {
+  repositories { google(); mavenCentral() }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:${agp}'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin}'
+  }
+}
+ext.kotlinVersion = '${kotlin}'
+ext.androidGradlePluginVersion = '${agp}'
+subprojects {
+  repositories { google(); mavenCentral() }
+  plugins.withId('com.android.library') {
+    if (name == 'rn') {
+      android.buildFeatures.prefabPublishing = true
+      android.prefab { NitroIap { headers = 'include' } }
+    }
+  }
+  afterEvaluate {
+    if (name in ['rn', 'expo']) {
+      // Exercise the shipped build scripts independently of framework plugins.
+      configurations.implementation.dependencies.clear()
+      dependencies.add('implementation', 'org.jetbrains.kotlin:kotlin-stdlib:${kotlin}')
+      assert plugins.hasPlugin('org.jetbrains.kotlin.android') == ${!builtIn}
+    }
+  }
+}
+tasks.register('verifyCompatibility') {
+  dependsOn ':rn:assembleDebug', ':rn:assembleRelease', ':expo:assembleDebug'
+  doLast {
+    ['rn', 'expo'].each { name ->
+      def lib = project(":\$name")
+      assert lib.android.compileOptions.targetCompatibility == JavaVersion.VERSION_17
+      def archive = lib.layout.buildDirectory.file("outputs/aar/\$name-debug.aar").get().asFile
+      def aar = new java.util.zip.ZipFile(archive)
+      try {
+        def classes = new java.util.jar.JarInputStream(aar.getInputStream(aar.getEntry('classes.jar')))
+        def names = []
+        try {
+          for (def entry = classes.nextJarEntry; entry != null; entry = classes.nextJarEntry) {
+            names.add(entry.name)
+          }
+        } finally { classes.close() }
+        assert names.contains('dev/openiap/probe/Probe.class')
+        if (name == 'rn') {
+          assert names.contains('dev/openiap/probe/GeneratedBase.class')
+          assert aar.getEntry('jni/arm64-v8a/libNitroIap.so') != null
+          assert aar.getEntry('prefab/modules/NitroIap/libs/android.arm64-v8a/libNitroIap.so') != null
+          assert aar.getEntry('jni/arm64-v8a/libfbjni.so') == null
+          assert !names.contains('META-INF/removed.txt')
+          assert !names.contains('lib/libfbjni.so')
+          assert lib.android.defaultConfig.externalNativeBuild.cmake.cppFlags.join(' ').tokenize().contains('-fstack-protector-all')
+          assert lib.android.buildTypes.debug.externalNativeBuild.cmake.cppFlags.contains('-O1 -g')
+          assert lib.android.buildTypes.release.externalNativeBuild.cmake.cppFlags.contains('-O2')
+        }
+      } finally { aar.close() }
+    }
+    println 'Verified Kotlin classes, generated sources, native packaging, and compiler flags.'
+  }
+}
+`,
+  );
+  for (const [source, name, packageName] of [
+    [rn, "rn", "react-native-iap"],
+    [expo, "expo", "expo-iap"],
+  ]) {
+    copy(
+      join(source, "android/build.gradle"),
+      `${packageName}/android/build.gradle`,
+    );
+    copy(join(source, "package.json"), `${packageName}/package.json`);
+    copy(
+      join(repo, "openiap-versions.json"),
+      `${packageName}/openiap-versions.json`,
+    );
+    write(
+      `${packageName}/android/src/main/AndroidManifest.xml`,
+      "<manifest />",
+    );
+    write(
+      `${packageName}/android/src/main/java/dev/openiap/probe/Probe.kt`,
+      `package dev.openiap.probe\nclass Probe${name === "rn" ? " : GeneratedBase()" : " { val debug = expo.modules.iap.BuildConfig.DEBUG }"}\n`,
+    );
+  }
+  copy(
+    join(rn, "android/gradle.properties"),
+    "react-native-iap/android/gradle.properties",
+  );
+  copy(
+    join(rn, "android/fix-prefab.gradle"),
+    "react-native-iap/android/fix-prefab.gradle",
+  );
+  copy(
+    join(rn, "android/consumer-rules.pro"),
+    "react-native-iap/android/consumer-rules.pro",
+  );
+  copy(
+    join(rn, "nitrogen/generated/android/NitroIap+autolinking.gradle"),
+    "react-native-iap/nitrogen/generated/android/NitroIap+autolinking.gradle",
+  );
+  write(
+    "react-native-iap/nitrogen/generated/android/kotlin/dev/openiap/probe/GeneratedBase.kt",
+    "package dev.openiap.probe\nopen class GeneratedBase\n",
+  );
+  write(
+    "react-native-iap/android/CMakeLists.txt",
+    `
+cmake_minimum_required(VERSION 3.22.1)
+project(NitroIap)
+add_library(NitroIap SHARED probe.cpp)
+`,
+  );
+  write(
+    "react-native-iap/android/probe.cpp",
+    'extern "C" int probe() { return 438; }\n',
+  );
+  write(
+    "react-native-iap/android/include/probe.h",
+    'extern "C" int probe();\n',
+  );
+  write(
+    "react-native-iap/android/src/main/jniLibs/arm64-v8a/libfbjni.so",
+    "excluded",
+  );
+  write(
+    "react-native-iap/android/src/main/resources/META-INF/removed.txt",
+    "excluded",
+  );
+  write(
+    "react-native-iap/android/src/main/resources/lib/libfbjni.so",
+    "excluded",
+  );
+  copy(
+    join(expo, "android/openiap-android-sdk.gradle"),
+    "expo-iap/android/openiap-android-sdk.gradle",
+  );
+  copy(
+    join(
+      expo,
+      "node_modules/expo-modules-core/android/ExpoModulesCorePlugin.gradle",
+    ),
+    "expo-modules-core/ExpoModulesCorePlugin.gradle",
+  );
+  for (const name of ["consumer", "unrelated"]) {
+    write(
+      `${name}/build.gradle`,
+      `
+apply plugin: 'com.android.application'
+android {
+  namespace = 'dev.openiap.${name}'
+  compileSdk = ${defaults.NitroIap_compileSdkVersion}
+  defaultConfig { minSdk = ${defaults.NitroIap_minSdkVersion} }
+}
+${name === "consumer" ? "dependencies { implementation project(':rn') }" : ""}
+`,
+    );
+  }
+  const refreshed = [];
+  const unchanged = [];
+  for (const module of ["react-native-iap/android", "consumer", "unrelated"]) {
+    for (const variant of ["Debug", "release", "customDebug"]) {
+      for (const abi of ["arm64-v8a", "x86_64"]) {
+        const path = `${module}/.cxx/${variant}/probe/${abi}/prefab_config.json`;
+        write(path, "{}");
+        utimesSync(join(root, path), 1, 1);
+        (module !== "unrelated" && abi === "arm64-v8a"
+          ? refreshed
+          : unchanged
+        ).push(path);
+      }
+    }
+  }
+  write(
+    "verify-prefab.gradle",
+    `
+gradle.projectsEvaluated {
+  rootProject.tasks.named('verifyCompatibility') {
+    doLast {
+      ${JSON.stringify(refreshed)}.each { assert rootProject.file(it).lastModified() > 1000 }
+      ${JSON.stringify(unchanged)}.each { assert rootProject.file(it).lastModified() == 1000 }
+    }
+  }
+}
+`,
+  );
+  console.log(`Checking AGP ${agp} (${mode}) in ${root}`);
+  const result = spawnSync(
+    gradle,
+    [
+      "-p",
+      root,
+      "--no-daemon",
+      "--console=plain",
+      "-I",
+      join(root, "verify-prefab.gradle"),
+      "verifyCompatibility",
+    ],
+    { stdio: "inherit" },
+  );
+  if (result.error) throw result.error;
+  assert.equal(result.status, 0, `AGP ${agp} (${mode}) compatibility failed`);
+} finally {
+  if (process.env.KEEP_GRADLE_FIXTURE) console.log(`Fixture retained: ${root}`);
+  else rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Android library builds now support AGP 9 built-in Kotlin while retaining the Kotlin Android plugin on AGP 8 and AGP 9 opt-out projects.

## Changes

- Apply the Kotlin plugin only when the Android plugin has not registered Kotlin.
- Register Nitro-generated Kotlin sources explicitly and use the public Android DSL for SDK, lint, native flags, and packaging settings.
- Refresh prefab metadata after project configuration without the removed variant API, preserving consumer and ABI scoping.
- Generate Expo's BuildConfig explicitly for its logging helper.
- Run both shipped Gradle scripts in CI and check compiled Kotlin classes, debug/release native builds, prefab publication, and resource exclusions.

## Verification

| AGP | Gradle | Kotlin mode | Result |
| --- | --- | --- | --- |
| 8.8.2 | 8.13 | Kotlin plugin 2.1.20 | Passed |
| 8.13.2 | 9.4.1 | Kotlin plugin | Passed |
| 9.0.1 | 9.4.1 | Built-in | Passed |
| 9.2.1 | 9.4.1 | Built-in | Passed |
| 9.2.1 | 9.4.1 | Built-in and new DSL disabled | Passed |

- Actual library Kotlin sources and React Native arm64 C++ compile with AGP 9.0.1, 9.2.1, and 9.2.1 opt-out.
- Existing examples pass Android unit tests, AAR builds, and Play/Horizon/Amazon Kotlin compilation.
- Library lint/type checks and library/example Jest tests pass; SDK parity, declared facts, and CI path audits pass.

The CI matrix isolates the library build scripts from framework plugins. The AGP 9 full-source checks use prebuilt Nitro and Expo Modules Core AARs from the existing example builds. Upgrading a whole application still requires compatible React Native, Expo, Nitro, and other Gradle plugins.

No recording is applicable to this build-only change; the matrix checks the resulting AAR contents and native libraries.

## Device regression (32d4929e)

All six arm64 example APKs built successfully: React Native and Expo on Play, Amazon, and Horizon. The four physical-device rows below passed connection, product fetch, restored-purchase handling, cancellation/error delivery, a new sandbox consumable purchase, finish/consume, and ownership refresh.

| Example | Device / test store | New purchase → finish/consume → ownership refresh |
| --- | --- | --- |
| React Native | Pixel 2 / Google Play test card | PASS |
| React Native | Fire tablet / Amazon App Tester | PASS |
| Expo | Pixel 2 / Google Play test card | PASS |
| Expo | Fire tablet / Amazon App Tester | PASS |

Exactly four approved sandbox purchases were completed, one 10 Bulbs consumable per row; no real charges were made. Each success alert followed awaited transaction completion, and refreshed ownership excluded the consumed SKU. No native loading failures or crashes were observed. Google cancellation returned `user-cancelled`; App Tester cancellation returned the existing `purchase-error` mapping. Tests used the existing example toolchains and skipped server verification; no production IAPKit writes were made. Original apps and data were preserved.
