### PR TITLE
docs(godot): the GDExtension editor errors also appear on macOS

### DIFF
--- a/packages/docs/src/pages/docs/setup/godot.tsx
+++ b/packages/docs/src/pages/docs/setup/godot.tsx
@@ -149,7 +149,7 @@ make android
         <p>
           The default release zip does not include macOS runtime frameworks, so
           most projects can skip this section. It applies only if you build from
-          source with macOS support or use a custom zip containing{' '}
+          source with macOS support or use a release or custom zip containing{' '}
           <code>addons/godot-iap/bin/macos</code>. If Godot reports that{' '}
           <code>GodotIap.framework</code> or{' '}
           <code>SwiftGodotRuntime.framework</code> is damaged, clear quarantine
@@ -663,24 +663,25 @@ func _on_purchase_error(error):
         </p>
 
         <h3 id="gdextension-non-apple-editor" className="anchor-heading">
-          GDExtension errors in the Windows or Linux editor
+          GDExtension errors in the desktop editor
           <a href="#gdextension-non-apple-editor" className="anchor-link">
             #
           </a>
         </h3>
         <p>
-          The bundled GDExtension ships Apple libraries only, so editors on
-          Windows and Linux log{' '}
+          The current release zip ships an iOS-only GDExtension, so the editor
+          on every desktop — Windows, Linux, and macOS alike — logs{' '}
           <code>
             No GDExtension library found for current OS and architecture
           </code>{' '}
-          each time the project is scanned. Android is unaffected: it loads the
-          AAR plugin from <code>addons/godot-iap/android/</code>, and Android
-          exports keep working.
+          each time the project is scanned. The messages stop nothing: Android
+          loads the AAR plugin from <code>addons/godot-iap/android/</code>, and
+          iOS exports still embed and load the frameworks.
         </p>
         <p>
-          The addon declares <code>include_tags</code> so Godot can skip the
-          extension silently, but engine support for that filter (
+          The zip's <code>.gdextension</code> declares{' '}
+          <code>include_tags = [&quot;ios&quot;]</code> so Godot can skip it
+          silently. Engine support for that filter (
           <a
             href="https://github.com/godotengine/godot/pull/121575"
             target="_blank"
@@ -688,9 +689,8 @@ func _on_purchase_error(error):
           >
             godotengine/godot#121575
           </a>
-          ) merged after 4.8-dev3, so only 4.8 snapshots newer than dev3 honor
-          it. On 4.8-dev3 and older — including 4.3 through 4.7 — there is no
-          way to suppress the message (
+          ) first shipped in 4.8-dev4; on 4.8-dev3 and older — including 4.3
+          through 4.7 — the messages cannot be suppressed (
           <a
             href="https://github.com/godotengine/godot/issues/105615"
             target="_blank"
@@ -698,7 +698,7 @@ func _on_purchase_error(error):
           >
             godotengine/godot#105615
           </a>
-          ). While developing for Android on a non-Apple machine, rename the
+          ). To silence them while you are not exporting for iOS, rename the
           file:
         </p>
         <CodeBlock language="bash">
@@ -706,9 +706,8 @@ func _on_purchase_error(error):
    addons/godot-iap/bin/godot_iap.gdextension.disabled`}
         </CodeBlock>
         <p>
-          Restore the name before building for iOS or macOS. Those builds
-          require a Mac, so nothing in <code>bin/</code> is usable from a
-          Windows or Linux machine in the meantime.
+          Restore the name before an iOS export, on any machine: Godot discovers
+          and loads the native extension through that file.
         </p>
       </section>
 

--- a/packages/docs/src/pages/docs/setup/godot.tsx
+++ b/packages/docs/src/pages/docs/setup/godot.tsx
@@ -707,7 +707,9 @@ func _on_purchase_error(error):
         </CodeBlock>
         <p>
           Restore the name before an iOS export, on any machine: Godot discovers
-          and loads the native extension through that file.
+          and loads the native extension through that file. Skip the rename if
+          your copy carries <code>bin/macos</code> — a source build, or the
+          3.3.2 and 3.3.3 zips — since a macOS editor loads that library.
         </p>
       </section>
 

--- a/packages/docs/src/pages/docs/setup/godot.tsx
+++ b/packages/docs/src/pages/docs/setup/godot.tsx
@@ -669,8 +669,9 @@ func _on_purchase_error(error):
           </a>
         </h3>
         <p>
-          The current release zip ships an iOS-only GDExtension, so the editor
-          on every desktop — Windows, Linux, and macOS alike — logs{' '}
+          The current release zip ships an iOS-only GDExtension, so on Godot
+          4.8-dev3 and older the editor on every desktop — Windows, Linux, and
+          macOS alike — logs{' '}
           <code>
             No GDExtension library found for current OS and architecture
           </code>{' '}


### PR DESCRIPTION
The Godot setup guide said only Windows and Linux editors log "No GDExtension library found for current OS and architecture". The release zip ships an iOS-only `.gdextension` (`include_tags = ["ios"]`, one `ios.arm64` library, no `bin/macos`), so a macOS editor takes the same path — reported on #366.

The section now covers all three desktops, names 4.8-dev4 as the first Godot build that reads `include_tags` and skips the extension silently (its loader is 331 commits past the godotengine/godot#121575 merge; 4.7 and 4.8-dev3 print the error at loader line 369), and corrects why the file must be restored before an iOS export: the plugin's own export hook embeds the frameworks, and the `.gdextension` is what lets Godot discover and load the extension. The anchor id is unchanged because #366 links to it.

No recording: the change is one prose section. Rendered text checked in the dev server at `/docs/setup/godot#gdextension-non-apple-editor`.

Checks: docs prettier, typecheck + build, audit:docs, audit:release-state, git diff --check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded macOS damaged-framework guidance to cover release ZIP archives containing macOS frameworks.
  - Updated GDExtension troubleshooting for Windows, Linux, and macOS editors.
  - Clarified Android and iOS behavior, including that the release extension is iOS-only.
  - Documented `include_tags = ["ios"]` support in Godot 4.8-dev4 and later.
  - Broadened filename workaround guidance to non-iOS development while noting that macOS-capable packages are exempt.
  - Scoped the desktop editor warning to Godot 4.8-dev3 and earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->