### PR TITLE
ci: register scoped npm publisher workflow

### DIFF
--- a/.github/workflows/release-openiap.yml
+++ b/.github/workflows/release-openiap.yml
@@ -1,0 +1,19 @@
+name: "A. Release: OpenIAP npm packages"
+
+# Register the workflow on main so a reviewed next ref can receive dispatches.
+# The scoped-package implementation replaces this registration in PR #448.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  registration:
+    name: Workflow registration only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report registration status
+        run: |
+          echo "Workflow registered. No package publication was attempted."
+          echo "Use the reviewed next ref for prereleases; PR #448 enables stable releases."

--- a/scripts/git-test-environment.mjs
+++ b/scripts/git-test-environment.mjs
@@ -1,0 +1,17 @@
+import { execFileSync } from "node:child_process";
+
+export function isolateGitEnvironment(context) {
+  const names = execFileSync("git", ["rev-parse", "--local-env-vars"], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split("\n");
+  const saved = new Map(names.map((name) => [name, process.env[name]]));
+  for (const name of names) delete process.env[name];
+  context.after(() => {
+    for (const [name, value] of saved) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+}

--- a/scripts/release-branch-policy.test.mjs
+++ b/scripts/release-branch-policy.test.mjs
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { isolateGitEnvironment } from "./git-test-environment.mjs";
 
 import {
   allowsPrereleaseMetadata,
@@ -1419,7 +1420,8 @@ test("production docs are guarded as stable-only", () => {
   );
 });
 
-test("production docs require a verified Vercel deployment result", () => {
+test("production docs require a verified Vercel deployment result", (context) => {
+  isolateGitEnvironment(context);
   const temporaryRoot = mkdtempSync(resolve(tmpdir(), "openiap-deploy-"));
   const remoteRoot = mkdtempSync(resolve(tmpdir(), "openiap-deploy-origin-"));
 

--- a/scripts/sync-sponsors.test.mjs
+++ b/scripts/sync-sponsors.test.mjs
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { isolateGitEnvironment } from "./git-test-environment.mjs";
 
 import {
   discoverReadmes,
@@ -384,7 +386,76 @@ test("rejects hardcoded funding URLs outside the generated block", () => {
   }
 });
 
-test("audits sponsor surfaces from the staged snapshot", () => {
+test("Git fixtures preserve the invoking worktree and index", (context) => {
+  const environment = {
+    PATH: process.env.PATH,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: os.devNull,
+  };
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openiap-hook-owner-"));
+  const worktree = `${root}-linked`;
+  context.after(() => {
+    fs.rmSync(worktree, { recursive: true, force: true });
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: root, encoding: "utf8", env: environment });
+  git("init", "-q");
+  fs.writeFileSync(path.join(root, "sentinel"), "committed\n");
+  git("add", ".");
+  git(
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "commit",
+    "-qm",
+    "owner",
+  );
+  git("worktree", "add", "-q", "-b", "linked", worktree);
+  fs.writeFileSync(path.join(worktree, "sentinel"), "staged\n");
+  git("-C", worktree, "add", "sentinel");
+  const gitDir = git("-C", worktree, "rev-parse", "--absolute-git-dir").trim();
+  const trackedState = [
+    path.join(root, ".git/config"),
+    path.join(gitDir, "index"),
+  ];
+  const before = trackedState.map((file) => fs.readFileSync(file));
+  const refs = git("show-ref");
+  execFileSync(
+    process.execPath,
+    [
+      "--test",
+      "--test-name-pattern=^(audits sponsor surfaces from the staged snapshot|production docs require a verified Vercel deployment result)$",
+      fileURLToPath(import.meta.url),
+      fileURLToPath(
+        new URL("./release-branch-policy.test.mjs", import.meta.url),
+      ),
+    ],
+    {
+      cwd: worktree,
+      env: {
+        ...environment,
+        GIT_DIR: gitDir,
+        GIT_COMMON_DIR: path.join(root, ".git"),
+        GIT_INDEX_FILE: path.join(gitDir, "index"),
+        GIT_WORK_TREE: worktree,
+      },
+      stdio: "pipe",
+    },
+  );
+  assert.equal(git("show-ref"), refs);
+  for (const [index, file] of trackedState.entries()) {
+    assert.deepEqual(fs.readFileSync(file), before[index], file);
+  }
+  assert.equal(
+    fs.readFileSync(path.join(worktree, "sentinel"), "utf8"),
+    "staged\n",
+  );
+});
+
+test("audits sponsor surfaces from the staged snapshot", (context) => {
+  isolateGitEnvironment(context);
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "openiap-sponsor-index-"));
 
   try {


### PR DESCRIPTION
Register `release-openiap.yml` on the default branch so the reviewed `next` branch can validate npm alpha publication before #448 is merged. This registration runs a read-only status step; #448 supplies package validation and publishing.

Isolate the sponsor and docs-deployment Git fixtures from inherited hook variables. Linked-worktree pre-commit checks otherwise write fixture commits and bare-repository configuration into the invoking repository. A regression test injects synthetic repository variables and verifies its refs, config, index, and working file stay unchanged.

Validation: 55 fixture/release-policy tests, actionlint, and the normal linked-worktree pre-commit gates pass. There is no visual or interactive surface to record. No device regression is required: the diff contains repository automation and test fixtures only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - The release workflow is now manually triggered and records release status without publishing packages.
  - Prerelease and stable-release status messaging has been clarified.

- **Tests**
  - Improved test isolation for Git-related environment settings.
  - Added safeguards confirming tests preserve worktree, index, references, and staged content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->