### PR TITLE
fix(apple): build the example against the current purchase types

### DIFF
--- a/packages/apple/Example/OpenIapExample/Screens/AllProductsView.swift
+++ b/packages/apple/Example/OpenIapExample/Screens/AllProductsView.swift
@@ -293,6 +293,10 @@ struct AllProductsView: View {
             return "auto-renewable"
         case .nonRenewingSubscription:
             return "non-renewing"
+        case .subscriptionBundle:
+            return "subscription-bundle"
+        case .subscriptionSuite:
+            return "subscription-suite"
         }
     }
 
@@ -306,6 +310,10 @@ struct AllProductsView: View {
             return .blue
         case .nonRenewingSubscription:
             return .indigo
+        case .subscriptionBundle:
+            return .teal
+        case .subscriptionSuite:
+            return .mint
         }
     }
 

--- a/packages/apple/Example/OpenIapExample/Screens/SubscriptionFlowScreen.swift
+++ b/packages/apple/Example/OpenIapExample/Screens/SubscriptionFlowScreen.swift
@@ -811,7 +811,7 @@ struct SubscriptionFlowScreen: View {
         print("   📋 Purchase Details:")
         print("      • Transaction ID: \(purchase.id)")
         print("      • Product ID: \(purchase.productId)")
-        print("      • Platform: \(purchase.platform)")
+        print("      • Store: \(purchase.store)")
         print("      • Purchase State: \(purchase.purchaseState)")
         print("      • Is Auto-Renewing: \(purchase.isAutoRenewing)")
 

--- a/packages/apple/Example/OpenIapExample/Screens/uis/PurchaseDetailSheet.swift
+++ b/packages/apple/Example/OpenIapExample/Screens/uis/PurchaseDetailSheet.swift
@@ -16,7 +16,7 @@ struct PurchaseDetailSheet: View {
         var items: [DetailItem] = [
             DetailItem(label: "Purchase ID", value: purchase.id),
             DetailItem(label: "Product ID", value: purchase.productId),
-            DetailItem(label: "Platform", value: purchase.platform.rawValue.uppercased()),
+            DetailItem(label: "Store", value: purchase.store.rawValue.uppercased()),
             DetailItem(label: "Purchase State", value: purchase.purchaseState.rawValue.capitalized),
             DetailItem(label: "Quantity", value: String(purchase.quantity)),
             DetailItem(label: "Auto Renewing", value: boolLabel(purchase.isAutoRenewing))


### PR DESCRIPTION
The SwiftUI example under `packages/apple/Example` no longer compiled, so
the iOS row of the device regression could not run at all.

Two drifts had accumulated against the generated types:

- The example read `purchase.platform`. That field is now `store`, typed
  `IapStore`. Three call sites still used the old name.
- Two `ProductTypeIOS` switches predate the `subscription-bundle` and
  `subscription-suite` cases, so they stopped being exhaustive.

Checks: `xcodebuild -project Martie.xcodeproj -scheme OpenIapExample -configuration Debug -destination "generic/platform=iOS"` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display support for subscription bundle and subscription suite product types, including labels and color indicators.

* **Bug Fixes**
  * Updated purchase details and success logging to show the correct store information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->