### PR TITLE
docs: let the Commerce Protocol own its navigation

### DIFF
--- a/packages/docs/src/pages/docs/index.tsx
+++ b/packages/docs/src/pages/docs/index.tsx
@@ -199,6 +199,15 @@ function readSavedSidebarCollapsed() {
   return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true';
 }
 
+/** The protocol's own pages, with or without a trailing slash: `/docs/commerce-
+ * protocol/` renders the landing page, which must not link back to itself. */
+function isCommerceProtocolPage(pathname: string): boolean {
+  const path = pathname.replace(/\/+$/, '');
+  return (
+    path.startsWith('/docs/commerce-protocol/') || path === '/docs/webhooks'
+  );
+}
+
 function Docs() {
   const { pathname } = useLocation();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -1106,8 +1115,7 @@ function Docs() {
         {/* The protocol's own pages are reached from its landing page, not from
             this sidebar, so a reader who arrives at one directly needs a way
             back into that section. */}
-        {(pathname.startsWith('/docs/commerce-protocol/') ||
-          pathname === '/docs/webhooks') && (
+        {isCommerceProtocolPage(pathname) && (
           <Link to="/docs/commerce-protocol" className="docs-section-backlink">
             ← Commerce Protocol
           </Link>

--- a/packages/docs/src/pages/docs/index.tsx
+++ b/packages/docs/src/pages/docs/index.tsx
@@ -7,6 +7,7 @@ import type {
 import { createPortal } from 'react-dom';
 import { Bookmark } from 'lucide-react';
 import {
+  Link,
   Route,
   Routes,
   Navigate,
@@ -441,37 +442,6 @@ function Docs() {
               </NavLink>
             </li>
             <MenuDropdown
-              title="Commerce Protocol"
-              titleTo="/docs/commerce-protocol"
-              items={[
-                { to: '/docs/commerce-protocol/profiles', label: 'Profiles' },
-                {
-                  to: '/docs/commerce-protocol/operations',
-                  label: 'Operations',
-                },
-                { to: '/docs/commerce-protocol/rest', label: 'REST' },
-                { to: '/docs/commerce-protocol/graphql', label: 'GraphQL' },
-                { to: '/docs/webhooks', label: 'Events & Webhooks' },
-                {
-                  to: '/docs/commerce-protocol/authentication',
-                  label: 'Authentication',
-                },
-                {
-                  to: '/docs/commerce-protocol/capabilities',
-                  label: 'Capabilities',
-                },
-                {
-                  to: '/docs/commerce-protocol/conformance',
-                  label: 'Conformance',
-                },
-                {
-                  to: '/docs/commerce-protocol/versioning',
-                  label: 'Versioning',
-                },
-              ]}
-              onItemClick={closeSidebar}
-            />
-            <MenuDropdown
               title="Life Cycle"
               titleTo="/docs/lifecycle"
               items={[
@@ -819,6 +789,23 @@ function Docs() {
                 Errors
               </NavLink>
             </li>
+            {/* Deliberately not a section of these docs: the server-side spec
+                has its own top-level navigation, and this is the doorway to
+                it, not an entry in this list. */}
+            <li className="docs-nav-doorway-item">
+              <NavLink
+                to="/docs/commerce-protocol"
+                className="docs-nav-doorway"
+                onClick={closeSidebar}
+              >
+                <span className="docs-nav-doorway__label">
+                  Commerce Protocol
+                </span>
+                <span className="docs-nav-doorway__hint">
+                  The server side, specified separately
+                </span>
+              </NavLink>
+            </li>
           </ul>
           <h3 style={{ marginTop: '2rem' }}>Setup Guide</h3>
           <ul>
@@ -1116,6 +1103,15 @@ function Docs() {
         </button>
       </div>
       <main className="docs-content">
+        {/* The protocol's own pages are reached from its landing page, not from
+            this sidebar, so a reader who arrives at one directly needs a way
+            back into that section. */}
+        {(pathname.startsWith('/docs/commerce-protocol/') ||
+          pathname === '/docs/webhooks') && (
+          <Link to="/docs/commerce-protocol" className="docs-section-backlink">
+            ← Commerce Protocol
+          </Link>
+        )}
         <Routes>
           <Route
             index

--- a/packages/docs/src/styles/documentation.css
+++ b/packages/docs/src/styles/documentation.css
@@ -1617,3 +1617,57 @@
   font-weight: 600;
   white-space: nowrap;
 }
+
+/* The Commerce Protocol is a separate specification with its own top-level
+   navigation, so its entry in this sidebar is a doorway rather than a section:
+   it must read as leaving these docs, not as opening another list. */
+.docs-nav-doorway-item {
+  margin-top: 1rem;
+}
+
+.docs-sidebar .docs-nav a.docs-nav-doorway {
+  display: block;
+  white-space: normal;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--sidebar-border, var(--border-color));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-color) 6%, transparent);
+  text-decoration: none;
+}
+
+.docs-sidebar .docs-nav a.docs-nav-doorway:hover {
+  border-color: color-mix(in srgb, var(--accent-color) 45%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 11%, transparent);
+}
+
+.docs-nav-doorway__label {
+  display: block;
+  font-weight: 600;
+}
+
+.docs-nav-doorway__label::after {
+  content: ' →';
+  opacity: 0.55;
+}
+
+.docs-nav-doorway__hint {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--sidebar-text-muted, var(--text-secondary));
+}
+
+/* Shown only on the protocol's own pages, which the docs sidebar no longer
+   lists: without it, arriving at one directly leaves no route back. */
+.docs-section-backlink {
+  display: inline-block;
+  margin-bottom: 1.25rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.docs-section-backlink:hover {
+  color: var(--accent-color);
+}

--- a/packages/docs/src/styles/documentation.css
+++ b/packages/docs/src/styles/documentation.css
@@ -1621,7 +1621,11 @@
 /* The Commerce Protocol is a separate specification with its own top-level
    navigation, so its entry in this sidebar is a doorway rather than a section:
    it must read as leaving these docs, not as opening another list. */
-.docs-nav-doorway-item {
+/* `.docs-nav li { margin: 0 }` outranks a bare class, and the sidebar takes
+   its colours from the page theme — `--sidebar-*` is declared but unused, so
+   those variables would have put a white border and grey caption on a #f5f5f5
+   sidebar in light mode. */
+.docs-nav .docs-nav-doorway-item {
   margin-top: 1rem;
 }
 
@@ -1629,7 +1633,7 @@
   display: block;
   white-space: normal;
   padding: 0.6rem 0.75rem;
-  border: 1px solid var(--sidebar-border, var(--border-color));
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   background: color-mix(in srgb, var(--accent-color) 6%, transparent);
   text-decoration: none;
@@ -1655,7 +1659,7 @@
   margin-top: 0.15rem;
   font-size: 0.75rem;
   line-height: 1.35;
-  color: var(--sidebar-text-muted, var(--text-secondary));
+  color: var(--text-secondary);
 }
 
 /* Shown only on the protocol's own pages, which the docs sidebar no longer


### PR DESCRIPTION
The Commerce Protocol had a top-level nav entry and a nine-item dropdown inside
the docs sidebar at the same time — the same section presented twice, once as a
destination and once as a chapter of something else. The dropdown is gone.

What stays in the sidebar is one doorway under Errors, bordered and captioned
rather than listed, so it reads as leaving these docs. The protocol's own pages
are reached from its landing page, which already lists all nine, and each of
them now carries a link back to the section — including the webhook contract,
which lives outside the folder — since the dropdown was previously the only way
back.

No routes or URLs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated specifications for the client package and Commerce Protocol, including package availability and versioning details.
  * Simplified Commerce Protocol navigation with a direct link to its landing page.
  * Added contextual back-links from Commerce Protocol and webhooks pages to improve navigation.
  * Added styling for the new protocol entry point and back-link to provide clearer visual guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->